### PR TITLE
Improved HTML for navbar and friends

### DIFF
--- a/gwsumm/config.py
+++ b/gwsumm/config.py
@@ -94,6 +94,9 @@ class GWSummConfigParser(ConfigParser):
     def from_configparser(cls, cp):
         """Copy an existing :class:`~ConfigParser.ConfigParser`.
         """
+        # if its already what we need, just return this instance
+        if isinstance(cp, cls):
+           return cp
         # set up temporary buffer
         buf = StringIO()
         # write to buffer

--- a/gwsumm/html/__init__.py
+++ b/gwsumm/html/__init__.py
@@ -52,6 +52,7 @@ JS['fancybox'] = (
 JS['datepicker'] = (
     '//cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/'
     '1.6.0/js/bootstrap-datepicker.min.js')
+JS['bootstrap-ligo'] = os.path.join(STATICDIR, 'bootstrap-ligo.min.js')
 JS['gwsumm'] = os.path.join(STATICDIR, 'gwsumm.min.js')
 
 CSS = OrderedDict()

--- a/gwsumm/html/bootstrap/__init__.py
+++ b/gwsumm/html/bootstrap/__init__.py
@@ -74,7 +74,6 @@ def banner(title, subtitle=None, titleclass=None, substitleclass=None):
     """
     page = markup.page()
     page.div(class_='banner')
-    page.div(class_='container')
     if titleclass is None:
         page.h1(str(title))
     else:
@@ -84,13 +83,12 @@ def banner(title, subtitle=None, titleclass=None, substitleclass=None):
     elif subtitle is not None:
         page.p(subtitle)
     page.div.close()
-    page.div.close()
 
     return page
 
 
 def navbar(links, class_='navbar navbar-fixed-top',
-           brand=None, dropdown_class=[''], collapse=True):
+           brand=None, collapse=True):
     """Construct a navigation bar in bootstrap format.
 
     Parameters
@@ -133,29 +131,23 @@ def navbar(links, class_='navbar navbar-fixed-top',
 
     # ---- collapsable part (<nav>) ----
 
-    # build dropdown menus
-    #    - this model allows for multiple copies of the menus to be written
-    #      for multiple screen sizes
-    if isinstance(dropdown_class, (str, unicode)):
-        dropdown_class = [dropdown_class]
     if links:
-        for ddclass in dropdown_class:
-            page.ul(class_='nav navbar-nav %s' % ddclass)
-            for i, link in enumerate(links):
-                if (isinstance(link, (list, tuple)) and
-                        isinstance(link[1], basestring)):
-                    page.li()
-                    text, link = link
-                    page.a(text, href=link)
-                elif (isinstance(link, (list, tuple)) and
-                      isinstance(link[1], (list, tuple))):
-                    page.li(class_='dropdown')
-                    page.add(str(dropdown(*link)))
-                else:
-                    page.li()
-                    page.add(str(link))
-                page.li.close()
-            page.ul.close()
+        page.ul(class_='nav navbar-nav')
+        for i, link in enumerate(links):
+            if (isinstance(link, (list, tuple)) and
+                    isinstance(link[1], basestring)):
+                page.li()
+                text, link = link
+                page.a(text, href=link)
+            elif (isinstance(link, (list, tuple)) and
+                  isinstance(link[1], (list, tuple))):
+                page.li(class_='dropdown')
+                page.add(str(dropdown(*link)))
+            else:
+                page.li()
+                page.add(str(link))
+            page.li.close()
+        page.ul.close()
 
     page.nav.close()
     page.div.close()
@@ -389,7 +381,7 @@ def state_switcher(states, default=0):
                onclick='$(this).load_state(\'%s\');' % href)
         page.li.close()
     page.ul.close()
-    page.div.close()
+    page.div.close()  # btn-group
     return page
 
 

--- a/gwsumm/html/bootstrap/__init__.py
+++ b/gwsumm/html/bootstrap/__init__.py
@@ -315,7 +315,8 @@ def wrap_content(page):
     return out
 
 
-def footer(user=True, about=None, issues=True, content=None, span=12):
+def footer(user=True, about=None, issues=True, content=None, span=12,
+           class_='footer'):
     """Construct a footer with the given HTML content
 
     Parameters
@@ -341,7 +342,7 @@ def footer(user=True, about=None, issues=True, content=None, span=12):
             </footer>
     """
     page = markup.page(twotags=['footer'])
-    page.FOOTER()
+    page.FOOTER(class_=class_)
     page.div(class_='container')
     page.div(class_='row')
     page.div(class_='col-md-%d' % span)

--- a/gwsumm/tabs/builtin.py
+++ b/gwsumm/tabs/builtin.py
@@ -747,8 +747,7 @@ class StateTab(PlotTab):
 
         # combine and return
         return html.navbar(self._build_nav_links(tabs), brand=brand_,
-                           class_=class_,
-                           dropdown_class=['hidden-xs visible-lg', 'hidden-lg'])
+                           class_=class_)
 
     @staticmethod
     def build_html_content(frame):

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -469,7 +469,6 @@ class Tab(object):
         initargs.setdefault('metainfo', html.META)
         self.page = html.markup.page()
         self.page.init(css=css, script=js, title=title, base=base, **initargs)
