### PR TITLE
Fixed two bugs in `data.spectral`

### DIFF
--- a/gwsumm/data/spectral.py
+++ b/gwsumm/data/spectral.py
@@ -28,6 +28,9 @@ try:
 except ImportError:
     from ordereddict import OrderedDict
 
+# imports for filter
+from math import pi
+
 import numpy
 
 from astropy import units

--- a/gwsumm/data/spectral.py
+++ b/gwsumm/data/spectral.py
@@ -159,7 +159,11 @@ def _get_spectrogram(channel, segments, config=None, cache=None,
                     continue
                 else:
                     d = float(abs(s))
-                    tmp.append(type(s)(s[0], s[0] + d//stride * stride))
+                    e = (s[0] + d // stride * stride +
+                         fftparams.get('overlap', 0))
+                    if e - s[0] > d:
+                        e -= fftparams['fftlength']
+                    tmp.append(type(s)(s[0], e))
             new = tmp
         timeserieslist = get_timeseries(channel, new, config=config,
                                         cache=cache, frametype=frametype,


### PR DESCRIPTION
This PR fixes two bugs in `data.spectral`:

- need to import common `math`/`numpy` stuff for `eval(filter)` calls
- gwpy 0.1 introduced overlapping time strides in spectrogram, meaning the amount of data in each time bin is greater, so we need to account for that in how we truncate the timeseries used to calculate a spectrogram