### PR TITLE
Use X1_DMT_C00 for lower-latency access to h(t)

### DIFF
--- a/gwsumm/data/timeseries.py
+++ b/gwsumm/data/timeseries.py
@@ -70,6 +70,7 @@ FRAMETYPE_REGEX = {
     'science': re.compile('[A-Z][0-9]_R\Z'),
     'second-trend': re.compile('[A-Z][0-9]_T\Z'),
     'minute-trend': re.compile('[A-Z][0-9]_M\Z'),
+    'low-latency h(t)': re.compile('[A-Z][0-9]_DMT_C00\Z'),
     'calibrated h(t) version 0': re.compile('[A-Z][0-9]_HOFT_C00\Z'),
     'calibrated h(t) version 1': re.compile('[A-Z][0-9]_HOFT_C01\Z'),
     'calibrated h(t) version 2': re.compile('[A-Z][0-9]_HOFT_C02\Z'),
@@ -518,12 +519,29 @@ def _get_timeseries_dict(channels, segments, config=None,
                 fcache = find_frames(ifo, frametype, span[0], span[1],
                                      config=config, gaps='ignore',
                                      onerror=datafind_error)
+                cachesegments = find_cache_segments(fcache)
+                gaps = SegmentList([span]) - cachesegments
                 if len(fcache) == 0 and frametype == '%s_R' % ifo:
                     frametype = '%s_C' % ifo
                     vprint("    Moving to backup frametype %s\n" % frametype)
                     fcache = find_frames(ifo, frametype, span[0], span[1],
                                          config=config, gaps='ignore',
                                          onerror=datafind_error)
+                elif abs(gaps) and frametype == '%s_HOFT_C00' % ifo:
+                    frametype = '%s_DMT_C00' % ifo
+                    vprint("    Gaps discovered in aggregated h(t) type "
+                           "%s_HOFT_C00, checking %s\n" % (ifo, frametype))
+                    c2 = find_frames(ifo, frametype, span[0], span[1],
+                                     config=config, gaps='ignore',
+                                     onerror=datafind_error)
+                    g2 = SegmentList([span]) - find_cache_segments(c2)
+                    if abs(g2) < abs(gaps):
+                        vprint("    Greater coverage with frametype %s\n"
+                               % frametype)
+                        fcache = c2
+                    else:
+                        vprint("    No extra coverage with frametype %s\n"
+                               % frametype)
 
             # parse discontiguous cache blocks and rebuild segment list
             cachesegments = find_cache_segments(fcache)


### PR DESCRIPTION
This PR implements a check against the availability of `X1_HOFT_C00` frames, moving to `X1_DMT_C00` if gaps are present. In most circumstances this should allow lower-latency access to h(t) - if no extra frame files are found, the original type is used for consistency.