### PR TITLE
Removed references to GWpy's deprecated Spectrum

### DIFF
--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -34,10 +34,7 @@ import numpy
 from astropy import units
 
 from gwpy.segments import (DataQualityFlag, SegmentList, Segment)
-try:
-    from gwpy.frequencyseries import FrequencySeries
-except ImportError:
-    from gwpy.spectrum import Spectrum as FrequencySeries
+from gwpy.frequencyseries import FrequencySeries
 from gwpy.spectrogram import SpectrogramList
 
 from .. import globalv

--- a/gwsumm/data/spectral.py
+++ b/gwsumm/data/spectral.py
@@ -36,10 +36,7 @@ import numpy
 from astropy import units
 
 from gwpy.segments import (DataQualityFlag, SegmentList)
-try:
-    from gwpy.frequencyseries import FrequencySeries
-except ImportError:
-    from gwpy.spectrum import Spectrum as FrequencySeries
+from gwpy.frequencyseries import FrequencySeries
 from gwpy.spectrogram import SpectrogramList
 
 from .. import globalv

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -31,10 +31,7 @@ from matplotlib.pyplot import subplots
 
 from astropy.units import Quantity
 
-try:
-    from gwpy.frequencyseries import FrequencySeries
-except ImportError:
-    from gwpy.spectrum import Spectrum as FrequencySeries
+from gwpy.frequencyseries import FrequencySeries
 from gwpy.plotter import *
 from gwpy.plotter.tex import label_to_latex
 

--- a/gwsumm/plot/triggers.py
+++ b/gwsumm/plot/triggers.py
@@ -144,7 +144,7 @@ class TriggerDataPlot(TimeSeriesDataPlot):
         if 'time' in xcolumn:
             base = TimeSeriesPlot
         elif 'freq' in xcolumn:
-            base = SpectrumPlot
+            base = FrequencySeriesPlot
         else:
             base = Plot
         plot = self.plot = EventTablePlot(


### PR DESCRIPTION
This PR removes all remaining references to the deprecated (now removed) `gwpy.spectrum.Spectrum` object.