### PR TITLE
Re-written mode module with enum

### DIFF
--- a/bin/gw_summary
+++ b/bin/gw_summary
@@ -419,7 +419,7 @@ starttime = Time(float(opts.gpsstart), format='gps')
 endtime = Time(float(opts.gpsend), format='gps')
 
 # set mode and output directory
-mode.set_mode(mode.MODE_ENUM[opts.mode.upper()])
+mode.set_mode(opts.mode)
 try:
     path = mode.get_base(utc)
 except ValueError:
@@ -461,7 +461,7 @@ You have selected %s mode.
 Start time %s (%s)
 End time: %s (%s)
 Output directory: %s
-""" % (os.getpid(), mode.MODE_NAME[mode.get_mode()],
+""" % (os.getpid(), mode.get_mode().name,
        starttime.utc.iso, starttime.gps,
        endtime.utc.iso, endtime.gps,
        os.path.abspath(os.path.join(opts.output_dir, path))))

--- a/gwsumm/archive.py
+++ b/gwsumm/archive.py
@@ -160,7 +160,7 @@ def read_data_archive(sourcefile):
             try:
                 add_timeseries(ts, key=ts.channel.ndsname)
             except ValueError:
-                if mode.get_mode() != mode.SUMMARY_MODE_DAY:
+                if mode.get_mode() != mode.Mode.day:
                     raise
                 warnings.warn('Caught ValueError in combining daily archives')
                 # get end time
@@ -237,7 +237,7 @@ def find_daily_archives(start, end, ifo, tag, basedir=os.curdir):
     s = from_gps(to_gps(start))
     e = from_gps(to_gps(end))
     while s < e:
-        daybase = mode.get_base(s, mode=mode.SUMMARY_MODE_DAY)
+        daybase = mode.get_base(s, mode=mode.Mode.day)
         ds = to_gps(s)
         s += datetime.timedelta(days=1)
         de = to_gps(s)

--- a/gwsumm/channels.py
+++ b/gwsumm/channels.py
@@ -42,7 +42,7 @@ else:
 from gwpy.detector import Channel
 
 from . import globalv
-from .mode import *
+from .mode import Mode
 from .utils import re_quote
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -136,7 +136,7 @@ def get_channel(channel, find_trend_source=True, timeout=5):
             # set default trend type based on mode
             if type_ is None and ':DMT-' in name:  # DMT is always m-trend
                 type_ = 'm-trend'
-            elif type_ is None and globalv.MODE == SUMMARY_MODE_GPS:
+            elif type_ is None and globalv.MODE == Mode.gps:
                 type_ = 's-trend'
             elif type_ is None:
                 type_ = 'm-trend'

--- a/gwsumm/html/bootstrap/__init__.py
+++ b/gwsumm/html/bootstrap/__init__.py
@@ -28,7 +28,7 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 from .. import markup
 from ..utils import highlight_syntax
-from ...mode import *
+from ...mode import (Mode, get_mode)
 from ...utils import re_cchar
 from ..._version import get_versions
 
