### PR TITLE
Fixed a couple of bugs in running gw_summary{_pipe} without defaults.ini

### DIFF
--- a/bin/gw_summary_pipe
+++ b/bin/gw_summary_pipe
@@ -387,7 +387,7 @@ for job in jobs:
 if not opts.skip_html_wrapper:
     htmljob.add_opt('html-only', '')
     htmljob.add_opt('config-file', ','.join(
-        [globalconfig]+opts.config_file))
+        [globalconfig]+opts.config_file).strip(','))
 
     htmlnode = GWSummaryDAGNode(htmljob)
     for configfile in opts.config_file:
@@ -406,7 +406,8 @@ if not opts.html_wrapper_only:
     # configure each data node
     for i, configfile in enumerate(opts.config_file):
         node = GWSummaryDAGNode(datajob)
-        node.add_var_arg('--config-file %s,%s' % (globalconfig, configfile))
+        node.add_var_arg('--config-file %s' % ','.join(
+            [globalconfig, configfile]).strip(','))
         if opts.archive:
             jobtag = os.path.splitext(os.path.basename(configfile))[0]
             archivetag = jobtag.upper().replace('-', '_')

--- a/gwsumm/config.py
+++ b/gwsumm/config.py
@@ -347,7 +347,7 @@ class GWSummConfigParser(ConfigParser):
             try:
                 css[key] = self.get(section, '%s-css' % key)
             except NoSectionError:
-                return []
+                return css.values()
             except NoOptionError:
                 continue
         files = css.values()
@@ -367,7 +367,7 @@ class GWSummConfigParser(ConfigParser):
             try:
                 js[key] = self.get(section, '%s-js' % key)
             except NoSectionError:
-                break
+                return js.values()
             except NoOptionError:
                 continue
         files = js.values()

--- a/gwsumm/config.py
+++ b/gwsumm/config.py
@@ -65,10 +65,13 @@ class GWSummConfigParser(ConfigParser):
     # disable colon separator
     OPTCRE = re.compile(
         r'(?P<option>[^=\s][^=]*)\s*(?P<vi>[=])\s*(?P<value>.*)$')
-    # use OrderedDict for dict type
-    _dict = OrderedDict
     # set interpolation match
     _interpvar_re = re.compile(r"%\(([^)]+)\)s")
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('dict_type', OrderedDict)
+        ConfigParser.__init__(self, *args, **kwargs)
+    __init__.__doc__ = ConfigParser.__init__.__doc__
 
     def ndoptions(self, section, **kwargs):
         try:

--- a/gwsumm/tests/test_config.py
+++ b/gwsumm/tests/test_config.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWSumm.
+#
+# GWSumm is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWSumm is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWSumm.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for `gwsumm.data`
+
+"""
+
+import tempfile
+
+from matplotlib import rcParams
+
+from astropy import units
+
+from compat import unittest
+from gwsumm import (state, config, html)
+from gwsumm.channels import get_channel
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+class ConfigTestCase(unittest.TestCase):
+
+    def new(self):
+        return config.GWSummConfigParser()
+
+    def test_init(self):
+        cp = self.new()
+        self.assertIs(cp.optionxform, str)
+        self.assertIs(cp._dict, config.OrderedDict)
+
+    def test_read(self):
+        cp = self.new()
+        self.assertRaises(IOError, cp.read, 'does-not-exist.ini')
+
+    def test_set_date_options(self):
+        cp = self.new()
+        cp.set_date_options(0, 100)
+
+    def test_get_css(self):
+        cp = self.new()
+        css = cp.get_css()
+        self.assertEqual(css, html.get_css().values())
+
+    def test_get_javascript(self):
+        cp = self.new()
+        js = cp.get_javascript()
+        self.assertEqual(js, html.get_js().values())
+
+    def test_load_rcParams(self):
+        cp = self.new()
+        cp.add_section('rcParams')
+        cp.set('rcParams', 'axes.labelsize', '100')
+        cp.load_rcParams()
+        self.assertEqual(rcParams['axes.labelsize'], 100)
+
+    def test_load_states(self):
+        cp = self.new()
+        cp.set_date_options(0, 100)
+        cp.add_section('states')
+        cp.set('states', 'locked', 'X1:TEST-STATE:1')
+        cp.load_states()
+        states = state.get_states()
+        self.assertEqual(len(states), 2)
+        self.assertIn('locked', states)
+        self.assertEqual(states['locked'].definition, 'X1:TEST-STATE:1')
+        self.assertIn(state.ALLSTATE, states)
+
+    def test_finalize(self):
+        cp = self.new()
+        cp.set_date_options(0, 100)
+        cp.finalize()
+
+    def test_load_plugins(self):
+        cp = self.new()
+        cp.add_section('plugins')
+        cp.set('plugins', 'tempfile', '')
+        plugins = cp.load_plugins()
+        self.assertListEqual(plugins, [tempfile])
+
+    def test_load_units(self):
+        cp = self.new()
+        cp.add_section('units')
+        cp.set('units', 'myunit', 'meter')
+        newunits = cp.load_units()
+        self.assertListEqual(newunits, [units.meter])
+
+    def test_load_channels(self):
+        cp = self.new()
+        cp.add_section('X1:TEST-CHANNEL:1')
+        cp.set('X1:TEST-CHANNEL:1', 'frametype', 'X1_TEST')
+        cp.load_channels()
+        c = get_channel('X1:TEST-CHANNEL:1')
+        self.assertEqual(c.frametype, 'X1_TEST')
+        # test with interpolation
+        cp.set(config.DEFAULTSECT, 'ifo', 'X1')
+        cp.add_section('%(ifo)s:TEST-CHANNEL_2:1')
+        cp.set('%(ifo)s:TEST-CHANNEL_2:1', 'resample', '128')
+        cp.interpolate_section_names(ifo='X1')
+        cp.load_channels()
+        c = get_channel('X1:TEST-CHANNEL_2:1')
+        self.assertEqual(c.resample, 128)


### PR DESCRIPTION
This PR fixes two problems in running `gw_summary` and `gw_summary_pipe` without passing a `defaults.ini` file, or at least one without an `[html]` section.