### PR TITLE
Use six.string_types for all isinstance calls

### DIFF
--- a/gwsumm/config.py
+++ b/gwsumm/config.py
@@ -25,6 +25,8 @@ import warnings
 from StringIO import StringIO
 from importlib import import_module
 
+from six import string_types
+
 # import these for evaluating lambda expressions in the configuration file
 import math
 import numpy
@@ -91,7 +93,7 @@ class GWSummConfigParser(ConfigParser):
 
     def read(self, filenames):
         readok = ConfigParser.read(self, filenames)
-        if isinstance(filenames, (unicode, str)):
+        if isinstance(filenames, string_types):
             filenames = filenames.split(',')
         for fp in filenames:
             if fp not in readok:

--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -29,6 +29,8 @@ except ImportError:
     from ordereddict import OrderedDict
 from itertools import izip_longest
 
+from six import string_types
+
 import numpy
 
 from astropy import units
@@ -157,7 +159,7 @@ def _get_coherence_spectrogram(channel_pair, segments, config=None,
             except AttributeError:
                 filter_ = None
             else:
-                if isinstance(filter_, str):
+                if isinstance(filter_, string_types):
                     filter_ = safe_eval(filter_, strict=True)
 
             # check how much of this component still needs to be calculated

--- a/gwsumm/data/spectral.py
+++ b/gwsumm/data/spectral.py
@@ -28,6 +28,8 @@ try:
 except ImportError:
     from ordereddict import OrderedDict
 
+from six import string_types
+
 # imports for filter
 from math import pi
 
@@ -145,7 +147,7 @@ def _get_spectrogram(channel, segments, config=None, cache=None,
         except AttributeError:
             filter_ = None
         else:
-            if isinstance(filter_, str):
+            if isinstance(filter_, string_types):
                 filter_ = safe_eval(filter_, strict=True)
 
         # get time-series data

--- a/gwsumm/html/bootstrap.py
+++ b/gwsumm/html/bootstrap.py
@@ -24,6 +24,8 @@ import getpass
 import datetime
 import os.path
 
+from six import string_types
+
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 from . import markup
@@ -128,7 +130,7 @@ def navbar(links, class_='navbar navbar-fixed-top', brand=None, collapse=True):
         page.ul(class_='nav navbar-nav')
         for i, link in enumerate(links):
             if (isinstance(link, (list, tuple)) and
-                    isinstance(link[1], basestring)):
+                    isinstance(link[1], string_types)):
                 page.li()
                 text, link = link
                 page.a(text, href=link)

--- a/gwsumm/html/html5.py
+++ b/gwsumm/html/html5.py
@@ -22,6 +22,8 @@
 import os.path
 from urlparse import urlparse
 
+from six import string_types
+
 from . import markup
 from ..utils import re_cchar
 
@@ -65,7 +67,7 @@ def load(url, id_='main', error=False, success=None):
         error = ('alert("Cannot load content from %r, use browser console '
                 'to inspect failure.");')
     else:
-        if not isinstance(error, (str, markup.page)):
+        if not isinstance(error, (string_types, markup.page)):
             error = 'Failed to load content from %r' % url
         error = ('$("#%s").html("<div class=\'alert alert-warning\'>'
                                 '<p>%s</p></div>");'

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -26,6 +26,8 @@ import re
 import warnings
 from itertools import cycle
 
+from six import string_types
+
 import numpy
 
 from matplotlib.pyplot import subplots
@@ -260,7 +262,8 @@ class SpectrogramDataPlot(TimeSeriesDataPlot):
             return self._pid
         except AttributeError:
             super(SpectrogramDataPlot, self).pid
-            if isinstance(self.ratio, str) and os.path.isfile(self.ratio):
+            if (isinstance(self.ratio, string_types) and
+                    os.path.isfile(self.ratio)):
                 self._pid += '_REFERENCE_RATIO'
             elif self.ratio:
                 self._pid += '_%s_RATIO' % re_cchar.sub(
@@ -292,7 +295,7 @@ class SpectrogramDataPlot(TimeSeriesDataPlot):
 
         # get cmap
         if ratio in ['median', 'mean'] or (
-                isinstance(ratio, str) and os.path.isfile(ratio)):
+                isinstance(ratio, string_types) and os.path.isfile(ratio)):
             self.pargs.setdefault('cmap', 'Spectral_r')
         cmap = self.pargs.pop('cmap', None)
 
@@ -326,7 +329,7 @@ class SpectrogramDataPlot(TimeSeriesDataPlot):
                 ratio = allspec.percentile(ratio)
             else:
                 ratio = getattr(allspec, ratio)(axis=0)
-        elif isinstance(ratio, str) and os.path.isfile(ratio):
+        elif isinstance(ratio, string_types) and os.path.isfile(ratio):
             try:
                 ratio = FrequencySeries.read(ratio)
             except IOError as e:

--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -28,6 +28,8 @@ import warnings
 from math import (floor, ceil)
 from urlparse import urlparse
 
+from six import string_types
+
 from matplotlib import rc_context
 
 from gwpy.segments import Segment
@@ -205,7 +207,7 @@ class DataPlot(SummaryPlot):
                  tag=None, pid=None, href=None, new=True, all_data=False,
                  read=True, fileformat='png', caption=None, **pargs):
         super(DataPlot, self).__init__(href=href, new=new, caption=caption)
-        if isinstance(channels, str):
+        if isinstance(channels, string_types):
             channels = split_channels(channels)
         self.channels = channels
         self.span = (start, end)
@@ -255,7 +257,7 @@ class DataPlot(SummaryPlot):
 
     @state.setter
     def state(self, state_):
-        if isinstance(state_, (unicode, str)):
+        if isinstance(state_, string_types):
             self._state = globalv.STATES[state_]
         else:
             self._state = state_
@@ -381,7 +383,8 @@ class DataPlot(SummaryPlot):
                     val = self.pargs.pop('%ss' % kwarg)
                 except KeyError:
                     val = None
-            if val is not None and isinstance(val, str) and 'self' in val:
+            if (val is not None and isinstance(val, string_types) and
+                    'self' in val):
                 try:
                     plotargs[kwarg] = safe_eval(val, locals_={'self': self})
                 except ZeroDivisionError:
@@ -408,7 +411,7 @@ class DataPlot(SummaryPlot):
         if defaults is None:
             defaults = chans
         labels = self.pargs.pop('labels', defaults)
-        if isinstance(labels, (unicode, str)):
+        if isinstance(labels, string_types):
             labels = labels.split(',')
         labels = map(lambda s: rUNDERSCORE.sub(r'\_', str(s).strip('\n ')),
                      labels)
@@ -486,7 +489,7 @@ class DataPlot(SummaryPlot):
         # get channels
         if channels is None:
             channels = params.pop('channels', [])
-        if isinstance(channels, (unicode, str)):
+        if isinstance(channels, string_types):
             channels = split_channels(channels)
         # parse specific parameters
         if 'all-data' in params:
@@ -543,7 +546,7 @@ class DataPlot(SummaryPlot):
         # save figure and close (build both png and pdf for pdf choice)
         if outputfile is None:
             outputfile = self.outputfile
-        if not isinstance(outputfile, str):
+        if not isinstance(outputfile, string_types):
             extensions = [None]
         elif outputfile.endswith('.pdf'):
             extensions = ['.pdf', '.png']
@@ -561,7 +564,7 @@ class DataPlot(SummaryPlot):
                 warnings.warn("Caught %s: %s [retrying...]"
                              % (type(e).__name__, str(e)))
                 self.plot.save(fp, **savekwargs)
-            if isinstance(fp, str):
+            if isinstance(fp, string_types):
                 vprint("        %s written\n" % fp)
         if close:
             self.plot.close()
@@ -570,7 +573,7 @@ class DataPlot(SummaryPlot):
     def apply_parameters(self, ax, **pargs):
         for key in pargs:
             val = pargs[key]
-            if key in ['xlim', 'ylim'] and isinstance(val, str):
+            if key in ['xlim', 'ylim'] and isinstance(val, string_types):
                 val = eval(val)
             try:
                 getattr(ax, 'set_%s' % key)(val)

--- a/gwsumm/plot/range.py
+++ b/gwsumm/plot/range.py
@@ -25,6 +25,8 @@ import re
 import hashlib
 from math import pi
 
+from six import string_types
+
 import numpy
 
 from gwpy.segments import (Segment, SegmentList)
@@ -125,7 +127,7 @@ class SimpleTimeVolumeDataPlot(get_plot('segments')):
     parse_plot_kwargs = get_plot('timeseries').parse_plot_kwargs
 
     def __init__(self, sources, *args, **kwargs):
-        if isinstance(sources, str):
+        if isinstance(sources, string_types):
             sources = split_channels(sources)
         channels = sources[::2]
         flags = sources[1::2]

--- a/gwsumm/plot/registry.py
+++ b/gwsumm/plot/registry.py
@@ -23,6 +23,7 @@ configuration INI files
 """
 
 import re
+from six import string_types
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -60,7 +61,7 @@ def get_plot(name):
     """Query the registry for the plot class registered to the given
     name
     """
-    if isinstance(name, str):
+    if isinstance(name, string_types):
         name = re.sub('[\'\"]', '', name)
     try:
         return _PLOTS[name]

--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -30,6 +30,8 @@ try:
 except ImportError:
     from ordereddict import OrderedDict
 
+from six import string_types
+
 import numpy
 
 from dateutil.relativedelta import relativedelta
@@ -92,7 +94,7 @@ class SegmentDataPlot(SegmentLabelSvgMixin, TimeSeriesDataPlot):
 
     @flags.setter
     def flags(self, flist):
-        if isinstance(flist, str):
+        if isinstance(flist, string_types):
             flist = [f.strip('\n ') for f in flist.split(',')]
         self._flags = []
         for f in flist:
@@ -165,7 +167,7 @@ class SegmentDataPlot(SegmentLabelSvgMixin, TimeSeriesDataPlot):
         # get flags
         if flags is None:
             flags = dict(config.items(section)).pop('flags', [])
-        if isinstance(flags, str):
+        if isinstance(flags, string_types):
             flags = [f.strip('\n ') for f in flags.split(',')]
         new.flags = flags
         return new
@@ -194,7 +196,7 @@ class SegmentDataPlot(SegmentLabelSvgMixin, TimeSeriesDataPlot):
                 active = active.get('facecolor')
             else:
                 self.pargs['facecolor'] = active
-            if isinstance(active, str) and active.lower() == 'red':
+            if isinstance(active, string_types) and active.lower() == 'red':
                 self.pargs['known'] = 'dodgerblue'
             else:
                 self.pargs['known'] = 'red'
@@ -347,7 +349,7 @@ class StateVectorDataPlot(TimeSeriesDataPlot):
         """
         chans = zip(*self.get_channel_groups())[0]
         labels = list(self.pargs.pop('labels', defaults))
-        if isinstance(labels, (unicode, str)):
+        if isinstance(labels, string_types):
             labels = labels.split(',')
         for i, l in enumerate(labels):
             if isinstance(l, (list, tuple)):

--- a/gwsumm/plot/triggers.py
+++ b/gwsumm/plot/triggers.py
@@ -24,6 +24,8 @@ from __future__ import division
 import re
 from itertools import (izip, cycle)
 
+from six import string_types
+
 from numpy import isinf
 
 from astropy.units import Quantity
@@ -158,7 +160,7 @@ class TriggerDataPlot(TimeSeriesDataPlot):
 
         # work out labels
         labels = self.pargs.pop('labels', self.channels)
-        if isinstance(labels, (unicode, str)):
+        if isinstance(labels, string_types):
             labels = labels.split(',')
         labels = map(lambda s: str(s).strip('\n '), labels)
 
@@ -325,7 +327,7 @@ class TriggerTimeSeriesDataPlot(TimeSeriesDataPlot):
 
         # work out labels
         labels = self.pargs.pop('labels', self.channels)
-        if isinstance(labels, (unicode, str)):
+        if isinstance(labels, string_types):
             labels = labels.split(',')
         labels = map(lambda s: str(s).strip('\n '), labels)
 
@@ -554,7 +556,7 @@ class TriggerRateDataPlot(TimeSeriesDataPlot):
 
         # work out labels
         labels = self.pargs.pop('labels', None)
-        if isinstance(labels, (unicode, str)):
+        if isinstance(labels, string_types):
             labels = labels.split(',')
         elif labels is None and self.column and len(self.channels) > 1:
             labels = []

--- a/gwsumm/segments.py
+++ b/gwsumm/segments.py
@@ -29,6 +29,8 @@ except ImportError:
 import warnings
 import operator
 
+from six import string_types
+
 try:
     from astropy.io.registry import IORegistryError
 except ImportError:  # astropy < 1.2
@@ -69,7 +71,7 @@ def get_segments(flag, validity=None, config=ConfigParser(), cache=None,
     -------
     FIXME
     """
-    if isinstance(flag, (unicode, str)):
+    if isinstance(flag, string_types):
         flags = flag.split(',')
     else:
         flags = flag
@@ -215,7 +217,7 @@ def get_segments(flag, validity=None, config=ConfigParser(), cache=None,
             out[compound].active &= validity
             if coalesce:
                 out[compound].coalesce()
-        if isinstance(flag, basestring):
+        if isinstance(flag, string_types):
             return out[flag]
         else:
             return out
@@ -263,7 +265,7 @@ def format_padding(flags, padding):
     """Format an arbitrary collection of paddings into a `dict`
     """
     # parse string to start with
-    if isinstance(padding, str):
+    if isinstance(padding, string_types):
         padding = list(eval(str))
     # zip list into dict
     if (isinstance(padding, (list)) or

--- a/gwsumm/tabs/builtin.py
+++ b/gwsumm/tabs/builtin.py
@@ -30,6 +30,8 @@ The `builtin` classes provide interfaces for simple operations including
 import os.path
 import warnings
 
+from six import string_types
+
 from .registry import (get_tab, register_tab)
 from ..plot import get_plot
 from ..utils import (re_quote, re_cchar)
@@ -278,18 +280,18 @@ class PlotTab(Tab):
             self._layout = None
             return
         # parse a single int
-        if isinstance(l, int) or (isinstance(l, str) and l.isdigit()):
+        if isinstance(l, int) or (isinstance(l, string_types) and l.isdigit()):
             self._layout = [int(l)]
             return
         # otherwise parse as a list of ints or pairs of ints
-        if isinstance(l, str):
+        if isinstance(l, string_types):
             l = l.split(',')
         self._layout = []
         for e in l:
             if isinstance(e, int):
                 self._layout.append(e)
                 continue
-            if isinstance(e, str):
+            if isinstance(e, string_types):
                 e = e.strip('([').rstrip(')]').split(',')
             if not isinstance(e, (list, tuple)) or not len(e) == 2:
                 raise ValueError("Cannot parse layout element %r (%s)"
@@ -411,7 +413,7 @@ class PlotTab(Tab):
             either the URL of a plot to embed, or a formatted `SummaryPlot`
             object.
         """
-        if isinstance(plot, str):
+        if isinstance(plot, string_types):
             plot = SummaryPlot(href=plot)
             plot.new = False
         if not isinstance(plot, SummaryPlot):
@@ -626,7 +628,7 @@ class StateTab(PlotTab):
             # allow default indication by trailing asterisk
             if state == default:
                 default_ = True
-            elif (default is None and isinstance(state, str) and
+            elif (default is None and isinstance(state, string_types) and
                     state.endswith('*')):
                 state = state[:-1]
                 default_ = True

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -38,6 +38,8 @@ import re
 from urlparse import urlparse
 from shutil import copyfile
 
+from six import string_types
+
 from gwpy.utils.compat import OrderedDict
 
 from gwpy.time import (from_gps, to_gps)
@@ -1154,7 +1156,7 @@ class TabList(list):
     @classmethod
     def from_ini(cls, config, tag='tab[_-]', match=[],
                  path=os.curdir, plotdir='plots'):
-        if isinstance(tag, str):
+        if isinstance(tag, string_types):
             tag = re.compile(tag)
         tabs = cls()
         parents = {}

--- a/gwsumm/tabs/etg.py
+++ b/gwsumm/tabs/etg.py
@@ -22,6 +22,8 @@
 import os
 from warnings import warn
 
+from six import string_types
+
 from astropy.io.registry import (register_reader, get_reader)
 
 from glue.lal import Cache
@@ -99,8 +101,8 @@ class EventTriggerTab(get_tab('default')):
         if etg is None:
             etg = self.name
         self.etg = etg
-        if table is None or isinstance(table, str):
-            tablename = isinstance(table, str) and table or self.etg
+        if table is None or isinstance(table, string_types):
+            tablename = isinstance(table, string_types) and table or self.etg
             try:
                 table = get_etg_table(tablename)
             except KeyError as e:
@@ -244,7 +246,7 @@ class EventTriggerTab(get_tab('default')):
     def process(self, *args, **kwargs):
         error = None
         # read the cache files
-        if isinstance(self.cache, str) and os.path.isfile(self.cache):
+        if isinstance(self.cache, string_types) and os.path.isfile(self.cache):
             with open(self.cache, 'r') as fobj:
                 try:
                     self.cache = Cache.fromfile(fobj).sieve(
@@ -254,7 +256,7 @@ class EventTriggerTab(get_tab('default')):
                         error = 'could not parse event cache file'
                     else:
                         raise
-        elif isinstance(self.cache, str):
+        elif isinstance(self.cache, string_types):
             error = 'could not locate event cache file'
             warn("Cache file %s not found." % self.cache)
         elif self.cache is not None and not isinstance(self.cache, Cache):

--- a/gwsumm/tabs/fscan.py
+++ b/gwsumm/tabs/fscan.py
@@ -22,6 +22,8 @@
 import os
 import glob
 
+from six import string_types
+
 from dateutil import parser
 
 from .registry import (get_tab, register_tab)
@@ -84,7 +86,7 @@ class FscanTab(base):
     def process(self, config=GWSummConfigParser(), **kwargs):
         # find all plots
         self.plots = []
-        if isinstance(self.directory, str):
+        if isinstance(self.directory, string_types):
             plots = sorted(
                 glob.glob(os.path.join(self.directory, 'spec_*.png')),
                 key=lambda p: float(os.path.basename(p).split('_')[1]))

--- a/gwsumm/tabs/guardian.py
+++ b/gwsumm/tabs/guardian.py
@@ -26,6 +26,8 @@ try:
 except ImportError:
     from ordereddict import OrderedDict
 
+from six import string_types
+
 from dateutil import tz
 
 import numpy
@@ -382,7 +384,7 @@ class GuardianStatePlot(get_plot('segments')):
         flags = map(lambda f: str(f).replace('_', r'\_'), self.flags)
         labels = self.pargs.pop('labels', self.pargs.pop('label', flags))
         ax.set_insetlabels(self.pargs.pop('insetlabels', True))
-        if isinstance(labels, (unicode, str)):
+        if isinstance(labels, string_types):
             labels = labels.split(',')
         labels = map(lambda s: re_quote.sub('', str(s).strip('\n ')), labels)
 

--- a/gwsumm/tabs/hveto.py
+++ b/gwsumm/tabs/hveto.py
@@ -23,6 +23,8 @@ import os
 import re
 from glob import glob
 
+from six import string_types
+
 from numpy import loadtxt
 
 from astropy.io.registry import register_reader
@@ -364,9 +366,9 @@ def read_hveto_triggers(f, columns=HVETO_COLUMNS, filt=None, nproc=1):
     # format list of files
     if isinstance(f, CacheEntry):
         files = [f.path]
-    elif isinstance(f, (str, unicode)) and f.endswith(('.cache', '.lcf')):
+    elif isinstance(f, string_types) and f.endswith(('.cache', '.lcf')):
         files = open_cache(f).pfnlist()
-    elif isinstance(f, (str, unicode)):
+    elif isinstance(f, string_types):
         files = f.split(',')
     elif isinstance(f, Cache):
         files = f.pfnlist()

--- a/gwsumm/tabs/stamp.py
+++ b/gwsumm/tabs/stamp.py
@@ -23,6 +23,8 @@ import os
 import re
 import glob
 
+from six import string_types
+
 from .registry import (get_tab, register_tab)
 
 from .. import (html, globalv)
@@ -73,7 +75,7 @@ class StampPEMTab(base):
     def process(self, config=GWSummConfigParser(), **kwargs):
         # find all plots
         self.plots = []
-        if isinstance(self.directory, str):
+        if isinstance(self.directory, string_types):
             plots = sorted(
                 glob.glob(os.path.join(self.directory, 'DAY_*.png')),
                 key=lambda p: float(re.split('[-_]', os.path.basename(p))[1]))

--- a/gwsumm/triggers.py
+++ b/gwsumm/triggers.py
@@ -22,6 +22,8 @@
 import re
 import warnings
 
+from six import string_types
+
 import numpy
 from numpy.lib import recfunctions
 
@@ -117,7 +119,7 @@ def register_etg_table(etg, table, force=False):
     KeyError
         if a `str` table cannot be resolved to a specific class
     """
-    if isinstance(table, str):
+    if isinstance(table, string_types):
         try:
             table = lsctables.TableByName[table]
         except KeyError as e:

--- a/gwsumm/utils.py
+++ b/gwsumm/utils.py
@@ -25,6 +25,8 @@ import re
 from multiprocessing import (cpu_count, active_children)
 from socket import getfqdn
 
+from six import string_types
+
 # import filter evals
 from math import pi
 import numpy
@@ -184,7 +186,7 @@ def safe_eval(val, strict=False, globals_=None, locals_=None):
         for more documentation on the underlying evaluation method
     """
     # don't evaluate non-strings
-    if not isinstance(val, str):
+    if not isinstance(val, string_types):
         return val
     # check that we aren't evaluating something dangerous
     try:


### PR DESCRIPTION
This PR updates all `isinstance(..., str)` calls to use `six.string_types`.