### PR TITLE
Fixed some variable assignment bugs in gwsumm.js

### DIFF
--- a/share/js/gwsumm.js
+++ b/share/js/gwsumm.js
@@ -196,8 +196,8 @@ $(window).load(function() {
 
   // load correct run type
   if (location.hash.length > 1) {
-    hash = location.hash.substring(1);
-    path = location.pathname + hash + '.html';
+    var hash = location.hash.substring(1);
+    var path = location.pathname + hash + '.html';
     $('#state_' + hash).load_state(path);
   }
 


### PR DESCRIPTION
This PR fixes a problem with setting the page state based on the `location.hash`.