### PR TITLE
Support pdf images

### DIFF
--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -260,6 +260,7 @@ class SpectrogramDataPlot(TimeSeriesDataPlot):
         clim = self.pargs.pop('clim')
         clog = self.pargs.pop('logcolor')
         clabel = self.pargs.pop('colorlabel')
+        rasterized = self.pargs.pop('rasterized', True)
         ratio = self.ratio
 
         # get cmap
@@ -308,7 +309,7 @@ class SpectrogramDataPlot(TimeSeriesDataPlot):
         for specgram in specgrams:
             if ratio is not None:
                 specgram = specgram.ratio(ratio)
-            ax.plot_spectrogram(specgram, cmap=cmap)
+            ax.plot_spectrogram(specgram, cmap=cmap, rasterized=rasterized)
 
         # add colorbar
         if len(specgrams) == 0:

--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -513,9 +513,6 @@ class DataPlot(SummaryPlot):
             outputfile = self.outputfile
         if outputfile.endswith('.pdf'):
             extensions = ['.pdf', '.png']
-            if self.href == self.outputfile:
-                self.fileformat = 'png'
-                self._href = self.outputfile
         else:
             extensions = [os.path.splitext(outputfile)[1]]
 
@@ -528,7 +525,6 @@ class DataPlot(SummaryPlot):
                              % (type(e).__name__, str(e)))
                 self.plot.save(fp, **savekwargs)
             vprint("        %s written\n" % fp)
-        vprint("        %s written\n" % self.outputfile)
         if close:
             self.plot.close()
         return outputfile

--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -360,7 +360,7 @@ class DataPlot(SummaryPlot):
                       'bins', 'range', 'normed', 'weights', 'cumulative',
                       'bottom', 'histtype', 'align', 'orientation', 'rwidth',
                       'log', 'stacked', 'logbins', 'linecolor',
-                      'facecolor']:
+                      'facecolor', 'rasterized']:
             try:
                 val = self.pargs.pop(kwarg)
             except KeyError:
@@ -560,11 +560,11 @@ class BarPlot(_SingleCallPlot, DataPlot):
     type = 'bar'
     DRAW_PARAMS = ['width', 'bottom', 'color', 'edgecolor', 'linewidth',
                    'xerr', 'yerr', 'ecolor', 'capsize', 'error_kw',
-                   'align', 'orientation', 'log', 'alpha']
+                   'align', 'orientation', 'log', 'alpha', 'rasterized']
 
 
 class PiePlot(_SingleCallPlot, DataPlot):
     type = 'pie'
     DRAW_PARAMS = ['explode', 'colors', 'autopct', 'pctdistance', 'shadow',
                    'labeldistance', 'startangle', 'radius', 'counterclock',
-                   'wedgeprops', 'textprops']
+                   'wedgeprops', 'textprops', 'rasterized']

--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -508,15 +508,26 @@ class DataPlot(SummaryPlot):
         # customise colorbars
         for cb in self.plot.colorbars:
             cb.outline.set_edgecolor(color)
-        # save figure and close
+        # save figure and close (build both png and pdf for pdf choice)
         if outputfile is None:
             outputfile = self.outputfile
-        try:
-            self.plot.save(outputfile, **savekwargs)
-        except (IOError, RuntimeError) as e:
-            warnings.warn("Caught %s: %s [retrying...]"
-                         % (type(e).__name__, str(e)))
-            self.plot.save(outputfile, **savekwargs)
+        if outputfile.endswith('.pdf'):
+            extensions = ['.pdf', '.png']
+            if self.href == self.outputfile:
+                self.fileformat = 'png'
+                self._href = self.outputfile
+        else:
+            extensions = [os.path.splitext(outputfile)[1]]
+
+        for ext in extensions:
+            fp = '%s%s' % (os.path.splitext(outputfile)[0], ext)
+            try:
+                self.plot.save(fp, **savekwargs)
+            except (IOError, RuntimeError) as e:
+                warnings.warn("Caught %s: %s [retrying...]"
+                             % (type(e).__name__, str(e)))
+                self.plot.save(fp, **savekwargs)
+            vprint("        %s written\n" % fp)
         vprint("        %s written\n" % self.outputfile)
         if close:
             self.plot.close()

--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -505,6 +505,9 @@ class DataPlot(SummaryPlot):
                 ax.spines[edge].set_edgecolor(color)
             if ax.legend_ and ax.legend_.get_frame().get_edgecolor() != 'none':
                 ax.legend_.get_frame().set_edgecolor(color)
+        # customise colorbars
+        for cb in self.plot.colorbars:
+            cb.outline.set_edgecolor(color)
         # save figure and close
         if outputfile is None:
             outputfile = self.outputfile

--- a/gwsumm/plot/triggers.py
+++ b/gwsumm/plot/triggers.py
@@ -175,7 +175,8 @@ class TriggerDataPlot(TriggerPlotMixin, TimeSeriesDataPlot):
             plotargs.append(dict())
         # get plot arguments
         for key in ['vmin', 'vmax', 'edgecolor', 'facecolor', 'size_by',
-                    'size_by_log', 'size_range', 'cmap', 's', 'marker']:
+                    'size_by_log', 'size_range', 'cmap', 's', 'marker',
+                    'rasterized']:
             try:
                 val = self.pargs.pop(key)
             except KeyError:

--- a/gwsumm/tabs/builtin.py
+++ b/gwsumm/tabs/builtin.py
@@ -419,6 +419,11 @@ class PlotTab(Tab):
             else:
                 page.a(href=plot.href, class_=aclass, **fancyboxargs)
             page.img(src=plot.src)
+            if plot.src.endswith('.pdf'):
+                page.img(src=plot.src.replace('.pdf', '.png'))
+            else:
+                page.img(src=plot.src)
+            page.img(src=plot.src)
             page.a.close()
             page.div.close()
             # detect end of row

--- a/gwsumm/tabs/builtin.py
+++ b/gwsumm/tabs/builtin.py
@@ -418,12 +418,10 @@ class PlotTab(Tab):
                        class_=aclass, **fbkw)
             else:
                 page.a(href=plot.href, class_=aclass, **fancyboxargs)
-            page.img(src=plot.src)
             if plot.src.endswith('.pdf'):
                 page.img(src=plot.src.replace('.pdf', '.png'))
             else:
                 page.img(src=plot.src)
-            page.img(src=plot.src)
             page.a.close()
             page.div.close()
             # detect end of row


### PR DESCRIPTION
This PR adds minimal support of PDF images, by adding `rasterized` to the list of understood plotting kwargs, and rendering both png and pdf images when PDF is requested, as follows:

- display png in HTML scaffold
- link png image to pdf image