@@ -252,20 +252,19 @@ def calendar(date, tag='a', class_='navbar-brand dropdown-toggle',
         triggering dropdown
     """
     mode = get_mode(mode)
-    if mode < SUMMARY_MODE_DAY:
-        raise ValueError("Cannot generate calendar for Mode %s"
-                         % MODE_NAME[mode])
+    if mode < Mode.day:
+        raise ValueError("Cannot generate calendar for Mode %s" % mode)
     if dateformat is None:
-        if mode == SUMMARY_MODE_DAY:
+        if mode == Mode.day:
             dateformat = '%B %d %Y'
-        elif mode == SUMMARY_MODE_WEEK:
+        elif mode == Mode.week:
             dateformat = 'Week of %B %d %Y'
-        elif mode == SUMMARY_MODE_MONTH:
+        elif mode == Mode.month:
             dateformat = '%B %Y'
-        elif mode == SUMMARY_MODE_YEAR:
+        elif mode == Mode.year:
             dateformat = '%Y'
         else:
-            raise ValueError("Cannot set dateformat for mode=%r" % mode)
+            raise ValueError("Cannot set dateformat for Mode %s" % mode)
     datestring = date.strftime(dateformat).replace(' 0', ' ')
     data_date = date.strftime('%d-%m-%Y')
     page = markup.page()
@@ -273,7 +272,7 @@ def calendar(date, tag='a', class_='navbar-brand dropdown-toggle',
            onclick='stepDate(-1)')
     page.a(id_=id_, class_=class_, title='Show/hide calendar',
            **{'data-date': data_date, 'data-date-format': 'dd-mm-yyyy',
-              'data-viewmode': '%ss' % mode})
+              'data-viewmode': '%ss' % mode.name})
     page.add(datestring)
     page.b('', class_='caret')
     page.a.close()

--- a/gwsumm/mode.py
+++ b/gwsumm/mode.py
@@ -20,59 +20,102 @@
 """
 
 import os.path
+from enum import (Enum, unique)
 
 from . import globalv
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
+# -- operating Mode -----------------------------------------------------------
+
+# https://docs.python.org/3/library/enum.html#orderedenum
+class OrderedEnum(Enum):
+    def __ge__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value >= other.value
+        return NotImplemented
+
+    def __gt__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value > other.value
+        return NotImplemented
+
+    def __le__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value <= other.value
+        return NotImplemented
+
+    def __lt__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value < other.value
+        return NotImplemented
+
+
 # set mode enum
-SUMMARY_MODE_STATIC = 0
-SUMMARY_MODE_EVENT = 1
-SUMMARY_MODE_GPS = 2
-SUMMARY_MODE_DAY = 10
-SUMMARY_MODE_WEEK = 11
-SUMMARY_MODE_MONTH = 12
-SUMMARY_MODE_YEAR = 13
+@unique
+class Mode(OrderedEnum):
+    """Enumeration of valid processing 'modes'
 
-MODE_NAME = {
-    SUMMARY_MODE_STATIC: 'STATIC',
-    SUMMARY_MODE_EVENT: 'EVENT',
-    SUMMARY_MODE_GPS: 'GPS',
-    SUMMARY_MODE_DAY: 'DAY',
-    SUMMARY_MODE_WEEK: 'WEEK',
-    SUMMARY_MODE_MONTH: 'MONTH',
-    SUMMARY_MODE_YEAR: 'YEAR',
-}
-
-MODE_ENUM = dict((val, key) for (key, val) in MODE_NAME.iteritems())
-
-
-def get_mode(mode=None):
-    """Return the current mode.
+    Each mode provides an association with a particular GPS interval
     """
-    if mode is None:
+    # no GPS associations
+    static = 0
+    # central GPS time (with duration)
+    event = 1
+    # arbitrary GPS [start, end) interval
+    gps = 2
+    # calendar epochs
+    day = 10
+    week = 11
+    month = 12
+    year = 13
+
+    def dir_format(self):
+        if self == Mode.day:
+            return os.path.join('day', '%Y%m%d')
+        elif self == Mode.week:
+            return os.path.join('week', '%Y%m%d')
+        elif self == Mode.month:
+            return os.path.join('month', '%Y%m')
+        elif self == Mode.year:
+            return os.path.join('year', '%Y')
+        raise ValueError("Cannot format base for Mode %s" % self)
+
+    def is_calendar(self):
+        if self >= Mode.day:
+            return True
+        return False
+
+
+# -- Mode accessors -----------------------------------------------------------
+
+def get_mode(m=None):
+    """Return the enum for the given mode, defaults to the current mode.
+    """
+    if m is None:
         return globalv.MODE
-    elif isinstance(mode, int):
-        try:
-            MODE_NAME[mode]
-        except KeyError:
-            ValueError("%s is not a valid mode" % mode)
-        else:
-            return mode
+    elif isinstance(m, (int, Enum)):
+        return Mode(m)
     else:
         try:
-            return MODE_ENUM[mode]
+            return Mode[str(m).lower()]
         except KeyError:
-            raise ValueError("%s is not a valid mode" % mode)
-
+            raise ValueError("%s is not a valid Mode" % m)
 
 def set_mode(m):
     """Set the current mode.
     """
-    if not isinstance(m, int):
-        m = MODE_ENUM[str(m).upper()]
+    if isinstance(m, int):
+        m = Mode(m)
+    else:
+        try:
+            m = Mode[str(m).lower()]
+        except KeyError:
+            raise ValueError("%s is not a valid Mode" % m)
     globalv.MODE = m
 
+
+# -- Mode utilities -----------------------------------------------------------
 
 def get_base(date, mode=None):
     """Determine the correct base attribute for the given date and mode.
@@ -89,16 +132,5 @@ def get_base(date, mode=None):
     base : `str`
         the recommended base URL to have a correctly linked calendar
     """
-    if mode is None:
-        mode = get_mode()
-    elif not isinstance(mode, int):
-        mode = MODE_ENUM[str(mode).upper()]
-    if mode == SUMMARY_MODE_DAY:
-        return os.path.join('day', date.strftime('%Y%m%d'))
-    elif mode == SUMMARY_MODE_WEEK:
-        return os.path.join('week', date.strftime('%Y%m%d'))
-    elif mode == SUMMARY_MODE_MONTH:
-        return os.path.join('month', date.strftime('%Y%m'))
-    elif mode == SUMMARY_MODE_YEAR:
-        return os.path.join('year', date.strftime('%Y'))
-    raise ValueError("Cannot format base for unknown mode %r" % mode)
+    mode = get_mode(mode)
+    return date.strftime(mode.dir_format())

--- a/gwsumm/mode.py
+++ b/gwsumm/mode.py
@@ -93,8 +93,8 @@ def get_mode(m=None):
     """Return the enum for the given mode, defaults to the current mode.
     """
     if m is None:
-        return globalv.MODE
-    elif isinstance(m, (int, Enum)):
+        m = globalv.MODE
+    if isinstance(m, (int, Enum)):
         return Mode(m)
     else:
         try:
@@ -107,7 +107,7 @@ def set_mode(m):
     """
     if isinstance(m, int):
         m = Mode(m)
-    else:
+    elif not isinstance(m, Mode):
         try:
             m = Mode[str(m).lower()]
         except KeyError:

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -35,7 +35,8 @@ from gwpy.frequencyseries import FrequencySeries
 from gwpy.plotter import *
 from gwpy.plotter.tex import label_to_latex
 
-from .. import (globalv, mode)
+from .. import globalv
+from ..mode import (Mode, get_mode)
 from ..utils import re_quote, re_cchar
 from ..channels import split as split_channels
 from ..data import (get_channel, get_timeseries, get_spectrogram,
@@ -102,7 +103,7 @@ class TimeSeriesDataPlot(DataLabelSvgMixin, DataPlot):
         if geometry[0] * geometry[1] == 1:
             axes = [axes]
         for ax in axes:
-            if mode.MODE_NAME[mode.get_mode()] == 'MONTH':
+            if get_mode() == Mode.month:
                 ax.set_xscale('days')
                 ax.set_xlabel('_auto')
             ax.set_epoch(float(self.start))

--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -38,7 +38,8 @@ from gwpy.plotter import *
 from gwpy.plotter.tex import label_to_latex
 from gwpy.time import (from_gps, to_gps)
 
-from .. import globalv, mode
+from .. import globalv
+from ..mode import (Mode, get_mode)
 from ..config import NoOptionError
 from ..utils import (re_quote, get_odc_bitmask, re_flagdiv, safe_eval)
 from ..data import (get_channel, get_timeseries)
@@ -489,19 +490,19 @@ class DutyDataPlot(SegmentDataPlot):
         """
         # if not given anything, work it out from the mode
         if self.bins is None:
-            m = mode.MODE_NAME[mode.get_mode()]
+            m = get_mode()
             duration = float(abs(self.span))
             # for year mode, use a month
-            if m in ['YEAR'] or duration >= 86400 * 300:
+            if m == Mode.year or duration >= 86400 * 300:
                 dt = relativedelta(months=1)
             # for more than 8 weeks, use weeks
             elif duration >= 86400 * 7 * 8:
                 dt = relativedelta(weeks=1)
             # for week and month mode, use daily
-            elif m in ['WEEK', 'MONTH'] or duration >= 86400 * 7:
+            elif m in [Mode.week, Mode.month] or duration >= 86400 * 7:
                 dt = relativedelta(days=1)
             # for day mode, make hourly duty factor
-            elif m in ['DAY']:
+            elif m == Mode.day:
                 dt = relativedelta(hours=1)
             # otherwise provide 10 bins
             else:

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -44,7 +44,7 @@ from gwpy.time import (from_gps, to_gps)
 from gwpy.segments import Segment
 
 from .. import html
-from ..mode import (get_mode, get_base, MODE_ENUM, MODE_NAME)
+from ..mode import (Mode, get_mode, get_base)
 from ..utils import (re_quote, re_cchar)
 from ..config import NoOptionError
 from .registry import (get_tab, register_tab)
@@ -411,7 +411,7 @@ class BaseTab(object):
                 kwargs['mode'] = get_mode(cp.get(section, 'mode'))
             except NoOptionError:
                 kwargs['mode'] = get_mode()
-        if kwargs['mode'] >= MODE_ENUM['GPS']:
+        if kwargs['mode'] >= Mode.gps:
             try:
                 kwargs['start']
             except KeyError:
@@ -420,7 +420,7 @@ class BaseTab(object):
                 kwargs['end']
             except KeyError:
                 kwargs['end'] = cp.getint(section, 'gps-end-time')
-        elif kwargs['mode'] == MODE_ENUM['EVENT']:
+        elif kwargs['mode'] == Mode.event:
             try:
                 kwargs['gpstime']
             except KeyError:
@@ -858,7 +858,7 @@ class IntervalTab(GpsTab):
                 start = kwargs.pop('start')
                 end = kwargs.pop('end')
             except KeyError:
-                mode = MODE_NAME[get_mode(kwargs.get('mode'))]
+                mode = get_mode(kwargs.get('mode')).name
                 raise TypeError("%s() in %r mode needs keyword argument 'span'"
                                 " or both 'start' and 'end'"
                                 % (type(self).__name__, mode))
@@ -966,7 +966,7 @@ class EventTab(GpsTab):
         try:
             gpstime = kwargs.pop('gpstime')
         except KeyError:
-            mode = MODE_NAME[get_mode(kwargs['mode'])]
+            mode = get_mode(kwargs['mode']).name
             raise TypeError("%s() in %r mode needs keyword argument 'gpstime'"
                             % (type(self).__name__, mode))
         duration = kwargs.pop('duration', 200)
@@ -1002,11 +1002,11 @@ class _MetaTab(type):
                 mode = None
         mode = get_mode(mode)
         # parse regular Tab (don't add a mixin)
-        if mode == MODE_ENUM['STATIC']:
+        if mode == Mode.static:
             kwargs.pop('mode', None)
             base = StaticTab
         # parse event Tab
-        elif mode == MODE_ENUM['EVENT']:
+        elif mode == Mode.event:
             kwargs['mode'] = mode
             base = EventTab
         # parse interval Tab

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -46,7 +46,7 @@ from .. import (globalv, html)
 from ..channels import (re_channel,
                         split_combination as split_channel_combination)
 from ..config import *
-from ..mode import (get_mode, MODE_ENUM)
+from ..mode import (Mode, get_mode)
 from ..data import (get_channel, get_timeseries_dict, get_spectrograms,
                     get_coherence_spectrograms, get_spectrum, FRAMETYPE_REGEX)
 from ..plot import get_plot
@@ -195,13 +195,13 @@ class DataTab(ProcessedTab, ParentTab):
                     section, 'subplot-duration'))
             except NoOptionError:
                 mode = get_mode()
-                if mode == MODE_ENUM['DAY']:
+                if mode == Mode.day:
                     subdelta = timedelta(hours=1)
-                elif mode == MODE_ENUM['WEEK']:
+                elif mode == Mode.week:
                     subdelta = timedelta(days=1)
-                elif mode == MODE_ENUM['MONTH']:
+                elif mode == Mode.month:
                     subdelta = timedelta(weeks=1)
-                elif mode == MODE_ENUM['YEAR']:
+                elif mode == Mode.year:
                     subdelta = timedelta(months=1)
                 else:
                     d = int(end - start)
@@ -696,7 +696,7 @@ class DataTab(ProcessedTab, ParentTab):
         if self.subplots:
             page.hr(class_='row-divider')
             page.h1('Sub-plots')
-            layout = get_mode() == MODE_ENUM['WEEK'] and [7] or [4]
+            layout = get_mode() == Mode.week and [7] or [4]
             plist = [p for p in self.subplots if p.state in [state, None]]
             page.add(str(self.scaffold_plots(plots=plist, state=state,
                                              layout=layout)))

--- a/gwsumm/tabs/etg.py
+++ b/gwsumm/tabs/etg.py
@@ -36,7 +36,7 @@ from ..data import get_channel
 from ..state import (get_state, ALLSTATE)
 from ..triggers import (get_etg_table, get_triggers, register_etg_table)
 from ..utils import re_quote
-from ..mode import (get_mode, MODE_ENUM)
+from ..mode import (Mode, get_mode)
 from .registry import (get_tab, register_tab)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -366,7 +366,7 @@ class EventTriggerTab(get_tab('default')):
             if self.subplots:
                 page.hr(class_='row-divider')
                 page.h1('Sub-plots')
-                layout = get_mode() == MODE_ENUM['WEEK'] and [7] or [4]
+                layout = get_mode() == Mode.week and [7] or [4]
                 plist = [p for p in self.subplots if p.state in [state, None]]
                 page.add(str(self.scaffold_plots(plots=plist, state=state,
                                                  layout=layout)))

--- a/gwsumm/tabs/fscan.py
+++ b/gwsumm/tabs/fscan.py
@@ -31,7 +31,7 @@ from .registry import (get_tab, register_tab)
 
 from .. import (html, globalv)
 from .. plot import get_plot
-from ..mode import SUMMARY_MODE_DAY
+from ..mode import Mode
 from ..config import (GWSummConfigParser, NoOptionError)
 from ..state import (ALLSTATE, SummaryState)
 
@@ -48,8 +48,9 @@ class FscanTab(base):
     type = 'fscan'
 
     def __init__(self, *args, **kwargs):
-        if globalv.MODE != SUMMARY_MODE_DAY:
-            raise RuntimeError("FscanTab is only available in 'DAY' mode.")
+        if kwargs['mode'] != Mode.day:
+            raise RuntimeError("FscanTab is only available in %s mode."
+                               % Mode.day.name)
         super(FscanTab, self).__init__(*args, **kwargs)
 
     @classmethod

--- a/gwsumm/tabs/hveto.py
+++ b/gwsumm/tabs/hveto.py
@@ -35,7 +35,7 @@ from gwpy.segments import (SegmentList, DataQualityFlag)
 from .registry import (get_tab, register_tab)
 
 from .. import (html, globalv)
-from ..mode import SUMMARY_MODE_DAY
+from ..mode import Mode
 from ..config import (GWSummConfigParser, NoSectionError, NoOptionError,
                       DEFAULTSECT)
 from ..channels import get_channel
@@ -65,8 +65,9 @@ class HvetoTab(base):
                    'Cum. Efficiency [%]', 'Cum. Deadtime [%]']
 
     def __init__(self, *args, **kwargs):
-        if globalv.MODE != SUMMARY_MODE_DAY:
-            raise RuntimeError("HvetoTab is only available in 'DAY' mode.")
+        if kargs['mode'] != Mode.day:
+            raise RuntimeError("HvetoTab is only available in %s mode."
+                               % Mode.day.name)
         super(HvetoTab, self).__init__(*args, **kwargs)
 
     @classmethod

--- a/gwsumm/tabs/ihope.py
+++ b/gwsumm/tabs/ihope.py
@@ -39,7 +39,7 @@ from ..data import find_cache_segments
 from ..triggers import (get_triggers, register_etg_table)
 from ..utils import re_quote
 from ..state import SummaryState
-from ..mode import (get_mode, MODE_ENUM)
+from ..mode import (Mode, get_mode)
 from .registry import (get_tab, register_tab)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -317,7 +317,7 @@ class DailyAhopeTab(base):
             if self.subplots:
                 page.hr(class_='row-divider')
                 page.h1('Sub-plots')
-                layout = get_mode() == MODE_ENUM['WEEK'] and [7] or [4]
+                layout = get_mode() == Mode.week and [7] or [4]
                 plist = [p for p in self.subplots if p.state in [state, None]]
                 page.add(str(self.scaffold_plots(plots=plist, state=state,
                                                  layout=layout)))

--- a/gwsumm/tabs/stamp.py
+++ b/gwsumm/tabs/stamp.py
@@ -30,8 +30,8 @@ from numpy import loadtxt
 from .registry import (get_tab, register_tab)
 
 from .. import (html, globalv)
-from .. plot import get_plot
-from ..mode import SUMMARY_MODE_DAY
+from ..mode import Mode
+from ..plot import get_plot
 from ..config import (GWSummConfigParser, NoOptionError)
 from ..state import (ALLSTATE, SummaryState)
 
@@ -48,8 +48,9 @@ class StampPEMTab(base):
     type = 'stamp'
 
     def __init__(self, *args, **kwargs):
-        if globalv.MODE != SUMMARY_MODE_DAY:
-            raise RuntimeError("StampPEMTab is only available in 'DAY' mode.")
+        if kwargs['mode'] != Mode.day:
+            raise RuntimeError("StampPEMTab is only available in %s mode."
+                               % Mode.day.name)
         super(StampPEMTab, self).__init__(*args, **kwargs)
 
     @classmethod

--- a/gwsumm/tests/test_mode.py
+++ b/gwsumm/tests/test_mode.py
@@ -46,10 +46,10 @@ class ModeTests(unittest.TestCase):
 
     def test_set_mode(self):
         mode.set_mode(0)
-        self.assertEqual(globalv.MODE, 0)
-        self.assertEqual(globalv.MODE, mode.SUMMARY_MODE_STATIC)
+        self.assertEqual(globalv.MODE, mode.Mode(0))
+        self.assertEqual(globalv.MODE, mode.Mode.static)
         mode.set_mode('GPS')
-        self.assertEqual(globalv.MODE, mode.SUMMARY_MODE_GPS)
+        self.assertEqual(globalv.MODE, mode.Mode.gps)
 
     def test_get_base(self):
         date = datetime.date(2015, 9, 22)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+enum34
 pykerberos
 m2crypto
 python-cjson

--- a/setup.py
+++ b/setup.py
@@ -85,11 +85,15 @@ requires = [
 tests_require = [
     'pytest>=2.8'
 ]
-if sys.version < (2.7):
-    tests_require.append('unittest2')
 extras_require = {
     'doc': ['sphinx', 'numpydoc', 'sphinx-bootstrap-theme', 'astropy_helpers'],
 }
+
+# version-specific packages
+if sys.version < '3':
+    requires.append('enum34')
+if sys.version < '2.7':
+    tests_require.append('unittest2')
 
 # -- data files ---------------------------------------------------------------
 


### PR DESCRIPTION
This PR introduces a re-write of the `gwsumm.mode` module, using the `enum.Enum` class introduced in python3 and back-ported by python2.7 via [`enum34`](https://pypi.python.org/pypi/enum34/).