### PR TITLE
New functionality and syntax for undoing demodulation

### DIFF
--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -622,7 +622,8 @@ class Tab(object):
                     groups[group] = zip(*sorted(
                         zip(groups[group], names),
                         key=lambda (t, n): n.lower() in ['summary', 'overview']
-                                           and n.upper() or n.lower()))[0]
+                                           and ' %s' % n.upper() or
+                                           n.lower()))[0]
                     # build link sets
                     links.append((group.strip('_'), []))
                     for i, child in enumerate(groups[group]):


### PR DESCRIPTION
This PR introduces a new syntax and functionality to undo demodulation, by fudging the frequency index back to the original pre-demodulation values. The user can give the demodulation frequency in the `[channel]` configuration:

```ini
[channel]
demodulation = 1028
```

Additionally, if the desired frequency-range on the plot is below the demodulation frequency, it is assumed that the information at those frequencies have been mapped into 'negative' frequencies in the new demodulated channel, so the appropriate conversions are done to reverse the frequencies so the data are in the right order.

This is originally to support the displaying the demodulated channels used for studying parametric instability in LIGO.