### PR TITLE
Don't force known segments on everything in get_segments

### DIFF
--- a/gwsumm/segments.py
+++ b/gwsumm/segments.py
@@ -211,8 +211,6 @@ def get_segments(flag, validity=None, config=ConfigParser(), cache=None,
                     if coalesce:
                         segs = segs.coalesce()
                     out[compound] = op(out[compound], segs)
-                    out[compound].known &= segs.known
-                    out[compound].active &= segs.known
             out[compound].known &= validity
             out[compound].active &= validity
             if coalesce:


### PR DESCRIPTION
This PR modifies `get_segments` to not force the `known` segments for components of a compound flag on everything, and to just let DataQualityFlag handle the mathematical compounding of multiple flags.