### PR TITLE
Changed trigger filtering to read triggers only once and filter

### DIFF
--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -324,8 +324,6 @@ class DataPlot(SummaryPlot):
             filts = "".join(map(str,
                 [getattr(c, 'filter', getattr(c, 'frequency_response', ''))
                  for c in self.channels]))
-            if self.filterstr:
-                filts = "".join([filts,self.filterstr])
             self._pid = hashlib.md5(chans+filts).hexdigest()[:6]
             return self.pid
 

--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -324,6 +324,8 @@ class DataPlot(SummaryPlot):
             filts = "".join(map(str,
                 [getattr(c, 'filter', getattr(c, 'frequency_response', ''))
                  for c in self.channels]))
+            if self.filterstr:
+                filts = "".join([filts,self.filterstr])
             self._pid = hashlib.md5(chans+filts).hexdigest()[:6]
             return self.pid
 

--- a/gwsumm/plot/triggers.py
+++ b/gwsumm/plot/triggers.py
@@ -216,7 +216,8 @@ class TriggerDataPlot(TimeSeriesDataPlot):
                                  self.state and str(self.state) or 'All')
             else:
                 key = str(channel)
-            table = get_triggers(key, self.etg, valid, query=False)
+            table = get_triggers(key, self.etg, valid,
+                                 filterstr=self.filterstr, query=False)
             ntrigs += len(table)
             # access channel parameters for limits
             for c, column in zip(('x', 'y', 'c'), (xcolumn, ycolumn, ccolumn)):
@@ -451,7 +452,8 @@ class TriggerHistogramPlot(get_plot('histogram')):
                                  self.state and str(self.state) or 'All')
             else:
                 key = str(channel)
-            table_ = get_triggers(key, self.etg, valid, query=False)
+            table_ = get_triggers(key, self.etg, valid,
+                                  filterstr=self.filterstr, query=False)
             livetime.append(float(abs(table_.segments)))
             data.append(get_table_column(table_, self.column))
             # allow channel data to set parameters
@@ -591,7 +593,8 @@ class TriggerRateDataPlot(TimeSeriesDataPlot):
                 key = '%s,%s' % (str(channel), state and str(state) or 'All')
             else:
                 key = str(channel)
-            table_ = get_triggers(key, self.etg, valid, query=False)
+            table_ = get_triggers(key, self.etg, valid,
+                                  filterstr=self.filterstr, query=False)
             if self.column:
                 rates = binned_event_rates(
                     table_, stride, self.column, bins, operator, self.start,

--- a/gwsumm/tabs/etg.py
+++ b/gwsumm/tabs/etg.py
@@ -179,15 +179,17 @@ class EventTriggerTab(get_tab('default')):
                 pass
         new = super(EventTriggerTab, cls).from_ini(config, section, **kwargs)
 
-        # set ETG for plots
-        for p in new.plots + new.subplots:
-            p.etg = new.etg.lower()
 
         # get trigger filter
         if config.has_option(section, 'trigger-filter'):
             new.filterstr = config.get(section, 'trigger-filter')
         else:
             new.filterstr = None
+
+        # set ETG and trigger filter for plots
+        for p in new.plots + new.subplots:
+            p.etg = new.etg.lower()
+            p.filterstr = new.filterstr
 
         # get loudest options
         if config.has_option(section, 'loudest'):


### PR DESCRIPTION
Filter strings are used when returning the trigger set instead of when reading, so the master trigger set is stored in global memory. Filter strings are processed in the md5 hash for each plot to differentiate the different sets of plots.

Working example here:

https://ldas-jobs.ligo-wa.caltech.edu/~tjmassin/summary/filterstr/day/20170113/detchar/pycbc_live_short/