### PR TITLE
Added parsing for datafind name matching

### DIFF
--- a/docs/configuration/data.rst
+++ b/docs/configuration/data.rst
@@ -295,7 +295,11 @@ The following channel configuration options are understood for a `DataTab`:
 
 ==================  ===========================================================
 channels            comma-separated list of channels to configure
-frametype           GWF type code to query for data frames
+frametype           GWF type code to query for data frames. Use a bar-separated
+                    part to specify a string to match frame URLS for, e.g.
+                    ``frametype = T|RDS9`` will find `T`-type frame files whose
+                    full URLs contain the string `RDS9` (looking at you
+                    GEO-600)
 resample            number of samples per second at which to resample data
 unit                physical unit of the data (after any filtering)
 filter              time-domain filter to apply. Should be of the form \

--- a/gwsumm/data.py
+++ b/gwsumm/data.py
@@ -161,6 +161,12 @@ def find_frames(ifo, frametype, gpsstart, gpsend, config=ConfigParser(),
     if gpsend <= gpsstart:
         return Cache()
 
+    # parse match
+    try:
+        frametype, match = frametype.split('|', 1)
+    except ValueError:
+        match = None
+
     def _query():
         if cert is not None:
             dfconn = datafind.GWDataFindHTTPSConnection(
@@ -168,7 +174,8 @@ def find_frames(ifo, frametype, gpsstart, gpsend, config=ConfigParser(),
         else:
             dfconn = datafind.GWDataFindHTTPConnection(host=host, port=port)
         return dfconn.find_frame_urls(ifo[0].upper(), frametype, gpsstart,
-                                      gpsend, urltype=urltype, on_gaps=gaps)
+                                      gpsend, urltype=urltype, on_gaps=gaps,
+                                      match=match)
     try:
         cache = _query()
     except RuntimeError as e:


### PR DESCRIPTION
This PR introduces an optional syntax for providing a `match` string for datafind queries. Users can now give `frametype = <type>|<match>` to query for frames of type `<type>` whose paths contain `<match>`, e.g. `frametype = T|RDS9` for GEO.