### PR TITLE
Added more observatory-related configuration defaults

### DIFF
--- a/bin/gw_summary
+++ b/bin/gw_summary
@@ -380,7 +380,7 @@ if not opts.on_segdb_error in ['raise', 'warn', 'ignore']:
 config = GWSummConfigParser()
 config.optionxform = str
 if opts.ifo:
-    config.set(DEFAULTSECT, 'ifo', opts.ifo)
+    config.set_ifo_options(opts.ifo, section=DEFAULTSECT)
 config.set(DEFAULTSECT, 'user', getpass.getuser())
 config.read(opts.config_file)
 

--- a/gwsumm/config.py
+++ b/gwsumm/config.py
@@ -136,6 +136,20 @@ class GWSummConfigParser(ConfigParser):
     def set_ifo_options(self, ifo, observatory=None,
                         section=DEFAULTSECT):
         """Set configurations options in [DEFAULT] based on the given `ifo`
+
+        The following options are set
+
+        - `IFO` - the two-character interferometer prefix, e.g. ``L1``
+        - `ifo` - the two-character interferometer prefix in lower-case,
+           e.g. ``l1``
+        - `SITE` - the single-character site ID, e.g. ``L``
+        - `site` - the single-character site ID,n lower-case e.g. ``l``
+
+        Additionally, if `observatory` is given, or the `ifo` matches known
+        observatories, the following option is set
+
+        - `observatory` - the name of the observatory, e.g. ``LIGO Livingston``
+
         """
         if observatory is None:
             observatory = OBSERVATORY_MAP.get(ifo)

--- a/gwsumm/config.py
+++ b/gwsumm/config.py
@@ -53,7 +53,7 @@ from gwpy.detector import (Channel, ChannelList)
 from gwpy.time import tconvert
 
 from .html import (get_css, get_js)
-from .utils import (nat_sorted, re_cchar, safe_eval)
+from .utils import (nat_sorted, re_cchar, safe_eval, OBSERVATORY_MAP)
 from .channels import (get_channels, split as split_channels)
 
 __all__ = _cp__all__ + ['InterpolationMissingOptionError', 'GWSummConfigParser']
@@ -132,6 +132,19 @@ class GWSummConfigParser(ConfigParser):
                         '[%s]' % section, section, key, '%%(%s)s' % key)
                 s = section % {key: val}
             self._sections[s] = self._sections.pop(section)
+
+    def set_ifo_options(self, ifo, observatory=None,
+                        section=DEFAULTSECT):
+        """Set configurations options in [DEFAULT] based on the given `ifo`
+        """
+        if observatory is None:
+            observatory = OBSERVATORY_MAP.get(ifo)
+        self.set(section, 'IFO', ifo)
+        self.set(section, 'ifo', ifo)  # for backwards compatibility
+        self.set(section, 'SITE', ifo[0].upper())
+        self.set(section, 'site', ifo[0].lower())
+        if observatory is not None:
+            self.set(section, 'observatory', observatory)
 
     def set_date_options(self, start, end, section=DEFAULTSECT):
         """Set datetime options in [DEFAULT] based on the given times

--- a/gwsumm/config.py
+++ b/gwsumm/config.py
@@ -21,6 +21,7 @@
 
 import os.path
 import re
+import warnings
 import sys
 from StringIO import StringIO
 from importlib import import_module
@@ -151,6 +152,11 @@ class GWSummConfigParser(ConfigParser):
         - `observatory` - the name of the observatory, e.g. ``LIGO Livingston``
 
         """
+        warnings.warn('In an upcoming release the `ifo` configuration option '
+                      'will be changed to hold the lower-case interferometer '
+                      'prefix, all configuration files should be modified to '
+                      'instead use the `IFO` option for the upper-case '
+                      'prefix.', DeprecationWarning)
         if observatory is None:
             observatory = OBSERVATORY_MAP.get(ifo)
         self.set(section, 'IFO', ifo)

