### PR TITLE
Revert removal of lxml, and fixed a bug

### DIFF
--- a/gwsumm/plot/mixins.py
+++ b/gwsumm/plot/mixins.py
@@ -24,7 +24,7 @@ import os.path
 import re
 from StringIO import StringIO
 
-from xml.etree import ElementTree as etree
+from lxml import etree
 
 from gwpy.plotter.tex import label_to_latex
 

--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -530,11 +530,11 @@ class DutyDataPlot(SegmentDataPlot):
         duty = numpy.zeros(len(bins))
         mean = numpy.zeros(len(bins))
         for i in range(len(bins)):
-            bin = SegmentList([Segment(float(self.start) + sum(bins[:i]),
-                                       float(self.start) + sum(bins[:i+1]))])
+            bin = SegmentList([Segment(self.start + float(sum(bins[:i])),
+                                       self.start + float(sum(bins[:i+1])))])
             d = float(abs(segments & bin))
             if normalized:
-                d *= normalized / float(bins[i])
+                d *= normalized / bins[i]
             duty[i] = d
             mean[i] = duty[:i+1].mean()
         if cumulative:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ pykerberos
 m2crypto
 python-cjson
 h5py
+lxml
 https://github.com/ligovirgo/trigfind/archive/v0.3.tar.gz
 http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz
 http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ requires = [
     'astropy',
     'gwpy',
     'h5py',
+    'lxml',
 ]
 tests_require = [
     'pytest>=2.8'


### PR DESCRIPTION
Turns out the standard library `xml` module doesn't write an SVG that works with javascript, so this PR reverts the commit that removed `lxml`. Also, I fixed a `TypeError` in segment plotting when trying to combine `glue.lal.LIGOTimeGPS` with `numpy.int64`.