### PR TITLE
Updated build-and-test configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,46 +2,68 @@ language: python
 
 addons:
   apt:
+    sources:
+      - sourceline: deb http://software.ligo.org/lscsoft/debian wheezy contrib
+        key_url: http://software.ligo.org/keys/deb/lscsoft.key
+      - sourceline: deb-src http://software.ligo.org/lscsoft/debian wheezy contrib
+        key_url: http://software.ligo.org/keys/deb/lscsoft.key
     packages:
+      - pkg-config  # lal
+      - zlib1g-dev  # lal
+      - libgsl0-dev  # lal
+      - swig  # lal
+      - bc  # lal
+      - libfftw3-dev  # lal
+      - libframe-dev  # lalframe
       - gcc  # nds2
       - gfortran  # numpy/scipy
       - libblas-dev  # numpy/scipy
       - liblapack-dev  # numpy/scipy
-      - swig  # m2crypto
       - libhdf5-serial-dev
 
+python:
+  - '2.6'
+  - '2.7'
+  - '3.5'
+
+env:
+  global:
+    - LAL_VERSION="6.18.0"
+    - LALFRAME_VERSION="1.4.3"
+    - NDS2_CLIENT_VERSION="0.11.2"
+  matrix:
+    - PIP_FLAGS="--quiet"
+    - PIP_FLAGS="--quiet --pre"
+
 matrix:
-  include:
-    - python: 2.6
-    - python: 2.7
-      env: PRE=""
-    - python: 3.5
-    - python: nightly
-    - python: 2.7
-      env: PRE="--pre"
+  exclude:
+    - python: '2.6'
+      env: PIP_FLAGS="--quiet --pre"
   allow_failures:
-    - python: 2.6
-    - python: 3.5
-    - python: nightly
-    - python: 2.7
-      env: PRE="--pre"
+    - python: '2.6'
+    - python: '3.5'
+    - python: '2.7'
+      env: PIP_FLAGS="--quiet --pre"
   fast_finish: true
 
 before_install:
-  - . .travis/build-src-dependencies.sh
   - pip install -q --upgrade pip
   - pip install ${PRE} -r requirements.txt
+  - . .travis/build-src-dependencies.sh
   - pip install ${PRE} -q coveralls "pytest>=2.8" pytest-runner unittest2
   # need to install astropy 1.1 specifically for py26
   - if [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]]; then pip install "astropy==1.1"; fi
 
 install:
-  - pip install .
+  # note: need --editable for executable coverage with `which ...` to work
+  - pip install --editable .
 
 script:
-  - coverage run --source=gwsumm --omit="gwsumm/tests/*,gwsumm/*version*" ./setup.py test
-  - coverage run --append --source=gwsumm --omit="gwsumm/tests/*,gwsumm/*version*" `which gw_summary` --help
-  - coverage run --append --source=gwsumm --omit="gwsumm/tests/*,gwsumm/*version*" `which gw_summary_pipe` --help
+  # run test suite
+  - coverage run ./setup.py test
+  # test executables
+  - coverage run --append `which gw_summary` --help
+  - coverage run --append `which gw_summary_pipe` --help
 
 after_success:
   - coveralls
@@ -49,3 +71,7 @@ after_success:
 cache:
   apt: true
   pip: true
+  directories:
+    - lal-${LAL_VERSION}
+    - lalframe-${LALFRAME_VERSION}
+    - nds2-client-${NDS2_CLIENT_VERSION}

--- a/.travis/build-src-dependencies.sh
+++ b/.travis/build-src-dependencies.sh
@@ -17,7 +17,7 @@ build-package() {
     wget $remote -O $tarball --quiet
     # unpack
     mkdir -p $tag
-    tar -zxf $tarball --strip-components=1 -C $tag
+    tar -xf $tarball --strip-components=1 -C $tag
     cd $tag
     # build and install
     ./configure --enable-silent-rules --quiet --prefix=$PREFIX $@
@@ -28,10 +28,11 @@ build-package() {
     rm -rf $tag $tarball
 }
 
-# build ldas-tools
-LDAS_TOOLS_VERSION="2.4.2"
-build-package ${REMOTE_SOURCE}/ldas-tools-${LDAS_TOOLS_VERSION}.tar.gz
-
 # build NDS2
-NDS2_CLIENT_VERSION="0.11.2"
 build-package ${REMOTE_SOURCE}/nds2-client-${NDS2_CLIENT_VERSION}.tar.gz --disable-swig-java --disable-mex-matlab
+
+# build LAL
+build-package ${REMOTE_SOURCE}/lalsuite/lal-${LAL_VERSION}.tar.xz --enable-swig-python
+
+# build LALFrame
+build-package ${REMOTE_SOURCE}/lalsuite/lalframe-${LALFRAME_VERSION}.tar.xz --enable-swig-python

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,9 @@ versionfile_source = gwsumm/_version.py
 versionfile_build = gwsumm/_version.py
 tag_prefix = v
 parentdir_prefix =
+
+[coverage:run]
+source = gwsumm
+omit =
+	gwsumm/tests/*
+	gwsumm/*version*


### PR DESCRIPTION
This PR updates the travis-ci build-and-test configuration as follows:

- added LAL build
- replaced LDAS_TOOLS with LALFrame build
- improved configuration with build/env matrix
- added coverage configuration to `setup.cfg`