### PR TITLE
Fixed bug in fftparams usage in `data._make_key`

### DIFF
--- a/gwsumm/data.py
+++ b/gwsumm/data.py
@@ -1441,6 +1441,9 @@ def _clean_fftparams(fftparams, channel):
     for param in ['fftlength', 'overlap', 'stride']:
         if hasattr(channel, param):
             fftparams[param] = float(getattr(channel, param))
+        # if channel doesn't have parameter, set it at the earliest oppotunity
+        else:
+            setattr(channel, param, fftparams[param])
 
     # checks
     if fftparams['stride'] == 0:

--- a/gwsumm/data.py
+++ b/gwsumm/data.py
@@ -1408,10 +1408,12 @@ def _make_key(channels, fftparams, method=None, sampling=None):
     # parameters to append to channel names
     p = []
     p.append(method)
-    p.append(fftparams.get('stride', None))
     p.append(fftparams.get('window', None))
-    p.append(fftparams.get('fftlength', None))
-    p.append(fftparams.get('overlap', None))
+    for param in ['stride', 'fftlength', 'overlap']:
+        try:
+            p.append(float(fftparams[param]))
+        except KeyError:
+            p.append(None)
     p.append(sampling)
 
     # build string


### PR DESCRIPTION
I have fixed a bug(/feature) in `gwsumm.data._make_key` whereby the same FFT params seem to be accessed at different stages as `int` or `float`, making the key different in the two cases.

The fix forces the conversion to `float` making the key `str`.

Additionally I commited a small enhancement to copy the general `fftparams` values to each channel if they don't have overrides - this should mean that if the general `fftparams` aren't passed later on, the channel will already have the values so the outcome should be the same.