### PR TITLE
Fixed handling of weights in trigger histogram

### DIFF
--- a/gwsumm/archive.py
+++ b/gwsumm/archive.py
@@ -277,7 +277,7 @@ def load_recarray(group):
     # read segments
     try:
         epoch = LIGOTimeGPS(group['segments'].attrs['epoch'])
-    except TypeError:
+    except (ValueError, TypeError):
         epoch = LIGOTimeGPS(float(group['segments'].attrs['epoch']))
     segments = SegmentList(Segment(epoch + x[0], epoch + x[1]) for
                            x in group['segments'][:])

--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -375,7 +375,12 @@ class DataPlot(SummaryPlot):
                     val = self.pargs.pop('%ss' % kwarg)
                 except KeyError:
                     val = None
-            if val is not None:
+            if val is not None and isinstance(val, str) and 'self' in val:
+                try:
+                    plotargs[kwarg] = safe_eval(val, locals_={'self': self})
+                except ZeroDivisionError:
+                    plotargs[kwarg] = 0
+            elif val is not None:
                 plotargs[kwarg] = safe_eval(val)
         chans = zip(*self.get_channel_groups())[0]
         for key, val in plotargs.iteritems():

--- a/gwsumm/plot/triggers.py
+++ b/gwsumm/plot/triggers.py
@@ -463,34 +463,31 @@ class TriggerHistogramPlot(get_plot('histogram')):
                 kwset['range'] = ax.common_limits(data)
 
         # plot
-        for arr, d, kwargs in zip(data, livetime, histargs):
-            weights = kwargs.pop('weights', None)
-            direction = kwargs.get('orientation', 'vertical')
-            if weights is True:
-                try:
-                    weights = 1/d
-                except ZeroDivisionError:
-                    pass
-                if direction == 'horizontal':
-                    self.pargs.setdefault(
-                        'xbound', 1/float(abs(self.span)) * .5)
-                else:
-                    self.pargs.setdefault(
-                        'ybound', 1/float(abs(self.span)) * .5)
-            if (kwargs.get('logy', False) or
-                kwargs.get('yscale', 'linear') == 'log'):
-                kwargs.setdefault('bottom', 1e-100)
-            label = kwargs.pop('label', None)
-            if arr.size:
-                ax.hist(arr, label=label, weights=weights, **kwargs)
-            else:
-                ax.plot([], label=label)
+        for arr, d, pargs in zip(data, livetime, histargs):
+            pargs.setdefault('label', None)
+            if isinstance(pargs.get('weights', None), (float, int)):
+                pargs['weights'] = numpy.ones_like(arr) * pargs['weights']
+            try:
+                print(arr.size)
+                print(pargs)
+                ax.hist(arr, **pargs)
+            except ValueError:  # empty dataset
+                p2 = pargs.copy()
+                p2.pop('weights')  # mpl errors on weights
+                if p2.get('log', False) or self.pargs.get('logx', False):
+                    p2['bottom'] = 1e-100  # default log 'bottom' is 1e-2
+                ax.hist([], **p2)
 
-        # tight scale the axes
-        if len(data) and direction == 'vertical' or True:
-            ax.autoscale_view(tight=True, scaley=False)
-        if len(data) and direction == 'horizontal' or False:
-            ax.autoscale_view(tight=True, scalex=False)
+        ## tight scale the axes
+        try:
+             d = pargs.pop('orientation', 'vertical')
+        except NameError:
+             pass
+        else:
+             if d == 'vertical':
+                 ax.autoscale_view(tight=True, scaley=False)
+             elif d == 'horizontal':
+                 ax.autoscale_view(tight=True, scalex=False)
 
         # customise plot
         self.apply_parameters(ax, **self.pargs)

--- a/gwsumm/tests/test_utils.py
+++ b/gwsumm/tests/test_utils.py
@@ -99,6 +99,11 @@ class UtilsTestCase(unittest.TestCase):
                           "os.remove('file-that-doesnt-exist')")
         self.assertRaises(ValueError, utils.safe_eval,
                           "lambda x: shutil.remove('file-that-doesnt-exist')")
+        # test locals or globals
+        t = utils.safe_eval('test', globals_={'test': 4})
+        self.assertEqual(t, 4)
+        t = utils.safe_eval('type(self)', locals_={'self': self})
+        self.assertEqual(t, type(self))
 
     def test_mkdir(self):
         d = 'test-dir/test-dir2'

--- a/gwsumm/utils.py
+++ b/gwsumm/utils.py
@@ -168,7 +168,7 @@ def get_default_ifo(fqdn=getfqdn()):
     raise ValueError("Cannot determine default IFO for host %r" % fqdn)
 
 
-def safe_eval(val, strict=False):
+def safe_eval(val, strict=False, globals_=None, locals_=None):
     """Evaluate the given string as a line of python, if possible
 
     If the :meth:`eval` fails, a `str` is returned instead, unless
@@ -183,6 +183,20 @@ def safe_eval(val, strict=False):
         raise an exception when the `eval` call fails (`True`) otherwise
         return the input as a `str` (`False`, default)
 
+    globals_ : `dict`, optional
+        dict of global variables to pass to `eval`, defaults to current
+        `globals`
+
+    locals_ : `dict`, optional
+        dict of local variables to pass to `eval`, defaults to current
+        `locals`
+
+        .. note::
+
+           Note the trailing underscore on the `globals_` and `locals_`
+           kwargs, this is required to not clash with the builtin `globals`
+           and `locals` methods`.
+
     Raises
     ------
     ValueError
@@ -192,6 +206,11 @@ def safe_eval(val, strict=False):
     NameError
     SyntaxError
         if the input cannot be evaluated, and `strict=True` is given
+
+    See also
+    --------
+    eval
+        for more documentation on the underlying evaluation method
     """
     # don't evaluate non-strings
     if not isinstance(val, str):
@@ -203,8 +222,17 @@ def safe_eval(val, strict=False):
         pass
     else:
         raise ValueError("Will not evaluate string containing %r" % match)
+    # format args for eval
+    if globals_ is None and locals_ is None:
+       args = ()
+    elif globals_ is None and locals_ is not None:
+       args = (globals(), locals_)
+    elif locals_ is None and globals_ is not None:
+       args = (globals_,)
+    else:
+       args = (globals_, locals_)
     # try and eval str
     try:
-        return eval(val)
+        return eval(val, *args)
     except (NameError, SyntaxError):
         return str(val)


### PR DESCRIPTION
This PR fixes the handling of `weights` in the `TriggerHistogramDataPlot` class. This required improving the `safe_eval` method to handle `globals` and `locals` parameters.