### PR TITLE
Support more complicated maths

### DIFF
--- a/gwsumm/tests/test_data.py
+++ b/gwsumm/tests/test_data.py
@@ -132,10 +132,12 @@ class DataTests(unittest.TestCase):
         self.assertListEqual(operators, [operator.add])
         self.assertIsInstance(chans[0], tuple)
         self.assertEqual(chans[0][0], 'L1:TEST')
-        self.assertTupleEqual(chans[0][1], (operator.mul, 2))
+        self.assertIsInstance(chans[0][1], list)
+        self.assertEqual(len(chans[0][1]), 1)
+        self.assertTupleEqual(chans[0][1][0], (operator.mul, 2))
         self.assertIsInstance(chans[1], tuple)
         self.assertEqual(chans[1][0], 'L1:TEST2')
-        self.assertTupleEqual(chans[1][1], (operator.pow, 5))
+        self.assertTupleEqual(chans[1][1][0], (operator.pow, 5))
 
     # -- test add/get methods -------------------
 


### PR DESCRIPTION
This PR modifies the `data.mathutils` module to support an arbitrary number of _non-commutative_ mathematical operations attached to a channel name, e.g.

```
L:PSL-ISS_DIFFRACTION_AVG.mean,m-trend * 0.02 + 0.385
```

All mathematic operations are performed simply left-to-right, meaning, 

```
L1:PSL-ISS_DIFFRACTION_AVG.mean,m-trend + 0.1  * 0.2
```

is logically the same as

```
(L1:PSL-ISS_DIFFRACTION_AVG.mean,m-trend + 0.1)  * 0.2
```

and not 

```
L1:PSL-ISS_DIFFRACTION_AVG.mean,m-trend + (0.1  * 0.2)
```

as would be assumed in written maths.