### PR TITLE
Added tabs that link to external URLs

### DIFF
--- a/bin/gw_summary
+++ b/bin/gw_summary
@@ -680,7 +680,7 @@ for tab in tablist:
                     multiprocess=opts.multiprocess,
                     segdb_error=opts.on_segdb_error,
                     datafind_error=opts.on_datafind_error, **cache)
-    if not tab.hidden and not isinstance(tab, get_tab('archived-link')):
+    if not tab.hidden and not isinstance(tab, get_tab('link')):
         mkdir(tab.href)
         page = tab.write_html(css=css, js=javascript, tabs=tabs, ifo=ifo,
                               ifomap=ifobases, about=about.index, base=base,

--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -69,11 +69,12 @@ class SummaryPlot(object):
     type = None
     _threadsafe = True
 
-    def __init__(self, href=None, src=None, new=True):
+    def __init__(self, href=None, src=None, new=True, caption=''):
         self.href = href
         if src:
             self.src = src
         self.new = new
+        self.caption = caption
 
     @property
     def href(self):
@@ -113,6 +114,16 @@ class SummaryPlot(object):
     @src.setter
     def src(self, url):
         self._src = url
+
+    @property
+    def caption(self):
+        """HTML <fancybox plot> title attribute for this `SummaryPlot`.
+        """
+        return self._caption
+
+    @caption.setter
+    def caption(self,text):
+        self._caption = text
 
     # ------------------------------------------------------------------------
     # TabSummaryPlot methods

--- a/gwsumm/tabs/builtin.py
+++ b/gwsumm/tabs/builtin.py
@@ -799,30 +799,6 @@ class StateTab(PlotTab):
             about=about, footer=footer, **inargs)
 
 register_tab(StateTab)
-<<<<<<< HEAD
-
-
-class ArchivedStateTab(SummaryArchiveMixin, StateTab):
-    """An archivable tab with data in multiple states
-    """
-    type = 'archived-state'
-
-    def __init__(self, name, start, end, mode=None, states=list(), **kwargs):
-        super(ArchivedStateTab, self).__init__(name, states=states, **kwargs)
-        self.span = (start, end)
-        self.mode = mode
-
-    @classmethod
-    def from_ini(cls, config, section, start=None, end=None, **kwargs):
-        config = GWSummConfigParser.from_configparser(config)
-        if start is None:
-            start = config.getint(section, 'gps-start-time')
-        if end is None:
-            end = config.getint(section, 'gps-end-time')
-        return super(ArchivedStateTab, cls).from_ini(config, section, start,
-                                                     end, **kwargs)
-
-register_tab(ArchivedStateTab)
 
 class UrlTab(Tab):
     type = 'link'
@@ -848,65 +824,3 @@ class UrlTab(Tab):
 
 register_tab(UrlTab)
 
-class AboutTab(SummaryArchiveMixin, Tab):
-    type = 'about'
-
-    def __init__(self, start, end, name='About', mode=None, **kwargs):
-        super(AboutTab, self).__init__(name, **kwargs)
-        self.span = (start, end)
-        self.mode = mode
-
-    def write_html(self, config=list(), **kwargs):
-        return super(AboutTab, self).write_html(
-            html.about_this_page(config=config), **kwargs)
-
-register_tab(AboutTab)
-
-
-class Error404Tab(SummaryArchiveMixin, Tab):
-    type = '404'
-
-    def __init__(self, start, end, name='404', mode=None, **kwargs):
-        super(Error404Tab, self).__init__(name, **kwargs)
-        self.span = (start, end)
-        self.mode = mode
-
-    def write_html(self, config=list(), top=None, **kwargs):
-        if top is None:
-            top = kwargs.get('base', self.path)
-        kwargs.setdefault('title', '404: Page not found')
-        page = html.markup.page()
-        page.div(class_='alert alert-danger')
-        page.p()
-        page.strong("The page you are looking for doesn't exist")
-        page.p.close()
-        page.p("This could be because the times for which you are looking "
-               "were never processed (or haven't even happened yet), or "
-               "because no page exists for the specific data products you "
-               "want. Either way, if you think this is in error, please "
-               "contact <a class=\"alert-link\" "
-               "href=\"mailto:detchar+code@ligo.org\">the DetChar group</a>.")
-        page.p("Otherwise, you might be interested in one of the following:")
-        page.div(style="padding-top: 10px;")
-        page.a("Take me back", role="button", class_="btn btn-lg btn-info",
-               title="Back", href="javascript:history.back()")
-        page.a("Take me up one level", role="button",
-               class_="btn btn-lg btn-warning", title="Up",
-               href="javascript:linkUp()")
-        page.a("Take me to the top level", role="button",
-               class_="btn btn-lg btn-success", title="Top", href=top)
-        page.div.close()
-        page.div.close()
-        page.script("""
-  function linkUp() {
-    var url = window.location.href;
-    if (url.substr(-1) == '/') url = url.substr(0, url.length - 2);
-    url = url.split('/');
-    url.pop();
-    window.location = url.join('/');
-  }""", type="text/javascript")
-        return super(Error404Tab, self).write_html(page, **kwargs)
-
-register_tab(Error404Tab)
-=======
->>>>>>> 3f89f01565ff14f93d3b783d0795a1891bf688f0

--- a/gwsumm/tabs/builtin.py
+++ b/gwsumm/tabs/builtin.py
@@ -873,23 +873,13 @@ class UrlTab(Tab):
 
     @classmethod
     def from_ini(cls, cp, section, *args, **kwargs):
-        kwargs.setdefault('url',cp.get(section,'url'))
+        kwargs.setdefault('url', cp.get(section,'url'))
         return super(UrlTab, cls).from_ini(cp, section, *args, **kwargs)
 
     def write_html(self, **kwargs):
         return
 
 register_tab(UrlTab)
-
-class ArchivedUrlTab(SummaryArchiveMixin, UrlTab):
-    type = 'archived-link'
-
-    def __init__(self, name, start, end, mode=None, **kwargs):
-        super(ArchivedUrlTab, self).__init__(name, **kwargs)
-        self.span = (start, end)
-        self.mode = mode
-
-register_tab(ArchivedUrlTab)
 
 class AboutTab(SummaryArchiveMixin, Tab):
     type = 'about'


### PR DESCRIPTION
Added a new tab class that is a direct link to a specified URL using the `tab.href` property of the tab. One line in `gw_summary` was modified that tells the tablist processor to skip link tabs when it makes directories and writes HTML. It can be done without using the ArchivedUrlTab class by setting `type = 'archived-link'`, but that seemed a little hacky.

Config file example:
```
[tab-gwpy]
type = link
name = GWpy
url = https://github.com/gwpy
```

Output example:
`https://ldas-jobs.ligo.caltech.edu/~thomas.massinger/summary/test_buttons3/day/20151226/instrument_status/`

Fixes #105 