### PR TITLE
Use img-responsive class for imgs

### DIFF
--- a/gwsumm/tabs/builtin.py
+++ b/gwsumm/tabs/builtin.py
@@ -419,9 +419,10 @@ class PlotTab(Tab):
             else:
                 page.a(href=plot.href, class_=aclass, **fancyboxargs)
             if plot.src.endswith('.pdf'):
-                page.img(src=plot.src.replace('.pdf', '.png'))
+                page.img(class_='img-responsive',
+                         src=plot.src.replace('.pdf', '.png'))
             else:
-                page.img(src=plot.src)
+                page.img(class_='img-responsive', src=plot.src)
             page.a.close()
             page.div.close()
             # detect end of row

--- a/gwsumm/tabs/fscan.py
+++ b/gwsumm/tabs/fscan.py
@@ -223,7 +223,7 @@ class FscanTab(base):
                     page.div(class_="col-md-6")
                     page.a(href=p.href, class_="fancybox plot",
                            **{'data-fancybox-group': 1})
-                    page.img(src=p.href)
+                    page.img(class_='img-responsive', src=p.href)
                     page.a.close()
                     page.div.close()
                 page.div.close()


### PR DESCRIPTION
This commit adds the `img-responsive` bootstrap class for all `<img>` elements