### PR TITLE
Use recarray for trigger storage

### DIFF
--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -201,11 +201,8 @@ class TimeSeriesDataPlot(DataLabelSvgMixin, DataPlot):
                         linestyle='--', color='red')
 
         # customise plot
-        for key, val in self.pargs.iteritems():
-            try:
-                getattr(ax, 'set_%s' % key)(val)
-            except AttributeError:
-                setattr(ax, key, val)
+        self.apply_parameters(ax, **self.pargs)
+
         if (len(channels) > 1 or plotargs[0].get('label', None) in
                 [re.sub(r'(_|\\_)', r'\_', channels[0]), None]):
             plot.add_legend(ax=ax, **legendargs)
@@ -937,11 +934,7 @@ class SpectralVarianceDataPlot(SpectrumDataPlot):
 
         # customise
         hlines = list(self.pargs.pop('hline', []))
-        for key, val in self.pargs.iteritems():
-            try:
-                getattr(ax, 'set_%s' % key)(val)
-            except AttributeError:
-                setattr(ax, key, val)
+        self.apply_parameters(ax, **self.pargs)
 
         # add horizontal lines to add
         if hlines:

--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -556,6 +556,17 @@ class DataPlot(SummaryPlot):
             self.plot.close()
         return outputfile
 
+    def apply_parameters(self, ax, **pargs):
+        for key in pargs:
+            val = pargs[key]
+            if key in ['xlim', 'ylim'] and isinstance(val, str):
+                val = eval(val)
+            try:
+                getattr(ax, 'set_%s' % key)(val)
+            except AttributeError:
+                setattr(ax, key, val)
+
+
 register_plot(DataPlot)
 
 

--- a/gwsumm/plot/triggers.py
+++ b/gwsumm/plot/triggers.py
@@ -76,7 +76,7 @@ class TriggerPlotMixin(object):
         return ChannelList(map(Channel, chans))
 
 
-class TriggerDataPlot(TriggerPlotMixin, TimeSeriesDataPlot):
+class TriggerDataPlot(TimeSeriesDataPlot):
     """Standard event trigger plot
     """
     _threadsafe = False
@@ -370,7 +370,7 @@ class TriggerTimeSeriesDataPlot(TimeSeriesDataPlot):
 register_plot(TriggerTimeSeriesDataPlot)
 
 
-class TriggerHistogramPlot(TriggerPlotMixin, get_plot('histogram')):
+class TriggerHistogramPlot(get_plot('histogram')):
     """HistogramPlot from a LIGO_LW Table
     """
     type = 'trigger-histogram'

--- a/gwsumm/plot/triggers.py
+++ b/gwsumm/plot/triggers.py
@@ -243,11 +243,7 @@ class TriggerDataPlot(TriggerPlotMixin, TimeSeriesDataPlot):
         legendargs = self.parse_legend_kwargs(markerscale=4)
         logx = self.pargs.pop('logx', self.pargs.pop('xscale', None) == 'log')
         logy = self.pargs.pop('logy', self.pargs.pop('yscale', None) == 'log')
-        for key, val in self.pargs.iteritems():
-            try:
-                getattr(ax, 'set_%s' % key)(val)
-            except AttributeError:
-                setattr(ax, key, val)
+        self.apply_parameters(ax, **self.pargs)
         if logx:
             if ax.get_xlim()[0] <= 0 and not ntrigs:
                 ax.set_xlim(1, 10)
@@ -480,11 +476,7 @@ class TriggerHistogramPlot(TriggerPlotMixin, get_plot('histogram')):
             ax.autoscale_view(tight=True, scalex=False)
 
         # customise plot
-        for key, val in self.pargs.iteritems():
-            try:
-                getattr(ax, 'set_%s' % key)(val)
-            except AttributeError:
-                setattr(ax, key, val)
+        self.apply_parameters(ax, **self.pargs)
         if len(self.channels) > 1:
             plot.add_legend(ax=ax, **legendargs)
 

--- a/gwsumm/plot/triggers.py
+++ b/gwsumm/plot/triggers.py
@@ -148,7 +148,8 @@ class TriggerDataPlot(TimeSeriesDataPlot):
             base = SpectrumPlot
         else:
             base = Plot
