### PR TITLE
Fixed bugs in using lambda filter expression

### DIFF
--- a/gwsumm/config.py
+++ b/gwsumm/config.py
@@ -25,6 +25,10 @@ import sys
 from StringIO import StringIO
 from importlib import import_module
 
+# import these for evaluating lambda expressions in the configuration file
+import math
+import numpy
+
 from six.moves import http_client as httplib
 
 if sys.version_info[0] >= 3:

--- a/gwsumm/data.py
+++ b/gwsumm/data.py
@@ -582,7 +582,13 @@ def _get_timeseries_dict(channels, segments, config=ConfigParser(),
                 else:
                     # filter with function
                     if callable(filt):
-                        data = filt(data)
+                        try:
+                            data = filt(data)
+                        except TypeError as e:
+                            if 'Can only apply' in str(e):
+                                data.value[:] = filt(data.value)
+                            else:
+                                raise
                     # filter with gain
                     elif (isinstance(filt, tuple) and len(filt) == 3 and
                               len(filt[0] + filt[1]) == 0):


### PR DESCRIPTION
This PR fixes problems with configuring time-domain filters via `lambda` expressions in the configuration file. It turns out `numpy` and `math` need to be available when the lambda is evaluated, not when it is used, plus there was a problem with units meaning astropy would refuse to use some functions.