### PR TITLE
New 404 error tab

### DIFF
--- a/bin/gw_summary
+++ b/bin/gw_summary
@@ -647,7 +647,6 @@ else:
     for key, val in config.nditems('html'):
         if re.search('-base\Z', key):
             ifobases[key.rsplit('-', 1)[0].title()] = val
-ifobases.pop(ifo, None)
 
 # -----------------------------------------------------------------------------
 # Read tabs

--- a/bin/gw_summary
+++ b/bin/gw_summary
@@ -454,6 +454,10 @@ else:
 if opts.multiprocess == 1:
     opts.multiprocess = False
 
+# set global html only flag
+if opts.html_only:
+    globalv.HTMLONLY = True
+
 # -----------------------------------------------------------------------------
 # Setup
 

--- a/bin/gw_summary
+++ b/bin/gw_summary
@@ -720,7 +720,7 @@ if not opts.no_html and urlbase:
     four0four = get_tab('404')(span[0], span[1], parent=None, path=path,
                                index=os.path.join(path, '404.html'))
     four0four.write_html(css=css, js=javascript, tabs=tabs, ifo=ifo,
-                         ifomap=ifobases, top=top,
+                         ifomap=ifobases, top=top, base=base,
                          writedata=not opts.html_only,
                          writehtml=not opts.no_html)
     url404 = os.path.join(urlbase, four0four.index)

--- a/bin/gw_summary
+++ b/bin/gw_summary
@@ -29,7 +29,7 @@ Run 'gw_summary <mode> --help' for details of the specific arguments and
 options acceptable for each mode.
 """
 
-from __future__ import division
+from __future__ import (division, print_function)
 
 import datetime
 import argparse
@@ -709,10 +709,25 @@ if 'public_html' in os.getcwd():
 elif ifo in ifobases:
     urlbase = urlparse(ifobases['ifo']).path
     base = urlbase
-# otherwise cannot process
+# otherwise let the write_html processor work it out on-the-fly
 else:
     urlbase = None
     base = None
+
+# write 404 error page
+if not opts.no_html and urlbase:
+    top = os.path.join(urlbase, path)
+    four0four = get_tab('404')(span[0], span[1], parent=None, path=path,
+                               index=os.path.join(path, '404.html'))
+    four0four.write_html(css=css, js=javascript, tabs=tabs, ifo=ifo,
+                         ifomap=ifobases, top=top,
+                         writedata=not opts.html_only,
+                         writehtml=not opts.no_html)
+    url404 = os.path.join(urlbase, four0four.index)
+    with open(os.path.join(path, '.htaccess'), 'w') as htaccess:
+        print('Options -Indexes', file=htaccess)
+        print('ErrorDocument 404 %s' % url404, file=htaccess)
+        print('ErrorDocument 403 %s' % url404, file=htaccess)
 
 # write config page
 about = get_tab('about')(span[0], span[1], parent=None, path=path)

--- a/bin/gw_summary
+++ b/bin/gw_summary
@@ -685,6 +685,18 @@ for tab in filter(lambda tab: tab.parent is not None, alltabs):
 
 tabs = tabs.values()
 
+# sort tabs by 'Summary', then lower case only, then everything else
+_sort_tabs = lambda tab: (
+    (tab.shortname == 'Summary' and tab.parent is None) and 1 or
+    tab.shortname == 'Summary' and 2 or
+    'ODC' in tab.shortname and 3 or
+    tab.shortname.islower() and tab.shortname.upper() or
+    tab.shortname.lower())
+tabs.sort(key=_sort_tabs)
+for tab in tabs:
+    tab.children.sort(key=_sort_tabs)
+alltabs.sort(key=_sort_tabs, reverse=True)
+
 # write config page
 about = get_tab('about')(span[0], span[1], parent=None, base=base)
 if not opts.no_html:
@@ -748,19 +760,6 @@ if opts.bulk_read and not opts.html_only:
                             config=config, nds=opts.nds, statevector=True,
                             multiprocess=opts.multiprocess, return_=False)
 
-# sort tabs by 'Summary', then lower case only, then everything else
-_sort_tabs = lambda tab: (
-    (tab.shortname == 'Summary' and tab.parent is None) and 1 or
-    tab.shortname == 'Summary' and 2 or
-    'ODC' in tab.shortname and 3 or
-    tab.shortname.islower() and tab.shortname.upper() or
-    tab.shortname.lower())
-
-tabs.sort(key=_sort_tabs)
-for tab in tabs:
-    tab.children.sort(key=_sort_tabs)
-
-alltabs.sort(key=_sort_tabs, reverse=True)
 for tab in alltabs:
     vprint("\n-------------------------------------------------\n")
     if tab.parent:

--- a/bin/gw_summary
+++ b/bin/gw_summary
@@ -39,6 +39,8 @@ import warnings
 import httplib
 import importlib
 
+from urlparse import urlparse
+
 warnings.filterwarnings('ignore', 'TimeSeries.crop given GPS start')
 warnings.filterwarnings('ignore', 'TimeSeries.crop given GPS end')
 warnings.filterwarnings('ignore', category=RuntimeWarning)
@@ -437,9 +439,9 @@ endtime = Time(float(opts.gpsend), format='gps')
 # set mode and output directory
 mode.set_mode(mode.MODE_ENUM[opts.mode.upper()])
 try:
-    base = mode.get_base(utc)
+    path = mode.get_base(utc)
 except ValueError:
-    base = os.path.join('%d-%d' % (opts.gpsstart, opts.gpsend))
+    path = os.path.join('%d-%d' % (opts.gpsstart, opts.gpsend))
 
 # set LAL FFT plan wisdom level
 duration = min(globalv.NOW, opts.gpsend) - opts.gpsstart
@@ -472,7 +474,7 @@ End time: %s (%s)
 Output directory: %s
 """ % (mode.MODE_NAME[mode.get_mode()], starttime.utc.iso, starttime.gps,
        endtime.utc.iso, endtime.gps,
-       os.path.abspath(os.path.join(opts.output_dir, base))))
+       os.path.abspath(os.path.join(opts.output_dir, path))))
 
 # -- Load plugins
 # loading the module containing a plugin should 'register' the relevant
