### PR TITLE
New time accounting tab

### DIFF
--- a/gwsumm/data.py
+++ b/gwsumm/data.py
@@ -688,14 +688,16 @@ def _get_timeseries_dict(channels, segments, config=ConfigParser(),
 
 def get_timeseries(channel, segments, config=ConfigParser(), cache=None,
                    query=True, nds='guess', multiprocess=True,
-                   frametype=None, statevector=False, return_=True):
+                   frametype=None, statevector=False, return_=True,
+                   **ioargs):
     """Retrieve the data (time-series) for a given channel
     """
     channel = get_channel(channel)
     out = get_timeseries_dict([channel.ndsname], segments, config=config,
                               cache=cache, query=query, nds=nds,
                               multiprocess=multiprocess, frametype=frametype,
-                              statevector=statevector, return_=return_)
+                              statevector=statevector, return_=return_,
+                              **ioargs)
     if return_:
         return out[channel.ndsname]
     return

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -108,13 +108,13 @@ class TimeSeriesDataPlot(DataLabelSvgMixin, DataPlot):
             ax.grid(True, which='both')
         return self.plot, axes
 
-    def finalize(self, outputfile=None, close=True):
+    def finalize(self, outputfile=None, close=True, **savekwargs):
         plot = self.plot
         ax = plot.axes[0]
         if 'xlim' not in self.pargs:
             ax.set_xlim(float(self.start), float(self.end))
         return super(TimeSeriesDataPlot, self).finalize(
-                   outputfile=outputfile, close=close)
+                   outputfile=outputfile, close=close, **savekwargs)
 
     def process(self, outputfile=None):
         """Read in all necessary data, and generate the figure.
@@ -876,13 +876,13 @@ class TriggerDataPlot(TimeSeriesDataPlot):
     def pid(self, id_):
         self._pid = str(id_)
 
-    def finalize(self, outputfile=None, close=True):
+    def finalize(self, outputfile=None, close=True, **savekwargs):
         if isinstance(self.plot, TimeSeriesPlot):
             return super(TriggerDataPlot, self).finalize(
-                       outputfile=outputfile, close=close)
+                       outputfile=outputfile, close=close, **savekwargs)
         else:
             return super(TimeSeriesDataPlot, self).finalize(
-                       outputfile=outputfile, close=close)
+                       outputfile=outputfile, close=close, **savekwargs)
 
     def process(self):
         # get columns

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -1771,3 +1771,114 @@ class ODCDataPlot(SegmentLabelSvgMixin, StateVectorDataPlot):
         return out
 
 register_plot(ODCDataPlot)
+
+
+class SegmentPiePlot(SegmentDataPlot):
+    type = 'segment-pie'
+    defaults = {
+        'legend-loc': 'center left',
+        'legend-bbox_to_anchor': (.8, .5),
+        'legend-frameon': False,
+    }
+
+    def init_plot(self, plot=Plot, geometry=(1,1)):
+        """Initialise the Figure and Axes objects for this
+        `TimeSeriesDataPlot`.
+        """
+        figsize = self.pargs.pop('figsize', [12, 6])
+        self.plot = Plot(figsize=figsize)
+        axes = [self.plot.gca()]
+        return self.plot, axes
+
+    def parse_plot_kwargs(self, defaults=dict()):
+        """Parse pie() keyword arguments
+        """
+        plotargs = defaults.copy()
+        plotargs.setdefault('labels', self._parse_labels())
+        for kwarg in ['explode', 'colors', 'autopct', 'pctdistance', 'shadow',
+                      'labeldistance', 'startangle', 'radius', 'counterclock',
+                      'wedgeprops', 'textprops']:
+            try:
+                val = self.pargs.pop(kwarg)
+            except KeyError:
+                try:
+                    val = self.pargs.pop('%ss' % kwarg)
+                except KeyError:
+                    val = None
+            if val is not None:
+                try:
+                    val = eval(val)
+                except Exception:
+                    pass
+                plotargs[kwarg] = val
+        return plotargs
+
+    def process(self):
+        (plot, axes) = self.init_plot(plot=Plot)
+        ax = axes[0]
+
+        # get labels
+        #flags = map(lambda f: str(f).replace('_', r'\_'), self.flags)
+        #labels = self.pargs.pop('labels', self.pargs.pop('label', flags))
+        #labels = map(lambda s: re_quote.sub('', str(s).strip('\n ')), labels)
+
+        # extract plotting arguments
+        legendargs = self.parse_legend_kwargs()
+        plotargs = self.parse_plot_kwargs()
+
+        # get segments
+        data = []
+        for flag in self.flags:
+            if self.state and not self.all_data:
+                valid = self.state.active
+            else:
+                valid = SegmentList([self.span])
+            segs = get_segments(flag, validity=valid, query=False).coalesce()
+            data.append(float(abs(segs.active)))
+
+        # make pie
+        labels = plotargs.pop('labels')
+        patches = ax.pie(data, **plotargs)[0]
+        ax.axis('equal')
+
+        # make legend
+        legendargs['title'] = self.pargs.pop('title', None)
+        tot = float(sum(data))
+        pclabels = []
+        for d, label in zip(data, labels):
+            try:
+                pc = d/tot * 100
+            except ZeroDivisionError:
+                pc = 0.0
+            pclabels.append(label_to_latex(
+                '%s [%1.1f%%]' % (label, pc)).replace(r'\\', '\\'))
+        leg = ax.legend(patches, pclabels, **legendargs)
+        legt = leg.get_title()
+        legt.set_fontsize('22')
+        legt.set_ha('left')
+
+        for wedge in patches:
+            wedge.set_edgecolor('white')
+
+        # customise plot
+        for key, val in self.pargs.iteritems():
+            try:
+                getattr(ax, 'set_%s' % key)(val)
+            except AttributeError:
+                setattr(ax, key, val)
+
+        # copy title and move axes
+        if ax.get_title():
+            title = plot.suptitle(ax.get_title())
+            title.update_from(ax.title)
+            title.set_y(title._y + 0.05)
+            ax.set_title('')
+        axpos = ax.get_position()
+        offset = -.2
+        ax.set_position([axpos.x0+offset, .05, axpos.width, .9])
+
+        # add bit mask axes and finalise
+        self.pargs['xlim'] = None
+        return self.finalize(transparent="True", pad_inches=0)
+
+register_plot(SegmentPiePlot)

--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -486,7 +486,7 @@ class DataPlot(SummaryPlot):
         raise NotImplementedError("This method should be provided by a "
                                   "sub-class")
 
-    def finalize(self, outputfile=None, close=True):
+    def finalize(self, outputfile=None, close=True, **savekwargs):
         """Save the plot to disk and close.
         """
         # quick fix for x-axis labels hitting the axis
@@ -496,7 +496,7 @@ class DataPlot(SummaryPlot):
         # save figure and close
         if outputfile is None:
             outputfile = self.outputfile
-        self.plot.save(outputfile)
+        self.plot.save(outputfile, **savekwargs)
         if close:
             self.plot.close()
         return outputfile

--- a/gwsumm/plot/mixins.py
+++ b/gwsumm/plot/mixins.py
@@ -82,7 +82,7 @@ class SvgMixin(object):
         super(SvgMixin, self).__init__(*args, **kwargs)
         self.preview_labels = False
 
-    def finalize(self, outputfile=None, close=True):
+    def finalize(self, outputfile=None, close=True, **savekwargs):
         if outputfile is None:
             outputfile = self.outputfile
         # make SVG
@@ -91,7 +91,7 @@ class SvgMixin(object):
         # or process as normal
         else:
             return super(SvgMixin, self).finalize(
-                outputfile=outputfile, close=close)
+                outputfile=outputfile, close=close, **savekwargs)
 
     @abc.abstractmethod
     def process_svg(self, outputfile):

--- a/gwsumm/tabs/__init__.py
+++ b/gwsumm/tabs/__init__.py
@@ -89,3 +89,4 @@ from .hveto import *
 from .sei import *
 from .guardian import *
 from .stamp import *
+from .management import *

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -836,7 +836,7 @@ class DataTab(DataTabBase):
         uniq = kwargs.pop('unique', True)
         out = set()
         for plot in self.plots:
-            if not plot.type in types:
+            if not plot.data in types:
                 continue
             if isnew and not plot.new:
                 continue

--- a/gwsumm/tabs/management.py
+++ b/gwsumm/tabs/management.py
@@ -1,0 +1,196 @@
+# coding=utf-8
+# Copyright (C) Duncan Macleod (2014)
+#
+# This file is part of GWSumm
+#
+# GWSumm is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWSumm is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWSumm.  If not, see <http://www.gnu.org/licenses/>
+
+"""Definition of the `AccountingTab`
+"""
+
+import re
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
+
+from gwpy.segments import (DataQualityDict, SegmentList, Segment)
+from gwpy.plotter import SegmentPlot
+
+from ..config import (GWSummConfigParser, NoOptionError)
+from ..state import ALLSTATE
+from .registry import (get_tab, register_tab)
+from .. import (globalv, version, html)
+from ..data import get_timeseries
+from ..segments import get_segments
+from ..plot.registry import (get_plot, register_plot)
+from ..utils import vprint
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+__version__ = version.version
+
+ParentTab = get_tab('default')
+
+
+class AccountingTab(ParentTab):
+    """Summarise the data recorded by the observatory mode channels
+    """
+    type = 'archived-accounting'
+
+    @classmethod
+    def from_ini(cls, config, section, plotdir='plots', base=''):
+        new = super(ParentTab, cls).from_ini(config, section, base=base)
+        if len(new.states) > 1 or new.states[0].name != ALLSTATE:
+            raise ValueError("AccountingTab does not accept state selection")
+
+        # add information
+        new.plots = []
+        new.channel = config.get(section, 'channel')
+        new.ifo = config.get(section, 'ifo')
+        new.modes = OrderedDict((int(idx), name) for (idx, name) in
+                                config.nditems(section) if idx.isdigit())
+
+        # -----------
+        # build plots
+
+        new.layout = (2, (1, 2))
+        new.segmenttag = '%s:%%s' % (new.channel)
+        tag = new.channel.split(':', 1)[-1].replace('-', '_')
+
+        groups = type(new.modes)(
+            (idx, name.strip('*')) for (idx, name) in new.modes.iteritems()
+            if int(idx) % 10 == 0)
+        pstates = OrderedDict(
+            (idx, name) for (idx, name) in new.modes.iteritems() if
+            not name.startswith('*'))
+        # plot segments
+        for flags, ptag in zip([groups, pstates], ['overview', 'details']):
+            new.plots.append(get_plot('segments')(
+                [new.segmenttag % idx for idx in flags],
+                new.span[0], new.span[1], labels=flags.values(),
+                outdir=plotdir, tag='%s_SEGMENTS_%s' % (tag, ptag.upper()),
+                known={'alpha': 0.1, 'facecolor': 'lightgray'},
+                title='%s observatory mode %s' % (new.ifo, ptag)))
+
+        # plot pie charts
+        try:
+            explode = map(float, config.get(section, 'pie-explode').split(','))
+        except NoOptionError:
+            explode = None
+        colors = dict(
+            (int(key[6:]), eval(color)) for (key, color) in
+            config.nditems(section) if re.match('color-\d+', key))
+        for flag in groups:
+            group = int(flag // 10 * 10)
+            if flag not in colors:
+                colors[flag] = colors.get(group, None)
+        ptag = 'overview'
+        piecolors = [colors.get(flag, None) for flag in groups]
+        if not any(piecolors):
+            piecolors = None
+        new.plots.append(get_plot('segment-pie')(
+            [new.segmenttag % idx for idx in groups],
+            new.span[0], new.span[1], labels=groups.values(),
+            outdir=plotdir, tag='%s_PIE_%s' % (tag, ptag.upper()),
+            colors=piecolors, explode=explode,
+            title='%s observatory mode %s' % (new.ifo, ptag)))
+
+        return new
+
+    def process(self, nds='guess', multiprocess=True,
+                config=GWSummConfigParser(), datacache=None,
+                **kwargs):
+        """Process time accounting data
+        """
+        ifo = self.ifo
+
+        for p in self.plots:
+            if p.outputfile in globalv.WRITTEN_PLOTS:
+                p.new = False
+
+        # get data
+        data = get_timeseries(self.channel, SegmentList([self.span]),
+                              config=config, nds=nds, dtype='int16',
+                              multiprocess=multiprocess, cache=datacache)
+        vprint("    All time-series data loaded\n")
+
+        # find segments
+        for ts in data:
+            modesegments = DataQualityDict()
+            for idx, name in self.modes.iteritems():
+                # get segments for state
+                tag = self.segmenttag % idx
+                if idx % 10:
+                    instate = ts == idx
+                else:
+                    instate = (ts >= idx) * (ts < idx+10)
+                modesegments[tag] = instate.to_dqflag(name=name.strip('*'))
+            globalv.SEGMENTS += modesegments
+
+        kwargs['segdb_error'] = 'ignore'
+        super(AccountingTab, self).process(
+            config=config, nds=nds, multiprocess=multiprocess,
+            datacache=datacache, **kwargs)
+
+    def write_state_html(self, state):
+        """Write the HTML for the given state of this `GuardianTab`
+        """
+        page = self.scaffold_plots()
+
+        page.div(class_='row')
+        page.div(class_='col-md-12')
+
+        # get segment data
+        groups = type(self.modes)((idx, name) for idx, name in
+                                  self.modes.iteritems() if idx % 10 == 0)
+        modes = type(self.modes)(
+            (idx, name) for idx, name in self.modes.iteritems() if
+            not name.startswith('*'))
+        headers = ['Index', 'Name', 'Active seconds',
+                   'Hours', '%']
+        tables = []
+        for flags, title in zip(
+                [groups, modes],
+                ['Top-level mode information', 'Detailed mode information']):
+            page.h1(title)
+            page.p('The following modes were defined for the above data and '
+                   'were active as given:')
+            data = []
+            pc = float(abs(state.active) / 100.)
+            tots = 0
+            toth = 0
+            totp = 0
+            for idx, name in flags.iteritems():
+                flag = get_segments(self.segmenttag % idx,
+                                    state.active, query=False).copy()
+                v = flag.version and str(flag.version) or ''
+                actives = abs(flag.active)
+                activeh = actives / 3600.
+                try:
+                    activep = actives / pc
+                except ZeroDivisionError:
+                    activep = 0
+                tots += actives
+                toth += activeh
+                totp += activep
+                data.append([str(idx), name.strip('*'), '%.1f' % actives,
+                             '%.1f' % activeh, '%.1f' % activep])
+            data.append(map(
+                lambda x: '<strong>%s</strong>' % x,
+                ['', 'Total:', '%.1f' % tots, '%.1f' % toth, '%.1f' % totp]))
+            page.add(str(html.data_table(headers, data)))
+
+        return super(ParentTab, self).write_state_html(state, plots=False,
+                                                       pre=page)
+register_tab(AccountingTab)


### PR DESCRIPTION
This PR implements a custom tab for displaying the time accounting data recorded by the `ODC-OBSERVATORY_MODE` channel.

The main additions are

- `/gwsumm/tabs/management.py` - defining the new tab
- `gwsumm/plot/builtin.py:SegmentPiePlot` - new plot for pie charts from segments