### PR TITLE
Fix bugs in handling of Rayleigh method selection

### DIFF
--- a/gwsumm/data/spectral.py
+++ b/gwsumm/data/spectral.py
@@ -96,12 +96,9 @@ def _get_spectrogram(channel, segments, config=None, cache=None,
 
     channel = get_channel(channel)
 
-    # special-case methods
-    if fftparams.get('method', None) is None and format in ['rayleigh']:
-        fftparams['method'] = format
-    # or, if we aren't given a method, check to see whether data have already
+    # if we aren't given a method, check to see whether data have already
     # been processed, if so, choose that one
-    elif fftparams.get('method', None) is None:
+    if fftparams.get('method', None) is None:
         methods = set([key.split(';')[1] for key in globalv.SPECTROGRAMS
                        if key.startswith('%s;' % channel.ndsname)])
         try:
@@ -111,6 +108,9 @@ def _get_spectrogram(channel, segments, config=None, cache=None,
 
     # clean fftparams dict using channel default values
     fftparams = get_fftparams(channel, **fftparams)
+    # override special-case methods
+    if format in ['rayleigh']:
+        fftparams.method = format
 
     # key used to store the coherence spectrogram in globalv
     key = make_globalv_key(channel, fftparams)
@@ -158,7 +158,8 @@ def _get_spectrogram(channel, segments, config=None, cache=None,
                                         datafind_error=datafind_error, nds=nds)
         # calculate spectrograms
         if len(timeserieslist):
-            vprint("    Calculating spectrograms for %s" % str(channel))
+            vprint("    Calculating (%s) spectrograms for %s"
+                   % (fftparams['method'], str(channel)))
         for ts in timeserieslist:
             # if too short for a single segment, continue
             if abs(ts.span) < (stride + fftparams.get('overlap', 0)):

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -473,7 +473,7 @@ class DataTab(DataTabBase):
                              **fftparams)
         if len(raychannels):
             fp2 = fftparams.copy()
-            fp2['method'] = 'rayleigh'
+            fp2['method'] = fp2['format'] = 'rayleigh'
             get_spectrograms(raychannels, state, config=config, return_=False,
                              multiprocess=multiprocess, **fp2)
 
@@ -501,6 +501,8 @@ class DataTab(DataTabBase):
 
         for channel in self.get_channels(
                 'rayleigh-spectrum', all_data=all_data, read=True):
+            fp2 = fftparams.copy()
+            fp2['method'] = fp2['format'] = 'rayleigh'
             get_spectrum(channel, state, config=config, return_=False, **fp2)
 
         # --------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes a problem in selecting the 'rayleigh' spectrum, where that selection would get wiped out if the channel had already been calculated via a median-mean spectrum (or otherwise).