### PR TITLE
Added 'State Information' section to HTML output of DataTab

### DIFF
--- a/gwsumm/state/core.py
+++ b/gwsumm/state/core.py
@@ -66,6 +66,8 @@ class SummaryState(DataQualityFlag):
     key : `str`, optional
         registry key for this state, defaults to :attr:`~SummaryState.name`
     """
+    MATH_DEFINITION = re.compile('(%s)' % '|'.join(MATHOPS.keys()))
+
     def __init__(self, name, known=SegmentList(), active=SegmentList(),
                  description=None, definition=None, hours=None, key=None,
                  filename=None, url=None):
@@ -286,14 +288,10 @@ class SummaryState(DataQualityFlag):
         if self.ready:
             return self
         # fetch data
-        if self.definition:
-            match = re.search('(%s)' % '|'.join(MATHOPS.keys()),
-                              self.definition)
-        else:
-            match = None
+        match = self.MATH_DEFINITION.search(str(self.definition))
         if self.filename:
             self._read_segments(self.filename)
-        elif match:
+        elif self.definition and match is not None:
             channel, thresh = self.definition.split(match.groups()[0])
             channel = channel.rstrip()
             thresh = float(thresh.strip())

--- a/gwsumm/tabs/etg.py
+++ b/gwsumm/tabs/etg.py
@@ -390,6 +390,9 @@ class EventTriggerTab(get_tab('default')):
                     page.div.close()
                     page.hr(class_='row-divider')
 
+            # write state information
+            page.add(str(self.write_state_information(state)))
+
         # write to file
         idx = self.states.index(state)
         with open(self.frames[idx], 'w') as fobj:


### PR DESCRIPTION
This PR modifies the `DataTab.write_state_html` method to print a `State Information` section, including the defintion and segments for the state of a given page.