### PR TITLE
Fixed ValueErrors in handling trend channels

### DIFF
--- a/gwsumm/archive.py
+++ b/gwsumm/archive.py
@@ -160,7 +160,7 @@ def read_data_archive(sourcefile):
             try:
                 add_timeseries(ts, key=ts.channel.ndsname)
             except ValueError:
-                if mode.get_mode() == mode.SUMMARY_MODE_DAY:
+                if mode.get_mode() != mode.SUMMARY_MODE_DAY:
                     raise
                 warnings.warn('Caught ValueError in combining daily archives')
                 # get end time

--- a/gwsumm/channels.py
+++ b/gwsumm/channels.py
@@ -112,10 +112,8 @@ def get_channel(channel, find_trend_source=True, timeout=5):
         found = globalv.CHANNELS.sieve(name=name, type=type_, exact_match=True)
     else:
         type_ = isinstance(channel, Channel) and channel.type or None
-        sr = isinstance(channel, Channel) and channel.sample_rate or None
         name = str(channel)
-        found = globalv.CHANNELS.sieve(name=name, type=type_,
-                                       sample_rate=sr, exact_match=True)
+        found = globalv.CHANNELS.sieve(name=name, type=type_, exact_match=True)
     if len(found) == 1:
         return found[0]
     elif len(found) > 1:
@@ -227,12 +225,12 @@ def update_missing_channel_params(channel, **kwargs):
 
     Parameters
     ----------
-    channel : `str`, `~gwpy.detector.Channel`
+    channel : `~gwpy.detector.Channel`
         channel to update
     **kwargs
         `(key, value)` pairs to set
     """
-    target = get_channel(str(channel))
+    target = get_channel(channel)
     for param in ['unit', 'sample_rate', 'frametype']:
         if getattr(target, param) is None:
             setattr(target, param, getattr(channel, param))

--- a/gwsumm/data/timeseries.py
+++ b/gwsumm/data/timeseries.py
@@ -661,6 +661,13 @@ def _get_timeseries_dict(channels, segments, config=None,
                 # XXX: HACK for failing unit check
                 if len(globalv.DATA[key]):
                     data._unit = globalv.DATA[key][-1].unit
+                # update channel type for trends
+                if (data.channel.type is None and
+                       data.channel.trend is not None):
+                    if data.dt.to('s').value == 1:
+                        data.channel.type = 's-trend'
+                    elif data.dt.to('s').value == 60:
+                        data.channel.type = 'm-trend'
                 # append and coalesce
                 add_timeseries(data, key=key, coalesce=True)
             if multiprocess:

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -184,7 +184,7 @@ class TimeSeriesDataPlot(DataLabelSvgMixin, DataPlot):
 
             # allow channel data to set parameters
             if len(flatdata):
-                chan = get_channel(str(flatdata[0].channel))
+                chan = get_channel(flatdata[0].channel)
             else:
                 chan = get_channel(clist[0])
             if getattr(chan, 'amplitude_range', None) is not None:


### PR DESCRIPTION
This PR works around occurences of `ValueError` when switching between second- and minute-trend versions of the same channel (in a non-hacky way).