### PR TITLE
Added support for frequency-response files

### DIFF
--- a/gwsumm/io.py
+++ b/gwsumm/io.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2017)
+#
+# This file is part of GWSumm.
+#
+# GWSumm is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWSumm is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWSumm.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Input/output utilities
+"""
+
+import os.path
+import re
+
+from astropy.io.registry import IORegistryError
+
+from gwpy.frequencyseries import FrequencySeries
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+HDF5_FILENAME = re.compile('(?P<ext>(.hdf5|.hdf|.h5))\/')
+
+
+def read_frequencyseries(filename):
+    """Read a `~gwpy.frequencyseries.FrequencySeries` from a file
+
+    IF using HDF5, the filename can be given as a combined filename/path, i.e.
+    ``test.hdf5/path/to/dataset``.
+
+    Parameters
+    ----------
+    filename : `str`
+        path of file to read
+
+    Returns
+    -------
+    series : `~gwpy.frequencyseries.FrequencySeries`
+        the data as read
+
+    Raises
+    ------
+    astropy.io.registry.IORegistryError
+        if the input format cannot be identified or is not registered
+    """
+    # try and parse path in HDF5 file if given
+    try:
+        ext = HDF5_FILENAME.search(filename).groupdict()['ext']
+    except AttributeError:  # no match
+        kwargs = {}
+    else:
+        kwargs = {'path': filename.rsplit(ext, 1)[1]}
+    # read file
+    try:
+        return FrequencySeries.read(filename, **kwargs)
+    except IORegistryError as e:
+        if filename.endswith('.gz'):
+            fmt = os.path.splitext(filename[:-3])[-1]
+        else:
+            fmt = os.path.splitext(filename)[-1]
+        return FrequencySeries.read(filename, format=fmt.lstrip('.'), **kwargs)

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -40,12 +40,11 @@ except ImportError:
 from astropy.units import Quantity
 from astropy.io.registry import IORegistryError
 
-from gwpy.frequencyseries import FrequencySeries
 from gwpy.plotter import *
 from gwpy.plotter.tex import label_to_latex
 from gwpy.segments import SegmentList
 
-from .. import globalv
+from .. import (globalv, io)
 from ..mode import (Mode, get_mode)
 from ..utils import re_cchar
 from ..data import (get_channel, get_timeseries, get_spectrogram,
@@ -331,16 +330,10 @@ class SpectrogramDataPlot(TimeSeriesDataPlot):
             else:
                 ratio = getattr(allspec, ratio)(axis=0)
         elif isinstance(ratio, string_types) and os.path.isfile(ratio):
-            try:  # try auto-identify format
-                ratio = FrequencySeries.read(ratio)
+            try:
+                ratio = io.read_frequencyseries(ratio)
             except IOError as e:  # skip if file can't be read
                 warnings.warn('IOError: %s' % str(e))
-            except IORegistryError as e:  # try format identification
-                if ratio.endswith('.gz'):
-                    fmt = os.path.splitext(ratio[:-3])[-1]
-                else:
-                    fmt = os.path.splitext(ratio)[-1]
-                ratio = FrequencySeries.read(ratio, format=fmt.lstrip('.'))
 
         # allow channel data to set parameters
         if getattr(channel, 'frequency_range', None) is not None:
@@ -527,17 +520,10 @@ class SpectrumDataPlot(DataPlot):
         for i, ref in enumerate(refs):
             if 'source' in ref:
                 source = ref.pop('source')
-                try:  # try auto-identify format
-                    refspec = FrequencySeries.read(source)
+                try:
+                    refspec = io.read_frequencyseries(source)
                 except IOError as e:  # skip if file can't be read
                     warnings.warn('IOError: %s' % str(e))
-                except IORegistryError as e:  # try format identification
-                    if source.endswith('.gz'):
-                        fmt = os.path.splitext(source[:-3])[-1]
-                    else:
-                        fmt = os.path.splitext(source)[-1]
-                    refspec = FrequencySeries.read(source,
-                                                   format=fmt.lstrip('.'))
                 else:
                     ref.setdefault('zorder', -len(refs) + 1)
                     if 'filter' in ref:
@@ -966,17 +952,10 @@ class SpectralVarianceDataPlot(SpectrumDataPlot):
         for i, ref in enumerate(refs):
             if 'source' in ref:
                 source = ref.pop('source')
-                try:  # try auto-identify format
-                    refspec = FrequencySeries.read(source)
+                try:
+                    refspec = io.read_frequencyseries(source)
                 except IOError as e:  # skip if file can't be read
                     warnings.warn('IOError: %s' % str(e))
-                except IORegistryError as e:  # try format identification
-                    if source.endswith('.gz'):
-                        fmt = os.path.splitext(source[:-3])[-1]
-                    else:
-                        fmt = os.path.splitext(source)[-1]
-                    refspec = FrequencySeries.read(source,
-                                                   format=fmt.lstrip('.'))
                 else:
                     if 'filter' in ref:
                         refspec = refspec.filter(*ref.pop('filter'))


### PR DESCRIPTION
This PR adds support for passing a `frequency-response` filter as a filepath containing a transfer function measurement.