### PR TITLE
Added trigger archiving

### DIFF
--- a/gwsumm/archive.py
+++ b/gwsumm/archive.py
@@ -254,9 +254,12 @@ def find_daily_archives(start, end, ifo, tag, basedir=os.curdir):
 def archive_recarray(table, key, parent, compression='gzip'):
     """Add a recarray to the given HDF5 group
     """
-    group = parent.create_group(key)
     # write segments with an offset to preserve precision
-    epoch = int(table.segments[0][0])
+    try:
+        epoch = int(table.segments[0][0])
+    except IndexError:  # no segments read
+        return
+    group = parent.create_group(key)
     segs = [(s[0] - epoch, s[1] - epoch) for s in table.segments]
     dset = group.create_dataset('segments', data=array(segs, dtype=float),
                                 compression=compression)

--- a/gwsumm/archive.py
+++ b/gwsumm/archive.py
@@ -26,14 +26,17 @@ import re
 import datetime
 import os.path
 
-from gwpy.time import (from_gps, to_gps)
+from numpy import (rec, array)
+
+from gwpy.time import (from_gps, to_gps, LIGOTimeGPS)
 from gwpy.timeseries import (StateVector, TimeSeries)
 from gwpy.spectrogram import Spectrogram
-from gwpy.segments import DataQualityFlag
+from gwpy.segments import (SegmentList, Segment, DataQualityFlag)
 
 from . import (globalv, mode)
 from .data import (get_channel, add_timeseries, add_spectrogram,
                    add_coherence_component_spectrogram)
+from .triggers import (GWRecArray, add_triggers)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -41,7 +44,7 @@ re_rate = re.compile('_EVENT_RATE_')
 
 
 def write_data_archive(outfile, timeseries=True, spectrogram=True,
-                       segments=True):
+                       segments=True, triggers=True):
     """Build and save an HDF archive of data processed in this job.
 
     Parameters
@@ -117,6 +120,13 @@ def write_data_archive(outfile, timeseries=True, spectrogram=True,
                 # loop over channels
                 for name, dqflag in globalv.SEGMENTS.iteritems():
                     dqflag.write(group, name=name, format='hdf')
+
+            # record all triggers
+            if triggers:
+                group = h5file.create_group('triggers')
+                for key in globalv.TRIGGERS:
+                    archive_recarray(globalv.TRIGGERS[key], key, group)
+
     except:
         if backup:
             restore_backup(backup, outfile)
@@ -193,6 +203,13 @@ def read_data_archive(sourcefile):
             dqflag = DataQualityFlag.read(dataset, format='hdf')
             globalv.SEGMENTS += {name: dqflag}
 
+        # read all triggers
+        try:
+            group = h5file['triggers']
+        except KeyError:
+            group = dict()
+        for key in group:
+            load_recarray(group[key])
 
 def backup_existing_archive(filename, suffix='.hdf',
                             prefix='gw_summary_archive_', dir=None):
@@ -230,3 +247,38 @@ def find_daily_archives(start, end, ifo, tag, basedir=os.curdir):
         if os.path.isfile(arch):
             archives.append(arch)
     return archives
+
+
+# -- utility methods --------------------------------------------------------
+
+def archive_recarray(table, key, parent, compression='gzip'):
+    """Add a recarray to the given HDF5 group
+    """
+    group = parent.create_group(key)
+    # write segments with an offset to preserve precision
+    epoch = int(table.segments[0][0])
+    segs = [(s[0] - epoch, s[1] - epoch) for s in table.segments]
+    dset = group.create_dataset('segments', data=array(segs, dtype=float),
+                                compression=compression)
+    dset.attrs['epoch'] = epoch
+    # write each column
+    for col in table.dtype.fields:
+        group.create_dataset(col, data=table[col], compression=compression)
+    return key
+
+
+def load_recarray(group):
+    """Read recarray from the given HDF5 group
+    """
+    columns = map(str, list(group))
+    # read segments
+    epoch = LIGOTimeGPS(group['segments'].attrs['epoch'])
+    segments = SegmentList(Segment(epoch + x[0], epoch + x[1]) for
+                           x in group['segments'][:])
+    columns.pop(columns.index('segments'))
+    # read columns
+    data = [group[c] for c in columns]
+    # format and add
+    table = rec.fromarrays(data, names=columns).view(GWRecArray)
+    add_triggers(table, group.name.split('/')[-1], segments=segments)
+    return table

--- a/gwsumm/tests/common.py
+++ b/gwsumm/tests/common.py
@@ -20,8 +20,25 @@
 """
 
 import sys
