### PR TITLE
HvetoTab: resolve symlink before analysis

### DIFF
--- a/gwsumm/tabs/hveto.py
+++ b/gwsumm/tabs/hveto.py
@@ -99,7 +99,8 @@ class HvetoTab(base):
         gps = int(new.span[0])
         duration = int(abs(new.span))
         basedir = os.path.normpath(config.get(section, 'base-directory'))
-        daydir = os.path.join(basedir, config.get(section, 'directory-tag'))
+        daydir = os.path.realpath(
+            os.path.join(basedir, config.get(section, 'directory-tag')))
         new.directory = daydir
         home_, postbase = daydir.split('/public_html/', 1)
         user = os.path.split(home_)[1]


### PR DESCRIPTION
This PR changes the processing of the hveto directories to break the symbolic link before doing any processing. This means no symbolic links will be used in the output HTML.

@areeda: is this what you were after?