-        plot = self.plot = EventTablePlot(figsize=[12, 6], base=base)
+        plot = self.plot = EventTablePlot(
+            figsize=self.pargs.pop('figsize', [12, 6]), base=base)
         ax = plot.gca()
         ax.grid(True, which='both')
         if isinstance(plot, TimeSeriesPlot):
@@ -243,6 +244,9 @@ class TriggerDataPlot(TimeSeriesDataPlot):
         legendargs = self.parse_legend_kwargs(markerscale=4)
         logx = self.pargs.pop('logx', self.pargs.pop('xscale', None) == 'log')
         logy = self.pargs.pop('logy', self.pargs.pop('yscale', None) == 'log')
+        if len(self.channels) == 1:
+            self.pargs.setdefault(
+                'title', '%s (%s)' % (self.channels[0].texname, self.etg))
         self.apply_parameters(ax, **self.pargs)
         if logx:
             if ax.get_xlim()[0] <= 0 and not ntrigs:
@@ -252,8 +256,6 @@ class TriggerDataPlot(TimeSeriesDataPlot):
             if ax.get_ylim()[0] <= 0 and not ntrigs:
                 ax.set_ylim(1, 10)
             ax.set_yscale('log')
-        if 'title' not in self.pargs.keys() and len(self.channels) == 1:
-            plot.title = '%s (%s)' % (self.channels[0].texname, self.etg)
 
         # correct log-scale empty axes
         if any(map(isinf, ax.get_ylim())):

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -530,7 +530,8 @@ class DataTab(DataTabBase):
                                               'trigger-histogram',
                                               all_data=all_data, state=state):
             get_triggers(channel, etg, state.active, config=config,
-                         cache=trigcache)
+                         cache=trigcache, multiprocess=multiprocess,
+                         return_=False)
 
         # --------------------------------------------------------------------
         # make plots

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -528,7 +528,7 @@ class DataTab(DataTabBase):
                                               'trigger-timeseries',
                                               'trigger-rate',
                                               'trigger-histogram',
-                                              all_data=all_data):
+                                              all_data=all_data, state=state):
             get_triggers(channel, etg, state.active, config=config,
                          cache=trigcache)
 

--- a/gwsumm/tests/test_config.py
+++ b/gwsumm/tests/test_config.py
@@ -101,16 +101,16 @@ class ConfigTestCase(unittest.TestCase):
 
     def test_load_channels(self):
         cp = self.new()
-        cp.add_section('X1:TEST-CHANNEL:1')
-        cp.set('X1:TEST-CHANNEL:1', 'frametype', 'X1_TEST')
+        cp.add_section('X1:TEST-CHANNEL')
+        cp.set('X1:TEST-CHANNEL', 'frametype', 'X1_TEST')
         cp.load_channels()
-        c = get_channel('X1:TEST-CHANNEL:1')
+        c = get_channel('X1:TEST-CHANNEL')
         self.assertEqual(c.frametype, 'X1_TEST')
         # test with interpolation
         cp.set(config.DEFAULTSECT, 'ifo', 'X1')
-        cp.add_section('%(ifo)s:TEST-CHANNEL_2:1')
-        cp.set('%(ifo)s:TEST-CHANNEL_2:1', 'resample', '128')
+        cp.add_section('%(ifo)s:TEST-CHANNEL_2')
+        cp.set('%(ifo)s:TEST-CHANNEL_2', 'resample', '128')
         cp.interpolate_section_names(ifo='X1')
         cp.load_channels()
-        c = get_channel('X1:TEST-CHANNEL_2:1')
+        c = get_channel('X1:TEST-CHANNEL_2')
         self.assertEqual(c.resample, 128)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ lxml
 https://github.com/ligovirgo/trigfind/archive/v0.3.tar.gz
 http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz
 http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz
-gwpy
+git+https://github.com/gwpy/gwpy
 libsass
 jsmin

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ m2crypto
 python-cjson
 h5py
 lxml
-https://github.com/ligovirgo/trigfind/archive/v0.3.tar.gz
+https://github.com/ligovirgo/trigfind/archive/v0.4.tar.gz
 http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz
 http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz
 git+https://github.com/gwpy/gwpy


### PR DESCRIPTION
This PR modifies the `gwsumm.triggers` module and all callers to use the `GWRecArray` object as the internal storage for triggers, rather than a `LIGO_LW` table (`glue.ligolw.table.Table`).