### PR TITLE
allow a trigger filter option

### DIFF
--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -379,7 +379,7 @@ class DataTab(ProcessedTab, ParentTab):
 
     def process_state(self, state, nds=None, multiprocess=True,
                       config=GWSummConfigParser(), datacache=None,
-                      trigcache=None, segmentcache=None,
+                      trigcache=None, segmentcache=None, filterstr=None,
                       segdb_error='raise', datafind_error='raise'):
         """Process data for this tab in a given state
 
@@ -540,7 +540,7 @@ class DataTab(ProcessedTab, ParentTab):
                                               all_data=all_data, state=state):
             get_triggers(channel, etg, state.active, config=config,
                          cache=trigcache, multiprocess=multiprocess,
-                         return_=False)
+                         filterstr=filterstr, return_=False)
 
         # --------------------------------------------------------------------
         # make plots

--- a/gwsumm/tabs/etg.py
+++ b/gwsumm/tabs/etg.py
@@ -98,6 +98,7 @@ class EventTriggerTab(get_tab('default')):
         self.url = url
         self.error = dict()
         # parse ETG and LIGO_LW table class
+        self.filterstr = None
         if etg is None:
             etg = self.name
         self.etg = etg
@@ -181,6 +182,12 @@ class EventTriggerTab(get_tab('default')):
         # set ETG for plots
         for p in new.plots + new.subplots:
             p.etg = new.etg.lower()
+
+        # get trigger filter
+        if config.has_option(section, 'trigger-filter'):
+            new.filterstr = config.get(section, 'trigger-filter')
+        else:
+            new.filterstr = None
 
         # get loudest options
         if config.has_option(section, 'loudest'):
@@ -280,6 +287,7 @@ class EventTriggerTab(get_tab('default')):
     def process_state(self, state, *args, **kwargs):
         if self.error.get(state, None):
             return
+        kwargs['filterstr'] = self.filterstr
         super(EventTriggerTab, self).process_state(state, *args, **kwargs)
 
     def write_state_html(self, state, pre=None):
@@ -317,7 +325,7 @@ class EventTriggerTab(get_tab('default')):
             if self.loudest:
                 # get triggers
                 table = get_triggers(self.channel, self.plots[0].etg, state,
-                                     query=False)
+                                     filterstr=self.filterstr, query=False)
                 # set table headers
                 headers = list(self.loudest['labels'])
                 columns = list(self.loudest['columns'])


### PR DESCRIPTION
This allows the optional setting of a trigger-filter string in the config file which is used to remove some triggers for display. You can use anything that is a column in the data table. For example the following

trigger-filter = template_duration > 0.7    template_duration < 500 

produces

https://ldas-jobs.ligo-wa.caltech.edu/~ahnitz/gwpysoft/L1/day/20161130/detchar/pycbc_live/

The arguments are processed left to right. 