### PR TITLE
Fixed atlas cluster FQDN checks for default IFO

### DIFF
--- a/gwsumm/utils.py
+++ b/gwsumm/utils.py
@@ -204,7 +204,7 @@ def get_default_ifo(fqdn=getfqdn()):
     ValueError
         if not default interferometer prefix can be parsed
     """
-    if '.uni-hannover.' in fqdn:
+    if '.uni-hannover.' in fqdn or '.atlas.' in fqdn:
         return 'G1'
     elif '.ligo-wa.' in fqdn:
         return 'H1'


### PR DESCRIPTION
This PR fixes the references to ATLAS (AEI-Hannover) in `gwsumm.utils.get_default_ifo`, meaning the G1 (GEO-600) interferometer prefix should be automatically selected correctly.