### PR TITLE
Added imports for use in safe_eval

### DIFF
--- a/gwsumm/utils.py
+++ b/gwsumm/utils.py
@@ -25,6 +25,10 @@ import re
 from multiprocessing import (cpu_count, active_children)
 from socket import getfqdn
 
+# import filter evals
+from math import pi
+import numpy
+
 from . import globalv
 
 re_cchar = re.compile("[\W_]+")


### PR DESCRIPTION
This PR fixes a shortcoming of the `safe_eval` function, which needs to have module-level access to `numpy` and `pi` so that users can use those in their expressions.