### PR TITLE
Added functionality to read captions from config files

### DIFF
--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -69,11 +69,12 @@ class SummaryPlot(object):
     type = None
     _threadsafe = True
 
-    def __init__(self, href=None, src=None, new=True):
+    def __init__(self, href=None, src=None, new=True, caption=''):
         self.href = href
         if src:
             self.src = src
         self.new = new
+        self.caption = caption
 
     @property
     def href(self):
@@ -113,6 +114,16 @@ class SummaryPlot(object):
     @src.setter
     def src(self, url):
         self._src = url
+
+    @property
+    def caption(self):
+        """HTML <fancybox plot> title attribute for this `SummaryPlot`.
+        """
+        return self._caption
+
+    @caption.setter
+    def caption(self,text):
+        self._caption = text
 
     # ------------------------------------------------------------------------
     # TabSummaryPlot methods

--- a/gwsumm/tabs/builtin.py
+++ b/gwsumm/tabs/builtin.py
@@ -386,7 +386,7 @@ class PlotTab(Tab):
                 plot.new = False  # this plot does not need to be generated
                 # get caption
                 try:
-                    plot.caption = cp.get(section, '%d-caption' % idx)
+                    plot.caption = re_quote.sub('', cp.get(section, '%d-caption' % idx))
                 except NoOptionError:
                     pass
                 kwargs['plots'].append(plot)


### PR DESCRIPTION
Adds functionality to add captions to figures in PlotTab class pages. 

Each plot is contained in a `SummaryPlot` class object, which contains the URL to the image and writes the `fancybox plot` class HTML. The caption tag needs to be passed to this same line of HTML, so I wrote it to be an instance variable of the `SummaryPlot` class. 

After the PlotTab class parses the config file for images, I added a block of code to make a list of captions that mirrors the ordering of the list of plots. If a plot doesn't have a caption, an entry of `caption = ''` is generated to keep the lists the same size with correct ordering. The lists `plots` and `captions` are both stored in the kwargs dictionary used to initialize the PlotTab. 

When each plot contained in the PlotTab is initialized in the `add_plot` method, they are cast into a SummaryPlot object, which now accepts a caption argument and defaults to `caption = ''` if none is provided.

If everything here seems okay, I'll move on to the DataTab which also uses the `SummaryPlot` class and `scaffold_plots` function to place images in the HTML and update the PR.