### PR TITLE
Allow custom rcParams globally and per-plot

### DIFF
--- a/bin/gw_summary
+++ b/bin/gw_summary
@@ -479,6 +479,8 @@ channels = config.load_channels()
 vprint("    Loaded %d channels\n" % len(channels))
 states = config.load_states()
 vprint("    Loaded %d states\n" % len(states))
+rcp = config.load_rcParams()
+vprint("    Loaded %d rcParams\n" % len(rcp))
 
 # read list of tabs
 tablist = TabList.from_ini(config, match=opts.process_tab,

--- a/gwsumm/config.py
+++ b/gwsumm/config.py
@@ -328,10 +328,15 @@ class GWSummConfigParser(ConfigParser):
         """Load custom `matplotlib.rcParams` for plots in this analysis
         """
         try:
-            new = self.nditems(section)
+            new = dict(self.nditems(section))
         except NoSectionError:
             return []
         else:
+            for key, value in new.items():
+                try:
+                    new[key] = eval(value)
+                except (SyntaxError, NameError):
+                    new[key] = value
             rcParams.update(new)
             return new
 

--- a/gwsumm/config.py
+++ b/gwsumm/config.py
@@ -45,6 +45,8 @@ try:
 except ImportError:
     from ordereddict import OrderedDict
 
+from matplotlib import rcParams
+
 from astropy import units
 
 from gwpy.detector import (Channel, ChannelList)
@@ -321,6 +323,17 @@ class GWSummConfigParser(ConfigParser):
             states.insert(0, all_)
 
         return states
+
+    def load_rcParams(self, section='rcParams'):
+        """Load custom `matplotlib.rcParams` for plots in this analysis
+        """
+        try:
+            new = self.nditems(section)
+        except NoSectionError:
+            return []
+        else:
+            rcParams.update(new)
+            return new
 
     def get_css(self, section='html'):
         # get critical CSS

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -120,7 +120,7 @@ class TimeSeriesDataPlot(DataLabelSvgMixin, DataPlot):
         return super(TimeSeriesDataPlot, self).finalize(
                    outputfile=outputfile, close=close, **savekwargs)
 
-    def process(self, outputfile=None):
+    def draw(self, outputfile=None):
         """Read in all necessary data, and generate the figure.
         """
         (plot, axes) = self.init_plot()
@@ -254,7 +254,7 @@ class SpectrogramDataPlot(TimeSeriesDataPlot):
     def pid(self):
         del self._pid
 
-    def process(self):
+    def draw(self):
         # initialise
         (plot, axes) = self.init_plot()
         ax = axes[0]
@@ -370,16 +370,16 @@ class SpectrumDataPlot(DataPlot):
                 'no_percentiles': False,
                 'reference_linestyle': '--'}
 
-    def process(self):
+    def draw(self):
         pargs = self.pargs.copy()
         try:
-            self._process()
+            self._draw()
         except OverflowError:
             self.pargs = pargs
             self.pargs['alpha'] = 0.0
-            self._process()
+            self._draw()
 
-    def _process(self):
+    def _draw(self):
         """Load all data, and generate this `SpectrumDataPlot`
         """
         plot = self.plot = FrequencySeriesPlot(
@@ -583,7 +583,7 @@ class TimeSeriesHistogramPlot(DataPlot):
                  histargs.setdefault('alpha', 0.7)
         return kwargs
 
-    def process(self, outputfile=None):
+    def draw(self, outputfile=None):
         """Get data and generate the figure.
         """
         # get plot and axes
@@ -714,7 +714,7 @@ class TimeSeriesHistogram2dDataPlot(TimeSeriesHistogramPlot):
                  }
         return kwargs
 
-    def process(self, outputfile=None):
+    def draw(self, outputfile=None):
         """Get data and generate the figure.
         """
         # get histogram parameters
@@ -807,7 +807,7 @@ class SpectralVarianceDataPlot(SpectrumDataPlot):
                 varargs[key] = self.pargs.pop(key)
         return varargs
 