@@ -559,7 +561,7 @@ except NoSectionError:
 # build directories
 mkdir(opts.output_dir)
 os.chdir(opts.output_dir)
-plotdir = os.path.join(base, 'plots')
+plotdir = os.path.join(path, 'plots')
 mkdir(plotdir)
 
 # -----------------------------------------------------------------------------
@@ -578,7 +580,7 @@ archives = []
 
 if opts.archive:
     from gwsumm import archive
-    archivedir = os.path.join(base, 'archive')
+    archivedir = os.path.join(path, 'archive')
     mkdir(archivedir)
     opts.archive = os.path.join(archivedir, '%s-%s-%d-%d.hdf'
                                 % (ifo, opts.archive, opts.gpsstart,
@@ -666,9 +668,9 @@ for section in filter(lambda n: re.match('tab[-\s]', n),
         DataTab = get_tab('archived-data')
         Tab = get_tab(type_)
         if issubclass(Tab, DataTab):
-            tab = Tab.from_ini(config, section, plotdir=plotdir, base=base)
+            tab = Tab.from_ini(config, section, plotdir=plotdir, path=path)
         else:
-            tab = Tab.from_ini(config, section, base=base)
+            tab = Tab.from_ini(config, section, path=path)
         alltabs.append(tab)
 
 # sort tabs into hierarchical list
@@ -697,15 +699,29 @@ for tab in tabs:
     tab.children.sort(key=_sort_tabs)
 alltabs.sort(key=_sort_tabs, reverse=True)
 
+# get URL from output directory
+if 'public_html' in os.getcwd():
+    urlbase = os.path.sep + os.path.join(
+                  '~%s' % config.get(DEFAULTSECT, 'user'),
+                  os.getcwd().split('public_html', 1)[1][1:])
+    base = urlbase
+# otherwise get URL from html config
+elif ifo in ifobases:
+    urlbase = urlparse(ifobases['ifo']).path
+    base = urlbase
+# otherwise cannot process
+else:
+    urlbase = None
+    base = None
+
 # write config page
-about = get_tab('about')(span[0], span[1], parent=None, base=base)
+about = get_tab('about')(span[0], span[1], parent=None, path=path)
 if not opts.no_html:
     mkdir(about.path)
     about.write_html(css=css, js=javascript, tabs=tabs, config=config.files,
-                     ifo=ifo, ifomap=ifobases, about=about.index,
+                     ifo=ifo, ifomap=ifobases, about=about.index, base=base,
                      writedata=not opts.html_only,
                      writehtml=not opts.no_html)
-
 
 # -----------------------------------------------------------------------------
 # Process all tabs
@@ -773,8 +789,8 @@ for tab in alltabs:
                     segdb_error=opts.on_segdb_error)
     if not tab.hidden:
         mkdir(tab.href)
-        page = tab.write_html(css=css, js=javascript, tabs=tabs,
-                              ifo=ifo, ifomap=ifobases, about=about.index,
+        page = tab.write_html(css=css, js=javascript, tabs=tabs, ifo=ifo,
+                              ifomap=ifobases, about=about.index, base=base,
                               writedata=not opts.html_only,
                               writehtml=not opts.no_html)
     vprint("%s complete!\n" % (name))

--- a/gwsumm/channels.py
+++ b/gwsumm/channels.py
@@ -102,6 +102,8 @@ def get_channel(channel, find_trend_source=True, timeout=5):
         # match single raw channel
         if len(matches) == 1 and not re.search('\.[a-z]+\Z', name):
             try:
+                if globalv.HTMLONLY:
+                    raise ValueError("")
                 new = Channel.query(name, timeout=timeout)
             except (ValueError, urllib2.URLError):
                 new = Channel(str(channel))

--- a/gwsumm/globalv.py
+++ b/gwsumm/globalv.py
@@ -43,6 +43,7 @@ START = time.time()
 MODE = 4
 WRITTEN_PLOTS = []
 NOW = tconvert('now').seconds
+HTMLONLY = False
 
 # comments
 IFO = None

--- a/gwsumm/html/bootstrap/__init__.py
+++ b/gwsumm/html/bootstrap/__init__.py
@@ -470,7 +470,7 @@ def base_map_dropdown(this,class_='btn-group pull-left base-map', id_=None,
         id_ = dict()
     # format links
     baselinks = [markup.oneliner.a(key, **{'data-new-base': val}) for
-                 (key, val) in bases.iteritems()]
+                 (key, val) in bases.iteritems() if key != this]
     # slam it all together
     page = markup.page()
     if baselinks:

--- a/gwsumm/tabs/builtin.py
+++ b/gwsumm/tabs/builtin.py
@@ -775,3 +775,50 @@ class AboutTab(SummaryArchiveMixin, Tab):
             html.about_this_page(config=config), **kwargs)
 
 register_tab(AboutTab)
+
+
+class Error404Tab(SummaryArchiveMixin, Tab):
+    type = '404'
+
+    def __init__(self, start, end, name='404', mode=None, **kwargs):
+        super(Error404Tab, self).__init__(name, **kwargs)
+        self.span = (start, end)
+        self.mode = mode
+
+    def write_html(self, config=list(), top=None, **kwargs):
+        if top is None:
+            top = kwargs.get('base', self.path)
+        kwargs.setdefault('title', '404: Page not found')
+        page = html.markup.page()
+        page.div(class_='alert alert-danger')
+        page.p()
+        page.strong("The page you are looking for doesn't exist")
+        page.p.close()
+        page.p("This could be because the times for which you are looking "
+               "were never processed (or haven't even happened yet), or "
+               "because no page exists for the specific data products you "
+               "want. Either way, if you think this is in error, please "
+               "contact <a class=\"alert-link\" "
+               "href=\"mailto:detchar+code@ligo.org\">the DetChar group</a>.")
+        page.p("Otherwise, you might be interested in one of the following:")
+        page.div(style="padding-top: 10px;")
+        page.a("Take me back", role="button", class_="btn btn-lg btn-info",
+               title="Back", href="javascript:history.back()")
+        page.a("Take me up one level", role="button",
+               class_="btn btn-lg btn-warning", title="Up",
+               href="javascript:linkUp()")
+        page.a("Take me to the top level", role="button",
+               class_="btn btn-lg btn-success", title="Top", href=top)
+        page.div.close()
+        page.div.close()
+        page.script("""
+  function linkUp() {
+    var url = window.location.href;
+    if (url.substr(-1) == '/') url = url.substr(0, url.length - 2);
+    url = url.split('/');
+    url.pop();
+    window.location = url.join('/');
+  }""", type="text/javascript")
+        return super(Error404Tab, self).write_html(page, **kwargs)
+
+register_tab(Error404Tab)

--- a/gwsumm/tabs/builtin.py
+++ b/gwsumm/tabs/builtin.py
@@ -60,8 +60,9 @@ class ExternalTab(Tab):
     group : `str`
         name of containing group for this tab in the navigation bar
         dropdown menu. This is only relevant if this tab has a parent.
-    base : `str`
-        path for HTML base attribute for this tab.
+    path : `str`
+        base output directory for this tab (should be the same directory
+        for all tabs in this run).
 
     Configuration
     -------------
@@ -203,8 +204,9 @@ class PlotTab(Tab):
     group : `str`, optional
         name of containing group for this tab in the navigation bar
         dropdown menu. This is only relevant if this tab has a parent.
-    base : `str`, optiona,
-        path for HTML base attribute for this tab.
+    path : `str`, optiona,
+        base output directory for this tab (should be the same directory
+        for all tabs in this run).
     """
     type = 'plots'
 
@@ -290,7 +292,7 @@ class PlotTab(Tab):
         """
         cp = GWSummConfigParser.from_configparser(cp)
 
-        kwargs.setdefault('base', '')
+        kwargs.setdefault('path', '')
 
         # get layout
         if cp.has_option(section, 'layout'):
@@ -532,8 +534,9 @@ class StateTab(PlotTab):
     group : `str`
         name of containing group for this tab in the navigation bar
         dropdown menu. This is only relevant if this tab has a parent.
-    base : `str`
-        path for HTML base attribute for this tab.
+    path : `str`
+        base output directory for this tab (should be the same directory
+        for all tabs in this run).
     """
     type = 'state'
 
@@ -581,9 +584,10 @@ class StateTab(PlotTab):
     def frames(self):
         # write page for each state
         statelinks = []
+        outdir = os.path.split(self.index)[0]
         for i, state in enumerate(self.states):
             statelinks.append(os.path.join(
-                self.path, '%s.html' % re_cchar.sub('_', str(state).lower())))
+                outdir, '%s.html' % re_cchar.sub('_', str(state).lower())))
         return statelinks
 
     # -------------------------------------------

--- a/gwsumm/tabs/builtin.py
+++ b/gwsumm/tabs/builtin.py
@@ -204,7 +204,7 @@ class PlotTab(Tab):
     group : `str`, optional
         name of containing group for this tab in the navigation bar
         dropdown menu. This is only relevant if this tab has a parent.
-    path : `str`, optiona,
+    path : `str`, optional,
         base output directory for this tab (should be the same directory
         for all tabs in this run).
     """

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -71,8 +71,9 @@ class Tab(object):
     group : `str`
         name of containing group for this tab in the navigation bar
         dropdown menu. This is only relevant if this tab has a parent.
-    base : `str`
-        path for HTML base attribute for this tab.
+    path : `str`
+        base output directory for this tab (should be the same directory
+        for all tabs in this run)
 
     Notes
     -----
@@ -86,7 +87,7 @@ class Tab(object):
     """Type identifier for this `Tab`"""
 
     def __init__(self, name, index=None, shortname=None, parent=None,
-                 children=list(), group=None, base='', hidden=False):
+                 children=list(), group=None, path=os.curdir, hidden=False):
         """Initialise a new `Tab`.
         """
         # names
@@ -98,7 +99,7 @@ class Tab(object):
         self.children = children
         self.group = group
         # HTML format
-        self.base = base
+        self.path = path
         self.index = index
         self.page = None
         self.hidden = hidden
@@ -173,10 +174,20 @@ class Tab(object):
 
     @property
     def index(self):
-        """The HTML path (relative to the :attr:`~Tab.base`) for this tab
+        """The HTML path (relative to the :attr:`~Tab.path`) for this tab
         """
         if not self._index:
-            self._index = os.path.join(self.path, 'index.html')
+            if self.shortname.lower() == 'summary':
+                p = ''
+            else:
+                p = re_cchar.sub('_', self.shortname.strip('_')).lower()
+            tab_ = self
+            while tab_.parent:
+                p = os.path.join(re_cchar.sub(
+                        '_', tab_.parent.shortname.strip('_')).lower(), p)
+                tab_ = tab_.parent
+            self._index = os.path.normpath(os.path.join(
+                self.path, p, 'index.html'))
         return self._index
 
     @index.setter
@@ -185,7 +196,7 @@ class Tab(object):
 
     @property
     def href(self):
-        """HTML href (relative to the :attr:`~Tab.base`) for this tab
+        """HTML href (relative to the :attr:`~Tab.path`) for this tab
 
         This attribute is just a convenience to clean-up the
         :attr:`~Tab.index` for a given tab, by removing index.htmls.
@@ -199,27 +210,6 @@ class Tab(object):
             return self.index
         else:
             return ''
-
-    @property
-    def path(self):
-        """Path of this tab's directory relative to the --output-dir
-        """
-        if self._index:
-            return os.path.split(self._index)[0]
-        else:
-            if self.shortname.lower() == 'summary':
-                p = ''
-            else:
-                p = re_cchar.sub('_', self.shortname.strip('_')).lower()
-            tab_ = self
-            while tab_.parent:
-                p = os.path.join(re_cchar.sub(
-                        '_', tab_.parent.shortname.strip('_')).lower(), p)
-                tab_ = tab_.parent
-            if self.base:
-                return os.path.normpath(os.path.join(self.base, p))
-            else:
-                return os.path.normpath(p)
 
     @property
     def title(self):
@@ -263,18 +253,6 @@ class Tab(object):
             self._group = None
         else:
             self._group = str(gp)
-
-    @property
-    def base(self):
-        """HTML <base> URL for this `Tab`
-
-        :type: `str`
-        """
-        return self._base
-
-    @base.setter
-    def base(self, url):
-        self._base = str(url)
 
     # -------------------------------------------
     # Tab instance methods
@@ -445,8 +423,12 @@ class Tab(object):
         you should preserve the same tag structure, or subclass both.
         """
         # find relative base path
-        n = len(self.index.split(os.path.sep)) - 1
-        base = os.sep.join([os.pardir] * n)
+        base = initargs.pop('base', None)
+        if base is None:
+            n = len(self.index.split(os.path.sep)) - 1
+            base = os.sep.join([os.pardir] * n)
+        if not base.endswith('/'):
+            base += '/'
 
         # move css and js files if needed
         if copy:
@@ -668,8 +650,8 @@ class Tab(object):
         page.div.close()
         return page
 
-    def write_html(self, maincontent, title=None, subtitle=None,
-                   tabs=list(), ifo=None, ifomap=dict(), brand=None,
+    def write_html(self, maincontent, title=None, subtitle=None, tabs=list(),
+                   ifo=None, ifomap=dict(), brand=None, base=None,
                    css=html.CSS, js=html.JS, about=None, footer=None, **inargs):
         """Write the HTML page for this `Tab`.
 
@@ -712,7 +694,7 @@ class Tab(object):
 
         # initialise HTML page
         self.initialise_html_page(title=title, subtitle=subtitle, css=css,
-                                  js=js)
+                                  base=base, js=js)
 
         # add navigation
         self.page.add(str(self.build_html_navbar(ifo=ifo, ifomap=ifomap,
@@ -819,16 +801,16 @@ class SummaryArchiveMixin(object):
         :attr:`~StateTab.span`.
         """
         date = from_gps(self.start)
-        # double-check base matches what is required from custom datepicker
+        # double-check path matches what is required from custom datepicker
         try:
-            requiredbase = mode.get_base(date, mode=self.mode)
+            requiredpath = mode.get_base(date, mode=self.mode)
         except ValueError:
             return html.markup.oneliner.div('%d-%d' % (self.start, self.end),
                                             class_='navbar-brand')
-        if not requiredbase in self.base:
-            raise RuntimeError("Tab base %r inconsistent with required "
+        if not requiredpath in self.path:
+            raise RuntimeError("Tab path %r inconsistent with required "
                                "format including %r for archive calendar"
-                               % (self.base, requiredbase))
+                               % (self.path, requiredpath))
         # format calendar
         return html.calendar(date, mode=self.mode % 3)
 

--- a/gwsumm/tabs/guardian.py
+++ b/gwsumm/tabs/guardian.py
@@ -68,11 +68,10 @@ class GuardianTab(Tab):
     type = 'archived-guardian'
 
     @classmethod
-    def from_ini(cls, config, section, plotdir='plots', base=''):
+    def from_ini(cls, config, section, plotdir='plots', **kwargs):
         """Define a new `GuardianTab`.
         """
-        new = super(Tab, cls).from_ini(
-                  config, section, base=base)
+        new = super(Tab, cls).from_ini(config, section, **kwargs)
         if len(new.states) > 1 or new.states[0].name != ALLSTATE:
             raise ValueError("GuardianTab does not accept state selection")
         new.plots = []

--- a/gwsumm/tabs/hveto.py
+++ b/gwsumm/tabs/hveto.py
@@ -69,7 +69,7 @@ class HvetoTab(base):
         super(HvetoTab, self).__init__(*args, **kwargs)
 
     @classmethod
-    def from_ini(cls, config, section, plotdir=os.curdir, base=''):
+    def from_ini(cls, config, section, **kwargs):
         """Define a new `HvetoTab` from a `ConfigParser`.
         """
         # set state information
@@ -93,8 +93,7 @@ class HvetoTab(base):
         config.set(section, 'states', state)
 
         # parse generic configuration
-        new = super(HvetoTab, cls).from_ini(config, section, plotdir=plotdir,
-                                            base=base)
+        new = super(HvetoTab, cls).from_ini(config, section, **kwargs)
 
         # work out day directory and url
         gps = int(new.span[0])

--- a/gwsumm/tabs/ihope.py
+++ b/gwsumm/tabs/ihope.py
@@ -60,7 +60,7 @@ class DailyAhopeTab(base):
                         get_reader('ligolw', SnglInspiralTable))
 
     @classmethod
-    def from_ini(cls, config, section, plotdir=os.curdir, base=''):
+    def from_ini(cls, config, section, **kwargs):
         """Define a new `DailyAhopeTab` from a `ConfigParser`.
         """
         # parse states
@@ -83,8 +83,7 @@ class DailyAhopeTab(base):
         config.set(section, 'states', state)
 
         # parse generic configuration
-        new = super(DailyAhopeTab, cls).from_ini(config, section,
-                                                 plotdir=plotdir, base=base)
+        new = super(DailyAhopeTab, cls).from_ini(config, section, **kwargs)
         new.channel = re_quote.sub('', config.get(section, 'channel'))
         for p in new.plots + new.subplots:
             p.etg = new.name.lower()

--- a/gwsumm/tabs/management.py
+++ b/gwsumm/tabs/management.py
@@ -49,8 +49,9 @@ class AccountingTab(ParentTab):
     type = 'archived-accounting'
 
     @classmethod
-    def from_ini(cls, config, section, plotdir='plots', base=''):
-        new = super(ParentTab, cls).from_ini(config, section, base=base)
+    def from_ini(cls, config, section, plotdir='plots', **kwargs):
+        new = super(ParentTab, cls).from_ini(config, section, plotdir=plotdir,
+                                             **kwargs)
         if len(new.states) > 1 or new.states[0].name != ALLSTATE:
             raise ValueError("AccountingTab does not accept state selection")
 

--- a/gwsumm/tabs/management.py
+++ b/gwsumm/tabs/management.py
@@ -50,8 +50,7 @@ class AccountingTab(ParentTab):
 
     @classmethod
     def from_ini(cls, config, section, plotdir='plots', **kwargs):
-        new = super(ParentTab, cls).from_ini(config, section, plotdir=plotdir,
-                                             **kwargs)
+        new = super(ParentTab, cls).from_ini(config, section, **kwargs)
         if len(new.states) > 1 or new.states[0].name != ALLSTATE:
             raise ValueError("AccountingTab does not accept state selection")
 

--- a/gwsumm/tabs/sei.py
+++ b/gwsumm/tabs/sei.py
@@ -76,12 +76,12 @@ class SEIWatchDogTab(base):
     window = 5
 
     @classmethod
-    def from_ini(cls, config, section, plotdir='plots', base=''):
+    def from_ini(cls, config, section, plotdir='plots', **kwargs):
         """Define a new `SEIWatchDogTab`.
         """
         chambers = config.get(section, 'chamber-type')
-        new = super(SEIWatchDogTab, cls).from_ini(
-                  config, section, plotdir=plotdir, base=base)
+        new = super(SEIWatchDogTab, cls).from_ini(config, section,
+                                                  plotdir=plotdir, **kwargs)
         new.ifo = config.get('DEFAULT', 'ifo')
         new.plotdir = plotdir
         chamber = str(chambers).upper()


### PR DESCRIPTION
This PR introduces a custom 404 tab for page not found. Changes are as follows

- `gw_summary` now writes a `404.html` page in the base of the output directory and an associated `.htaccess` file that disables directory listing and redirects 403 errors to 404
- the `Tab.base` attribute was renamed to `Tab.path`
- `Tab.write_html` now accepts a `base` keyword argument that it passes onto `Tab.initialize_html_page`
- a few other minor bug fixes

The LDAS admins have enabled override of the `Indexes` option in apache (`httpd`) to enable this for the LIGO summary pages.