--- a/gwsumm/utils.py
+++ b/gwsumm/utils.py
@@ -212,6 +212,15 @@ def safe_eval(val, strict=False, globals_=None, locals_=None):
 
 # -- IFO parsing --------------------------------------------------------------
 
+OBSERVATORY_MAP = {
+    'G1': 'GEO',
+    'H1': 'LIGO Hanford',
+    'K1': 'KAGRA',
+    'L1': 'LIGO Livingston',
+    'V1': 'Virgo',
+}
+
+
 def get_default_ifo(fqdn=getfqdn()):
     """Find the default interferometer prefix (IFO) for the given host
 

--- a/gwsumm/utils.py
+++ b/gwsumm/utils.py
@@ -45,6 +45,8 @@ UNSAFE_EVAL_STRS = ['os\.(?![$\'\" ])', 'shutil', '\.rm', '\.mv']
 UNSAFE_EVAL = re.compile('(%s)' % '|'.join(UNSAFE_EVAL_STRS))
 
 
+# -- utilities ----------------------------------------------------------------
+
 def elapsed_time():
     """Return the time (seconds) since this job started
     """
@@ -137,37 +139,6 @@ _re_odc = re.compile('(OUTMON|OUT_DQ|LATCH)')
 def get_odc_bitmask(odcchannel):
     return _re_odc.sub('BITMASK', str(odcchannel))
 
-
-def get_default_ifo(fqdn=getfqdn()):
-    """Find the default interferometer prefix (IFO) for the given host
-
-    Parameters
-    ----------
-    fqdn : `str`
-        the fully-qualified domain name (FQDN) of the host on which you
-        wish to find the default IFO
-
-    Returns
-    -------
-    IFO : `str`
-        the upper-case X1-style prefix for the default IFO, if found, e.g. `L1`
-
-    Raises
-    ------
-    ValueError
-        if not default interferometer prefix can be parsed
-    """
-    if '.uni-hannover.' in fqdn or '.atlas.' in fqdn:
-        return 'G1'
-    elif '.ligo-wa.' in fqdn:
-        return 'H1'
-    elif '.ligo-la.' in fqdn:
-        return 'L1'
-    elif '.virgo.' in fqdn or '.ego-gw.' in fqdn:
-        return 'V1'
-    raise ValueError("Cannot determine default IFO for host %r" % fqdn)
-
-
 def safe_eval(val, strict=False, globals_=None, locals_=None):
     """Evaluate the given string as a line of python, if possible
 
@@ -237,3 +208,35 @@ def safe_eval(val, strict=False, globals_=None, locals_=None):
         return eval(val, *args)
     except (NameError, SyntaxError):
         return str(val)
+
+
+# -- IFO parsing --------------------------------------------------------------
+
+def get_default_ifo(fqdn=getfqdn()):
+    """Find the default interferometer prefix (IFO) for the given host
+
+    Parameters
+    ----------
+    fqdn : `str`
+        the fully-qualified domain name (FQDN) of the host on which you
+        wish to find the default IFO
+
+    Returns
+    -------
+    IFO : `str`
+        the upper-case X1-style prefix for the default IFO, if found, e.g. `L1`
+
+    Raises
+    ------
+    ValueError
+        if not default interferometer prefix can be parsed
+    """
+    if '.uni-hannover.' in fqdn or '.atlas.' in fqdn:
+        return 'G1'
+    elif '.ligo-wa.' in fqdn:
+        return 'H1'
+    elif '.ligo-la.' in fqdn:
+        return 'L1'
+    elif '.virgo.' in fqdn or '.ego-gw.' in fqdn:
+        return 'V1'
+    raise ValueError("Cannot determine default IFO for host %r" % fqdn)


### PR DESCRIPTION
This PR modifies the `GWSummConfigParser` class to add a `set_ifo_options` method to set the following default options

- `IFO`
- `ifo`
- `SITE`
- `site`
- `observatory`

See the docstring for the method for details.