-        self.page.div(id_='wrap')
         return self.page
 
     def finalize_html_page(self, user=True, issues=True, about=None,
@@ -507,8 +506,6 @@ class Tab(object):
         if not self.page:
             raise RuntimeError("Cannot finalize HTML page before intialising "
                                "one")
-        # close #wrap div
-        self.page.div.close()
         # add footer
         self.page.add(str(html.footer(user=user, issues=issues, about=about,
                                       content=content)))
@@ -571,8 +568,7 @@ class Tab(object):
             brand_.div(str(brand), class_='navbar-brand')
         # combine and return
         return html.navbar(self._build_nav_links(tabs), class_=class_,
-                           brand=brand_,
-                           dropdown_class=['hidden-xs visible-lg', 'hidden-lg'])
+                           brand=brand_)
 
     def _build_nav_links(self, tabs):
         """Construct the ordered list of tabs to write into the navbar
@@ -663,9 +659,7 @@ class Tab(object):
         """
         page = html.markup.page()
         page.div(id_='main')
-        page.div(class_='container')
         page.div(str(content), id_='content')
-        page.div.close()
         page.div.close()
         return page
 
@@ -722,12 +716,17 @@ class Tab(object):
         # add navigation
         self.page.add(str(self.build_html_navbar(ifo=ifo, ifomap=ifomap,
                                                  tabs=tabs, brand=brand)))
+        # -- open main page container
+        self.page.div(class_='container')
+
         # add banner
         self.page.add(str(self.build_html_banner(title=title,
                                                  subtitle=subtitle)))
 
         # add #main content
         self.page.add(str(self.build_html_content(maincontent)))
+
+        self.page.div.close()  # container
         # close page and write
         self.finalize_html_page(about=about, content=footer)
         with open(self.index, 'w') as fobj:

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -605,7 +605,6 @@ class DataTab(DataTabBase):
         """
         page = html.markup.page()
         page.div(id_='main')
-        page.div(class_='container')
         page.div('', id_='content')
         page.add(str(html.load(frame, id_='content')))
         if globalv.HTML_COMMENTS_NAME:
@@ -617,7 +616,6 @@ class DataTab(DataTabBase):
             page.h1('Comments')
             page.add(str(html.comments_box(
                 globalv.HTML_COMMENTS_NAME, identifier=id_)))
-        page.div.close()
         page.div.close()
         return page
 

--- a/share/sass/gwsumm.scss
+++ b/share/sass/gwsumm.scss
@@ -2,27 +2,29 @@
  * gwsumm.scss - CSS extensions for bootstrap-ligo.css
  */
 
-// custom nav-bar elements
+body {
+		background-color: #eee;
+}
+
 .navbar {
 		// map page to another IFO
 		.base-map {
 				padding-right: 5px;
 				margin-right: 10px;
-				//margin-right: 10px;
 				.dropdown-menu {
-						//margin-left: -15px;
-						min-width: 54px;
+						min-width: 44px;
 						width: 100%;
 						a {
-								padding-left: 16px;
+								padding-left: 12px;
 								cursor: pointer;
 						}
-						@media (min-width: 1200px) {
+						@media (min-width: 768px) {
 								margin-left: -15px;
+								min-width: 52px;
+								a {
+										padding-left: 16px;
+								}
 						}
-				}
-				@media (max-width: 1199px) {
-						margin-right: -5px;
 				}
 		}
 
@@ -33,9 +35,8 @@
 						padding-right: 20px;
 						white-space: normal;;
 				}
-				@media (min-width: 1200px) {
+				@media (min-width: 768px) {
 						position: absolute;
-						float: right;
 						right: 0;
 				}
 		}


### PR DESCRIPTION
This PR improves the HTML and CSS styling for the `navbar`, and related elements on the page. The main changes are

- only write a single copy of the navbar, and just responsively style it well
- embed the whole page between the `</header>`and `<footer>` inside a single `.container`
- improved responsive styling of navbar elements