### PR TITLE
Fixed bug in summing LIGOTimeGPS and numpy.int64

### DIFF
--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -530,8 +530,8 @@ class DutyDataPlot(SegmentDataPlot):
         duty = numpy.zeros(len(bins))
         mean = numpy.zeros(len(bins))
         for i in range(len(bins)):
-            bin = SegmentList([Segment(self.start + sum(bins[:i]),
-                                       self.start + sum(bins[:i+1]))])
+            bin = SegmentList([Segment(float(self.start) + sum(bins[:i]),
+                                       float(self.start) + sum(bins[:i+1]))])
             d = float(abs(segments & bin))
             if normalized:
                 d *= normalized / float(bins[i])


### PR DESCRIPTION
This PR fixes a bug in `gwsumm.plot.segments` - just a type problem when using the `pylal.xlal.types.ligotimegps.LIGOTimeGPS` object.