+from functools import wraps
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
     import unittest
+
+from gwsumm import globalv
+
+
+# -- test decorators ----------------------------------------------------------
+
+def empty_globalv_CHANNELS(f):
+    @wraps(f)
+    def wrapped_f(*args, **kwargs):
+        _channels = globalv.CHANNELS
+        globalv.CHANNELS = type(globalv.CHANNELS)()
+        try:
+            return f(*args, **kwargs)
+        finally:
+            globalv.CHANNELS = _channels
+    return wrapped_f

--- a/gwsumm/tests/test_archive.py
+++ b/gwsumm/tests/test_archive.py
@@ -29,7 +29,7 @@ from numpy import testing as nptest
 
 from gwpy.timeseries import TimeSeries
 
-from compat import unittest
+from common import unittest
 from gwsumm import (archive, data, globalv, channels)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'

--- a/gwsumm/tests/test_channels.py
+++ b/gwsumm/tests/test_channels.py
@@ -20,7 +20,7 @@
 
 """
 
-from compat import unittest
+from common import (unittest, empty_globalv_CHANNELS)
 from gwsumm import (globalv, channels)
 from gwsumm.mode import set_mode
 
@@ -31,17 +31,6 @@ TREND_NAME = 'H1:TEST-TREND_CHANNEL.rms,m-trend'
 TREND_NAME2 = 'H1:TEST-TREND_CHANNEL.mean,m-trend'
 TREND_NAME3 = 'H1:TEST-TREND_CHANNEL_3.mean'
 TREND_NAME4 = 'H1:TEST-TREND_CHANNEL_4.mean'
-
-
-def empty_globalv_CHANNELS(f):
-    def wrapped_f(*args, **kwargs):
-        _channels = globalv.CHANNELS
-        globalv.CHANNELS = type(globalv.CHANNELS)()
-        try:
-            return f(*args, **kwargs)
-        finally:
-            globalv.CHANNELS = _channels
-    return wrapped_f
 
 
 class ChannelTests(unittest.TestCase):

--- a/gwsumm/tests/test_config.py
+++ b/gwsumm/tests/test_config.py
@@ -26,7 +26,7 @@ from matplotlib import rcParams
 
 from astropy import units
 
-from compat import unittest
+from common import unittest
 from gwsumm import (state, config, html)
 from gwsumm.channels import get_channel
 

--- a/gwsumm/tests/test_data.py
+++ b/gwsumm/tests/test_data.py
@@ -36,7 +36,7 @@ from gwpy.timeseries import TimeSeries
 from gwpy.detector import Channel
 from gwpy.segments import (Segment, SegmentList)
 
-from compat import unittest
+from common import (unittest, empty_globalv_CHANNELS)
 from gwsumm import (data, globalv)
 from gwsumm.data import (utils, mathutils)
 
@@ -169,6 +169,7 @@ class DataTests(unittest.TestCase):
         b = data.get_timeseries('H1:LOSC-STRAIN', LOSC_SEGMENTS)
         self.assertEqual(a, b)
 
+    @empty_globalv_CHANNELS
     def test_get_spectrogram(self):
         self.assertRaises(TypeError, data.get_spectrogram, 'H1:LOSC-STRAIN',
                           LOSC_SEGMENTS, cache=self.FRAMES['H1:LOSC-STRAIN'])

--- a/gwsumm/tests/test_data.py
+++ b/gwsumm/tests/test_data.py
@@ -105,6 +105,7 @@ class DataTests(unittest.TestCase):
         self.assertEqual(data.get_channel_type('H1:GDS-CALIB_STRAIN'), 'proc')
         self.assertEqual(data.get_channel_type('V1:GDS-CALIB_STRAIN'), 'adc')
 
+    @empty_globalv_CHANNELS
     def test_make_globalv_key(self):
         fftparams = utils.get_fftparams('L1:TEST-CHANNEL',
             stride=123.456, window='test-window', method='test-method')

--- a/gwsumm/tests/test_mode.py
+++ b/gwsumm/tests/test_mode.py
@@ -23,7 +23,7 @@
 import sys
 import datetime
 
-from compat import unittest
+from common import unittest
 from gwsumm import (globalv, mode)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'

--- a/gwsumm/tests/test_plot.py
+++ b/gwsumm/tests/test_plot.py
@@ -23,7 +23,7 @@
 from matplotlib import use
 use('agg')
 
-from compat import unittest
+from common import unittest
 from gwsumm import plot
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'

--- a/gwsumm/tests/test_tabs.py
+++ b/gwsumm/tests/test_tabs.py
@@ -29,7 +29,7 @@ from gwpy.detector import Channel
 from gwsumm import tabs
 from gwsumm.plot import SummaryPlot
 
-from compat import unittest
+from common import unittest
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 

--- a/gwsumm/triggers.py
+++ b/gwsumm/triggers.py
@@ -240,16 +240,15 @@ def get_triggers(channel, etg, segments, config=GWSummConfigParser(),
                     kwargs.setdefault('format', 'omega')
                 else:
                     kwargs.setdefault('format', 'ligolw')
-            elif isinstance(cache, Cache):
-                segcache = cache.sieve(segment=segment)
             else:
                 segcache = cache
             if isinstance(segcache, Cache):
+                segcache = segcache.sieve(segment=segment)
                 segcache = segcache.checkfilesexist()[0]
                 segcache.sort(key=lambda x: x.segment[0])
                 if etg == 'pycbc_live':  # remove empty HDF5 files
-                    segcache = filter_pycbc_live_files(segcache,
-                                                       ifo=kwargs['ifo'])
+                    segcache = type(segcache)(
+                        filter_pycbc_live_files(segcache, ifo=kwargs['ifo']))
             # if no files, skip
             if len(segcache) == 0:
                 continue

--- a/gwsumm/triggers.py
+++ b/gwsumm/triggers.py
@@ -308,7 +308,8 @@ def add_triggers(table, key, segments=None):
     else:
         segs = old.segments
         globalv.TRIGGERS[key] = recfunctions.stack_arrays(
-            (old, table), asrecarray=True, usemask=False).view(type(table))
+            (old, table), asrecarray=True, usemask=False,
+            autoconvert=True).view(type(table))
         globalv.TRIGGERS[key].segments = segs + segments
     globalv.TRIGGERS[key].segments.coalesce()
 

--- a/gwsumm/triggers.py
+++ b/gwsumm/triggers.py
@@ -273,9 +273,9 @@ def get_triggers(channel, etg, segments, config=GWSummConfigParser(),
             except AttributeError:
                 csegs = SegmentList()
             table.segments = csegs
-            add_triggers(keep_in_segments(table, SegmentList([segment]), etg),
-                         key, csegs)
-            ntrigs += len(table)
+            t2 = keep_in_segments(table, SegmentList([segment]), etg)
+            add_triggers(t2, key, csegs)
+            ntrigs += len(t2)
             vprint(".")
         vprint(" | %d events read\n" % ntrigs)
 


### PR DESCRIPTION
This PR introduces trigger archiving when using the `--archive` command-line option. Previously this was a pain because of the LIGO_LW table formatting, but with `GWRecArray` things are a bit easier.

Each column is stored as its own dataset, with the `segments` attribute as another dataset, with a fixed GPS offset to preserve nanosecond precision.