### PR TITLE
Raise all plot exceptions

### DIFF
--- a/gwsumm/tabs/etg.py
+++ b/gwsumm/tabs/etg.py
@@ -270,6 +270,7 @@ class EventTriggerTab(get_tab('default')):
         try:
             super(EventTriggerTab, self).process(*args, **kwargs)
         except IOError as e:
+            warn('Caught %s: %s' % (type(e).__name__, str(e)))
             msg = "GWSumm failed to process these data.<pre>%s</pre>" % str(e)
             for state in self.states:
                 self.error[state] = ( 'danger', msg)


### PR DESCRIPTION
This PR modifies the `DataTab.process_state` logic to catch any and all exceptions coming from `Plot.process` operations under multi-processing and raise them when the plotting is done.

Currently the exceptions are hidden away by the multiprocessing, which is probably not great.