### PR TITLE
Don't show state bar for 'All' state

### DIFF
--- a/gwsumm/plot/range.py
+++ b/gwsumm/plot/range.py
@@ -238,8 +238,7 @@ class SimpleTimeVolumeDataPlot(get_plot('segments')):
         # add extra axes and finalise
         if not plot.colorbars:
             plot.add_colorbar(ax=ax, visible=False)
-        if self.state:
-            self.add_state_segments(ax)
+        self.add_state_segments(ax)
         return self.finalize(outputfile=outputfile)
 
 register_plot(SimpleTimeVolumeDataPlot)

--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -293,8 +293,8 @@ class SegmentDataPlot(SegmentLabelSvgMixin, TimeSeriesDataPlot):
             plot.add_colorbar(ax=ax, visible=False)
         elif mask is not None:
             plot.add_bitmask(mask, topdown=True)
-        if self.state and self.state.name != ALLSTATE:
-            self.add_state_segments(ax)
+
+        self.add_state_segments(ax)
 
         rcParams['ytick.labelsize'] = _labelsize
         return self.finalize()
@@ -452,8 +452,8 @@ class StateVectorDataPlot(TimeSeriesDataPlot):
             plot.add_colorbar(ax=ax, visible=False)
         elif mask is not None:
             plot.add_bitmask(mask, topdown=True)
-        if self.state and self.state.name != ALLSTATE:
-            self.add_state_segments(ax)
+
+        self.add_state_segments(ax)
 
         return self.finalize()
 
@@ -730,8 +730,8 @@ class DutyDataPlot(SegmentDataPlot):
         if not plot.colorbars:
             for ax in axes:
                 plot.add_colorbar(ax=ax, visible=False)
-        if self.state:
-            self.add_state_segments(axes[-1])
+
+        self.add_state_segments(axes[-1])
 
         return self.finalize(outputfile=outputfile)
 
@@ -914,8 +914,7 @@ class ODCDataPlot(SegmentLabelSvgMixin, StateVectorDataPlot):
         # add bit mask axes and finalise
         if not plot.colorbars:
             plot.add_colorbar(ax=ax, visible=False)
-        if self.state and self.state.name != ALLSTATE:
-            self.add_state_segments(ax)
+        self.add_state_segments(ax)
         out = self.finalize()
         rcParams['ytick.labelsize'] = _labelsize
         return out

--- a/gwsumm/plot/triggers.py
+++ b/gwsumm/plot/triggers.py
@@ -302,9 +302,8 @@ class TriggerDataPlot(TimeSeriesDataPlot):
             plot.add_legend(ax=ax, **legendargs)
 
         # add state segments
-        if isinstance(plot, TimeSeriesPlot) and self.state:
+        if isinstance(plot, TimeSeriesPlot):
             self.add_state_segments(ax)
-
 
         # finalise
         return self.finalize()
@@ -382,8 +381,7 @@ class TriggerTimeSeriesDataPlot(TimeSeriesDataPlot):
         # add extra axes and finalise
         if not plot.colorbars:
             plot.add_colorbar(ax=ax, visible=False)
-        if self.state:
-            self.add_state_segments(ax)
+        self.add_state_segments(ax)
         return self.finalize()
 
 register_plot(TriggerTimeSeriesDataPlot)


### PR DESCRIPTION
This PR modifies the `gwsumm.plot` module to not show a state segments bar along the bottom of a time-axis plot if the state is 'All', i.e. showing all data. This bar is totally unnecessary.