### PR TITLE
Update colormaps for matplotlib 1.5

### DIFF
--- a/gwsumm/plot/__init__.py
+++ b/gwsumm/plot/__init__.py
@@ -54,7 +54,7 @@ rcParams.update({
 })
 
 # use new viridis colormap by default
-if mpl_version >= '1.5':
+if '1.5' <= mpl_version < '2.0':
     rcParams['image.cmap'] = 'viridis'
 
 from gwsumm import version

--- a/gwsumm/plot/__init__.py
+++ b/gwsumm/plot/__init__.py
@@ -40,6 +40,8 @@ The available classes are:
    TriggerRateDataPlot
 """
 
+from matplotlib import __version__ as mpl_version
+
 from gwpy.plotter import rcParams
 rcParams.update({
     'figure.subplot.bottom': 0.17,
@@ -50,6 +52,10 @@ rcParams.update({
     'grid.color': 'gray',
     'svg.fonttype': 'none',
 })
+
+# use new viridis colormap by default
+if mpl_version >= '1.5':
+    rcParams['image.cmap'] = 'viridis'
 
 from gwsumm import version
 

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -217,7 +217,6 @@ class SpectrogramDataPlot(TimeSeriesDataPlot):
     defaults = {'ratio': None,
                 'format': None,
                 'clim': None,
-                'cmap': 'jet',
                 'logcolor': False,
                 'colorlabel': None}
 
@@ -256,8 +255,12 @@ class SpectrogramDataPlot(TimeSeriesDataPlot):
         clim = self.pargs.pop('clim')
         clog = self.pargs.pop('logcolor')
         clabel = self.pargs.pop('colorlabel')
-        cmap = self.pargs.pop('cmap')
         ratio = self.ratio
+
+        # get cmap
+        if ratio in ['median', 'mean']:
+            self.pargs.setdefault('cmap', 'Spectral_r')
+        cmap = self.pargs.pop('cmap', None)
 
         # get data
         if self.state and not self.all_data:
@@ -577,7 +580,6 @@ class SpectralVarianceDataPlot(SpectrumDataPlot):
         'reference_linestyle': '--',
         'log': True,
         'nbins': 100,
-        'cmap': 'jet',
     }
 
     def __init__(self, channels, *args, **kwargs):
@@ -611,6 +613,7 @@ class SpectralVarianceDataPlot(SpectrumDataPlot):
             plot.suptitle(suptitle, y=0.993, va='top')
 
         # parse plotting arguments
+        cmap = self.pargs.pop('cmap', None)
         varargs = self.parse_variance_kwargs()
         plotargs = self.parse_plot_kwargs()[0]
         legendargs = self.parse_legend_kwargs()
@@ -644,7 +647,6 @@ class SpectralVarianceDataPlot(SpectrumDataPlot):
             plotargs.setdefault('vmin', 1/livetime)
         plotargs.setdefault('vmax', 1.)
         plotargs.pop('label')
-        plotargs.setdefault('cmap', 'jet')
 
         specgram = get_spectrogram(self.channels[0], valid, query=False,
                                     format='asd').join(gap='ignore')
@@ -657,7 +659,7 @@ class SpectralVarianceDataPlot(SpectrumDataPlot):
             variance /= livetime / specgram.dt.value
             # plot
             ax.plot(asd, color='grey', linewidth=0.3)
-            m = ax.plot_variance(variance, **plotargs)
+            m = ax.plot_variance(variance, cmap=cmap, **plotargs)
         #else:
         #    ax.scatter([1], [1], c=[1], visible=False, vmin=plotargs['vmin'],
         #               vmax=plotargs['vmax'], cmap=plotargs['cmap'])
@@ -734,7 +736,7 @@ class RayleighSpectrogramDataPlot(SpectrogramDataPlot):
     defaults = {'ratio': None,
                 'format': 'rayleigh',
                 'clim': [0.25, 4],
-                'cmap': 'spectral',
+                'cmap': 'BrBG',
                 'logcolor': True,
                 'colorlabel': 'Rayleigh statistic'}
 

--- a/gwsumm/plot/triggers.py
+++ b/gwsumm/plot/triggers.py
@@ -90,7 +90,6 @@ class TriggerDataPlot(TriggerPlotMixin, TimeSeriesDataPlot):
                 'clim': None,
                 'logcolor': False,
                 'colorlabel': None,
-                'cmap': 'jet',
                 'size_by': None,
                 'size_by_log': None,
                 'size_range': None}
@@ -169,7 +168,10 @@ class TriggerDataPlot(TriggerPlotMixin, TimeSeriesDataPlot):
         # get plot arguments
         for key in ['vmin', 'vmax', 'edgecolor', 'facecolor', 'size_by',
                     'size_by_log', 'size_range', 'cmap', 's', 'marker']:
-            val = self.pargs.pop(key)
+            try:
+                val = self.pargs.pop(key)
+            except KeyError:
+                continue
             if key == 'facecolor' and len(self.channels) > 1 and val is None:
                 val = color_cycle()
             if key == 'marker' and len(self.channels) > 1 and val is None:


### PR DESCRIPTION
This PR updates the default colormaps for image-like plots (include event scatters), and sets the default for matplotlib >= 1.5 to the new 'viridis' default.

This closes #20 by enabling the sequential colormaps as early as possible.

This should ideally be installed alongside gwpy/gwpy#173.