-    def _process(self):
+    def _draw(self):
         """Load all data, and generate this `SpectrumDataPlot`
         """
         plot = self.plot = FrequencySeriesPlot(

--- a/gwsumm/plot/mixins.py
+++ b/gwsumm/plot/mixins.py
@@ -87,14 +87,14 @@ class SvgMixin(object):
             outputfile = self.outputfile
         # make SVG
         if outputfile.endswith('.svg'):
-            self.process_svg(outputfile)
-        # or process as normal
+            self.draw_svg(outputfile)
+        # or continue as normal
         else:
             return super(SvgMixin, self).finalize(
                 outputfile=outputfile, close=close, **savekwargs)
 
     @abc.abstractmethod
-    def process_svg(self, outputfile):
+    def draw_svg(self, outputfile):
         pass
 
     def finalize_svg(self, tree, outputfile, script=None):
@@ -109,7 +109,7 @@ class SvgMixin(object):
 
 
 class DataLabelSvgMixin(SvgMixin):
-    def process_svg(self, outputfile):
+    def draw_svg(self, outputfile):
         for ax in self.plot.axes:
             for line in ax.lines:
                 line.set_rasterized(True)
@@ -169,7 +169,7 @@ class DataLabelSvgMixin(SvgMixin):
 
 
 class SegmentLabelSvgMixin(SvgMixin):
-    def process_svg(self, outputfile):
+    def draw_svg(self, outputfile):
         # render image
         super(SvgMixin, self).finalize(outputfile=StringIO(), close=False)
         ax = self.plot.axes[0]

--- a/gwsumm/plot/range.py
+++ b/gwsumm/plot/range.py
@@ -63,7 +63,7 @@ class RangePlotMixin(object):
                 value = [value]*len(self.channels)
             self.rangeparams[key] = value
 
-    def process(self):
+    def draw(self):
         """Read in all necessary data, and generate the figure.
         """
         # generate data
@@ -86,7 +86,7 @@ class RangePlotMixin(object):
         channels = self.channels
         outputfile = self.outputfile
         self.channels = keys
-        out = super(RangePlotMixin, self).process(outputfile=outputfile)
+        out = super(RangePlotMixin, self).draw(outputfile=outputfile)
         self.channels = channels
         return out
 
@@ -168,7 +168,7 @@ class SimpleTimeVolumeDataPlot(get_plot('segments')):
         ts[:] = livetime(ts.times.value) * ts.unit
         return (4/3. * pi * ts * range ** 3).to('Mpc^3 year')
 
-    def process(self, outputfile=None):
+    def draw(self, outputfile=None):
         """Generate the figure for this plot
         """
         plot, axes = self.init_plot()

--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -191,7 +191,7 @@ class SegmentDataPlot(SegmentLabelSvgMixin, TimeSeriesDataPlot):
             else:
                 return GREEN, 'red'
 
-    def process(self):
+    def draw(self):
         # get labelsize
         _labelsize = rcParams['ytick.labelsize']
         labelsize = self.pargs.pop('labelsize', 12)
@@ -339,7 +339,7 @@ class StateVectorDataPlot(TimeSeriesDataPlot):
             labels.append(None)
         return labels
 
-    def process(self):
+    def draw(self):
         # make font size smaller
         _labelsize = rcParams['ytick.labelsize']
         labelsize = self.pargs.pop('labelsize', 12)
@@ -541,7 +541,7 @@ class DutyDataPlot(SegmentDataPlot):
             duty = duty.cumsum()
         return duty, mean
 
-    def process(self, outputfile=None):
+    def draw(self, outputfile=None):
         sep = self.pargs.pop('sep', False)
         if sep:
             if self.pargs.get('side_by_side'):
@@ -758,7 +758,7 @@ class ODCDataPlot(SegmentLabelSvgMixin, StateVectorDataPlot):
                     self._pid + str(self.pargs['bits'])).hexdigest()[:6]
             return self.pid
 
-    def process(self):
+    def draw(self):
         # make font size smaller
         _labelsize = rcParams['ytick.labelsize']
         labelsize = self.pargs.pop('labelsize', 12)
@@ -928,7 +928,7 @@ class SegmentPiePlot(PiePlot, SegmentDataPlot):
                 wedgeargs[key[6:]] = self.pargs.pop(key)
         return wedgeargs
 
-    def process(self, outputfile=None):
+    def draw(self, outputfile=None):
         (plot, axes) = self.init_plot(plot=Plot)
         ax = axes[0]
 
