### PR TITLE
Fix meta-channel timeseries/spectrograms with mismatched segments

### DIFF
--- a/gwsumm/data.py
+++ b/gwsumm/data.py
@@ -720,7 +720,9 @@ def get_spectrogram(channel, segments, config=ConfigParser(), cache=None,
                                       return_=return_,
                                       multiprocess=multiprocess,
                                       **fftparams))
-    if return_:
+    if return_ and len(channels) == 1:
+        return specs[0]
+    elif return_:
         # get union of segments for all sub-channels
         datasegs = reduce(operator.and_, [sgl.segments for sgl in specs])
         # build meta-spectrogram for all interseceted segments

--- a/gwsumm/data.py
+++ b/gwsumm/data.py
@@ -427,7 +427,7 @@ def get_timeseries_dict(channels, segments, config=ConfigParser(),
                 for seg in datasegs:
                     ts = get_timeseries(
                         chanstrs[0], SegmentList([seg]), config=config,
-                        query=False, format=format, return_=True)[0]
+                        query=False, return_=True)[0]
                     ts.name = str(channel)
                     for op, ch in zip(operators, chanstrs[1:]):
                         try:
@@ -437,9 +437,9 @@ def get_timeseries_dict(channels, segments, config=ConfigParser(),
                             raise
                         data = get_timeseries(ch, SegmentList([seg]),
                                               config=config, query=False,
-                                              format=format, return_=True)
+                                              return_=True)
                         ts = op(ts, data[0])
-                    meta.append(sg)
+                    meta.append(ts)
                 out[channel.ndsname] = meta
         return out
 


### PR DESCRIPTION
This PR fixes a corner-case failure mode whereby meta-channel timeseries/spectrograms for which different channels have different availability (segments) would fail.

The code introduced here uses the intersection of the available data for all channels to ensure every channel has some data on which to operate.