### PR TITLE
Denote default state by trailing asterisk

### DIFF
--- a/gwsumm/data.py
+++ b/gwsumm/data.py
@@ -536,7 +536,7 @@ def _get_timeseries_dict(channels, segments, config=ConfigParser(),
                         if c.ndsname in filter_:
                             del c.filter
                 # read data
-                tsd = DictClass.read(segcache, qchannels, format='lcf',
+                tsd = DictClass.read(segcache, qchannels,
                                      start=segstart, end=segend, type=ctype,
                                      nproc=nproc, resample=qresample,
                                      verbose=verbose, **ioargs)

--- a/gwsumm/data.py
+++ b/gwsumm/data.py
@@ -1424,6 +1424,7 @@ def _make_key(channels, fftparams, method=None, sampling=None):
 
 def _clean_fftparams(fftparams, channel):
 
+    channel = get_channel(channel)
     # replace missing fftparams with defaults or values from given channel
 
     fftparams = fftparams.copy()

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -25,6 +25,8 @@ import hashlib
 import warnings
 from itertools import cycle
 
+import numpy
+
 from matplotlib.pyplot import subplots
 
 from astropy.units import Quantity
@@ -622,6 +624,8 @@ class TimeSeriesHistogramPlot(DataPlot):
                     (k, pargs[k]) for k in ['label', 'color'] if pargs.get(k))
                 ax.plot([], **kwargs)
             else:
+                if isinstance(pargs.get('weights', None), (float, int)):
+                    pargs['weights'] = numpy.ones_like(arr) * pargs['weights']
                 ax.hist(arr, **pargs)
 
         # customise plot

--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -511,20 +511,26 @@ class DataPlot(SummaryPlot):
         # save figure and close (build both png and pdf for pdf choice)
         if outputfile is None:
             outputfile = self.outputfile
-        if outputfile.endswith('.pdf'):
+        if not isinstance(outputfile, str):
+            extensions = [None]
+        elif outputfile.endswith('.pdf'):
             extensions = ['.pdf', '.png']
         else:
             extensions = [os.path.splitext(outputfile)[1]]
 
         for ext in extensions:
-            fp = '%s%s' % (os.path.splitext(outputfile)[0], ext)
+            try:
+                fp = '%s%s' % (os.path.splitext(outputfile)[0], ext)
+            except AttributeError:
+                fp = outputfile
             try:
                 self.plot.save(fp, **savekwargs)
             except (IOError, RuntimeError) as e:
                 warnings.warn("Caught %s: %s [retrying...]"
                              % (type(e).__name__, str(e)))
                 self.plot.save(fp, **savekwargs)
-            vprint("        %s written\n" % fp)
+            if isinstance(fp, str):
+                vprint("        %s written\n" % fp)
         if close:
             self.plot.close()
         return outputfile

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -117,33 +117,6 @@ class DataTab(DataTabBase):
         self.noplots = noplots
         self.subplots = []
 
-    @property
-    def states(self):
-        """The `list` of `states <gwsumm.state.SummaryState` for this `DataTab`
-        """
-        return self._states
-
-    @states.setter
-    def states(self, statelist):
-        self._states = []
-        for state in statelist:
-            self.add_state(state)
-
-    def add_state(self, state):
-        """Add a `SummaryState` to this `DataTab`
-
-        Parameters
-        ----------
-        state : `~gwsumm.state.SummaryState`, `str`
-            the `SummaryState` to add, or the key of a state that has been
-            registered
-        """
-        if isinstance(state, SummaryState):
-            self._states.append(state)
-        else:
-            self._states.append(get_state(state))
-        return self._states[-1]
-
     # -------------------------------------------
     # SummaryTab configuration parser
 
@@ -377,7 +350,8 @@ class DataTab(DataTabBase):
         self.finalize_states(
             config=config, segdb_error=stateargs.get('segdb_error', 'raise'),
             datafind_error=stateargs.get('datafind_error', 'raise'))
-        vprint("States finalised\n")
+        vprint("States finalised [%d total]\n" % len(self.states))
+        vprint("    Default state: %r\n" % str(self.defaultstate))
 
         # pre-process requests for 'all-data' plots
         all_data = any([(p.all_data & p.new) for p in self.plots])

--- a/gwsumm/tests/compat.py
+++ b/gwsumm/tests/compat.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Compatibility module to import unittest
+"""
+
+import sys
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest

--- a/gwsumm/tests/test_archive.py
+++ b/gwsumm/tests/test_archive.py
@@ -23,12 +23,12 @@
 import sys
 import os
 import tempfile
-import unittest
 
 from numpy import testing as nptest
 
 from gwpy.timeseries import TimeSeries
 
+from .compat import unittest
 from ..version import version as __version__
 from .. import (archive, data, globalv)
 

--- a/gwsumm/tests/test_channels.py
+++ b/gwsumm/tests/test_channels.py
@@ -20,13 +20,7 @@
 
 """
 
-import sys
-
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
-
+from .compat import unittest
 from .. import (globalv, channels)
 from ..mode import set_mode
 from ..version import version as __version__

--- a/gwsumm/tests/test_data.py
+++ b/gwsumm/tests/test_data.py
@@ -20,10 +20,9 @@
 
 """
 
-import unittest
-
 from gwpy.detector import Channel
 
+from .compat import unittest
 from .. import (data, version)
 
 __version__ = version.version
@@ -48,10 +47,12 @@ class DataTests(unittest.TestCase):
         self.assertEqual(data.find_frame_type(channel), 'H1_lldetchar')
 
     def test_make_key(self):
-        key = data._make_key('L1:TEST-CHANNEL', {'stride': 123.456},
+        key = data._make_key('L1:TEST-CHANNEL',
+                             {'stride': 123.456, 'window': 'test-window'},
                              method='test-method', sampling=654.321)
         self.assertEqual(
-            key, 'L1:TEST-CHANNEL;test-method;123.456;None;None;None;654.321')
+            key, 'L1:TEST-CHANNEL;test-method;test-window;123.456;'
+                 'None;None;654.321')
 
     def test_clean_fftparams(self):
         fftparams = data._clean_fftparams({}, 'L1:TEST-CHANNEL')
@@ -62,7 +63,7 @@ class DataTests(unittest.TestCase):
             {'window': 'median-mean', 'overlap': 0}, 'L1:TEST-CHANNEL')
         self.assertDictEqual(
             fftparams,
-            {'window': 'median-mean', 'fftlength': 1, 'overlap': 0,
-             'stride': 1.0})
+            {'window': 'median-mean', 'fftlength': 1.0, 'overlap': 0.5,
+             'stride': 2.0})
         self.assertRaises(ZeroDivisionError, data._clean_fftparams,
                           {'stride': 0}, None)

--- a/gwsumm/tests/test_mode.py
+++ b/gwsumm/tests/test_mode.py
@@ -23,11 +23,7 @@
 import sys
 import datetime
 
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
-
+from .compat import unittest
 from .. import (globalv, mode)
 from ..version import version as __version__
 

--- a/gwsumm/tests/test_plot.py
+++ b/gwsumm/tests/test_plot.py
@@ -20,11 +20,10 @@
 
 """
 
-import unittest
-
 from matplotlib import use
 use('agg')
 
+from .compat import unittest
 from .. import (plot, version)
 
 __version__ = version.version

--- a/gwsumm/tests/test_tabs.py
+++ b/gwsumm/tests/test_tabs.py
@@ -20,10 +20,9 @@
 
 """
 
-import unittest
-
 from gwpy.detector import Channel
 
+from .compat import unittest
 from .. import (tabs, version)
 
 __version__ = version.version


### PR DESCRIPTION
This PR fixes #39 by implementing a `defaultstate` property for the `StateTab` class. This is automagically set to the first state unless one of the states is added with `default=True` either in the call to `Tab.add_state` or by using a trailing asterisk in the config file, e.g.

```ini
[tab-hoft]
states = Locked, Ready*, Observing
```