@@ -1083,7 +1083,7 @@ class NetworkDutyPiePlot(SegmentPiePlot):
         'legend-fontsize': 24,
     })
 
-    def process(self):
+    def draw(self):
         # get segments
         if self.state and not self.all_data:
             valid = self.state.active
@@ -1122,7 +1122,7 @@ class NetworkDutyPiePlot(SegmentPiePlot):
         flags_ = self.flags
         outputfile = self.outputfile
         self.flags = networkflags
-        out = super(NetworkDutyPiePlot, self).process(outputfile=outputfile)
+        out = super(NetworkDutyPiePlot, self).draw(outputfile=outputfile)
         self.flags = flags_
         return out
 
@@ -1155,7 +1155,7 @@ class SegmentBarPlot(BarPlot, SegmentDataPlot):
         axes = [self.plot.gca()]
         return self.plot, axes
 
-    def process(self, outputfile=None):
+    def draw(self, outputfile=None):
         (plot, axes) = self.init_plot(plot=Plot)
         ax = axes[0]
 
@@ -1249,7 +1249,7 @@ class SegmentHistogramPlot(get_plot('histogram'), SegmentDataPlot):
                 'bottom': 0,
                 'rwidth': 1}
 
-    def process(self, outputfile=None):
+    def draw(self, outputfile=None):
         # make axes
         (plot, axes) = self.init_plot()
 

--- a/gwsumm/plot/triggers.py
+++ b/gwsumm/plot/triggers.py
@@ -137,7 +137,7 @@ class TriggerDataPlot(TriggerPlotMixin, TimeSeriesDataPlot):
             return super(TimeSeriesDataPlot, self).finalize(
                        outputfile=outputfile, close=close, **savekwargs)
 
-    def process(self):
+    def draw(self):
         # get columns
         xcolumn, ycolumn, ccolumn = self.columns
 
@@ -303,7 +303,7 @@ class TriggerTimeSeriesDataPlot(TimeSeriesDataPlot):
     type = 'trigger-timeseries'
     data = 'triggers'
 
-    def process(self):
+    def draw(self):
         """Read in all necessary data, and generate the figure.
         """
         (plot, axes) = self.init_plot()
@@ -410,7 +410,7 @@ class TriggerHistogramPlot(TriggerPlotMixin, get_plot('histogram')):
         ax.grid(True, which='both')
         return self.plot, ax
 
-    def process(self):
+    def draw(self):
         """Get data and generate the figure.
         """
         # get histogram parameters
@@ -533,7 +533,7 @@ class TriggerRateDataPlot(TimeSeriesDataPlot):
     def pid(self, id_):
         self._pid = str(id_)
 
-    def process(self):
+    def draw(self):
         """Read in all necessary data, and generate the figure.
         """
 
@@ -595,7 +595,7 @@ class TriggerRateDataPlot(TimeSeriesDataPlot):
         channels = self.channels
         outputfile = self.outputfile
         self.channels = keys
-        out = super(TriggerRateDataPlot, self).process(outputfile=outputfile)
+        out = super(TriggerRateDataPlot, self).draw(outputfile=outputfile)
         self.channels = channels
         return out
 

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -225,7 +225,7 @@ class DataTab(DataTabBase):
             mods = {}
             for key, val in cp.nditems(section):
                 if key.startswith('%d-' % index):
-                    opt = re_cchar.sub('_', key.split('-', 1)[1].lower())
+                    opt = key.split('-', 1)[1]
                     try:
                         mods[opt] = eval(val)
                     except (NameError, SyntaxError):
@@ -265,8 +265,8 @@ class DataTab(DataTabBase):
                 type_ = None
                 PlotClass = get_plot(pdef)
             # if the plot definition declares multiple states
-            if 'all_states' in mods:
-                mods.setdefault('all_data', True)
+            if 'all-states' in mods:
+                mods.setdefault('all-data', True)
                 if type_:
                     plot = PlotClass.from_ini(cp, pdef, start, end, sources,
                                               state=None, outdir=plotdir,


### PR DESCRIPTION
This PR  introduces parsing of an `[rcParams]` configuration section to set global `matplotlib.rcParams`, and also plot-level configuration options for context-managed rcParams for each plot.