### PR TITLE
Fixed bug in archive keys for get_spectrograms

### DIFF
--- a/gwsumm/data.py
+++ b/gwsumm/data.py
@@ -1282,7 +1282,7 @@ def get_spectrograms(channels, segments, config=ConfigParser(), cache=None,
         keys = []
         for channel in qchannels:
             fftparams_ = _clean_fftparams(fftparams, channel)
-            keys.append(_make_key(channel, fftparams, method=method))
+            keys.append(_make_key(channel, fftparams_, method=method))
         havesegs = reduce(operator.and_, (globalv.SPECTROGRAMS.get(
             key, SpectrogramList()).segments for key in keys))
         new = segments - havesegs


### PR DESCRIPTION
This PR fixes a bug where archived spectrograms weren't being recognised by `get_spectrograms`.