### PR TITLE
Filter events on `get` op, not `read`

### DIFF
--- a/gwsumm/plot/triggers.py
+++ b/gwsumm/plot/triggers.py
@@ -598,8 +598,8 @@ class TriggerRateDataPlot(TimeSeriesDataPlot):
                     stride, self.column, bins, operator, self.start,
                     self.end, timecolumn=tcol).values()
             else:
-                rates = [table.event_rate(stride, self.start, self.end,
-                                          timecolumn=tcol)]
+                rates = [table_.event_rate(stride, self.start, self.end,
+                                           timecolumn=tcol)]
             for bin, rate in zip(bins, rates):
                 rate.channel = channel
                 keys.append('%s_%s_EVENT_RATE_%s_%s'

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -380,7 +380,7 @@ class DataTab(ProcessedTab, ParentTab):
 
     def process_state(self, state, nds=None, multiprocess=True,
                       config=GWSummConfigParser(), datacache=None,
-                      trigcache=None, segmentcache=None, filterstr=None,
+                      trigcache=None, segmentcache=None, trigfilter=None,
                       segdb_error='raise', datafind_error='raise'):
         """Process data for this tab in a given state
 
@@ -405,6 +405,10 @@ class DataTab(ProcessedTab, ParentTab):
             `Cache` of files from which to read event triggers
         segmentcache : `~glue.lal.Cache`, optional
             `Cache` of files from which to read segments
+        trigfilter : `str`, optional
+            event table filter, either as space-separated `str` or `list`
+            of `str` components of the form ``column>threshold``, e.g.
+            ``snr>10``
         segdb_error : `str`, optional
             if ``'raise'``: raise exceptions when the segment database
             reports exceptions, if ``'warn''`, print warnings but continue,
@@ -541,7 +545,7 @@ class DataTab(ProcessedTab, ParentTab):
                                               all_data=all_data, state=state):
             get_triggers(channel, etg, state.active, config=config,
                          cache=trigcache, multiprocess=multiprocess,
-                         filterstr=filterstr, return_=False)
+                         filter=trigfilter, return_=False)
 
         # --------------------------------------------------------------------
         # make plots

--- a/gwsumm/tabs/etg.py
+++ b/gwsumm/tabs/etg.py
@@ -155,15 +155,17 @@ class EventTriggerTab(get_tab('default')):
                 pass
         new = super(EventTriggerTab, cls).from_ini(config, section, **kwargs)
 
-        # set ETG for plots
-        for p in new.plots + new.subplots:
-            p.etg = new.etg.lower()
 
         # get trigger filter
-        if config.has_option(section, 'trigger-filter'):
-            new.filterstr = config.get(section, 'trigger-filter')
+        if config.has_option(section, 'event-filter'):
+            new.filterstr = config.get(section, 'event-filter')
         else:
             new.filterstr = None
+
+        # set ETG and trigger filter for plots
+        for p in new.plots + new.subplots:
+            p.etg = new.etg.lower()
+            p.filterstr = new.filterstr
 
         # get loudest options
         if config.has_option(section, 'loudest'):
@@ -263,7 +265,7 @@ class EventTriggerTab(get_tab('default')):
     def process_state(self, state, *args, **kwargs):
         if self.error.get(state, None):
             return
-        kwargs['filterstr'] = self.filterstr
+        kwargs['trigfilter'] = self.filterstr
         super(EventTriggerTab, self).process_state(state, *args, **kwargs)
 
     def write_state_html(self, state, pre=None):
@@ -301,7 +303,7 @@ class EventTriggerTab(get_tab('default')):
             if self.loudest:
                 # get triggers
                 table = get_triggers(self.channel, self.plots[0].etg, state,
-                                     filterstr=self.filterstr, query=False)
+                                     filter=self.filterstr, query=False)
                 # set table headers
                 headers = list(self.loudest['labels'])
                 columns = list(self.loudest['columns'])


### PR DESCRIPTION
This PR improves the event filtering options to apply the filter on the `get` operation, not the `read`, so that two tabs can use the same dataset with different filtering.

This renames the configuration option for the `EventTriggerTab` to `event-filter`.

This closes #138 (supersedes).