### PR TITLE
Simplify custom labelsize in StateVector plotting

### DIFF
--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -358,8 +358,7 @@ class StateVectorDataPlot(TimeSeriesDataPlot):
 
     def draw(self):
         # make font size smaller
-        _labelsize = rcParams['ytick.labelsize']
-        labelsize = self.pargs.pop('labelsize', 12)
+        labelsize = self.rcParams.get('ytick.labelsize', 12)
         if self.pargs.get('insetlabels', True) is False:
             rcParams['ytick.labelsize'] = labelsize
 
@@ -440,8 +439,6 @@ class StateVectorDataPlot(TimeSeriesDataPlot):
         if self.state and self.state.name != ALLSTATE:
             self.add_state_segments(ax)
 
-        # reset tick size and return
-        rcParams['ytick.labelsize'] = _labelsize
         return self.finalize()
 
 register_plot(StateVectorDataPlot)


### PR DESCRIPTION
Since #74 each plot is `draw()`n in an rcParams context, meaning any changes made inside that method are not kept once the function closes. This PR simplifies the customisation of the `labelsize` for the `StateVectorDataPlot` to take advantage of this.