### PR TITLE
Updated dependencies to references lscsoft-glue and dqsegdb on pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,9 +48,9 @@ matrix:
 
 before_install:
   - pip install -q --upgrade pip
-  - pip install ${PRE} -r requirements.txt
+  - pip install ${PIP_FLAGS} -r requirements.txt
   - . .travis/build-src-dependencies.sh
-  - pip install ${PRE} -q coveralls "pytest>=2.8" pytest-runner unittest2
+  - pip install ${PIP_FLAGS} coveralls "pytest>=2.8" pytest-runner unittest2
   # need to install astropy 1.1 specifically for py26
   - if [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]]; then pip install "astropy==1.1"; fi
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -11,13 +11,9 @@ Dependencies
 The GWSumm package has the following build-time dependencies (i.e. required for installation):
 
 * `glue <https://www.lsc-group.phys.uwm.edu/daswg/projects/glue.html>`_
-* `NumPy <http://www.numpy.org>`_ >= 1.5
-* `Astropy <http://astropy.org>`_ >= 0.3
-* `GWpy <https://gwpy.github.io>`_ >= 0.1a5
-
-.. note::
-
-   The `GLUE <https://www.lsc-group.phys.uwm.edu/daswg/projects/glue.html>`_ package isn't available through PyPI, meaning you will have to install it manually from the link.
+* `NumPy <http://www.numpy.org>`_ >= 1.10
+* `Astropy <http://astropy.org>`_ >= 1.3
+* `GWpy <https://gwpy.github.io>`_ >= 0.3
 
 **Runtime dependencies**
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,11 @@ numpy>=1.10
 enum34
 pykerberos
 M2Crypto
-python-cjson
 h5py
 lxml
-https://github.com/ligovirgo/trigfind/archive/v0.4.tar.gz
-http://software.ligo.org/lscsoft/source/glue-1.53.0.tar.gz
-http://software.ligo.org/lscsoft/source/dqsegdb-1.4.0.tar.gz
+lscsoft-glue
+dqsegdb
+https://github.com/ligovirgo/trigfind/archive/v0.5.tar.gz
 gwpy>=0.3
 libsass
 jsmin

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ requires = [
     'numpy',
     'astropy',
     'matplotlib',
-    'lscsoft-glue',
+    'lscsoft_glue',
     'gwpy',
     'h5py',
     'dqsegdb',

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ requires = [
     'h5py',
     'dqsegdb',
     'lxml',
-    'trigfind>=0.3',
+    'trigfind',
 ]
 tests_require = [
     'pytest>=2.8'

--- a/setup.py
+++ b/setup.py
@@ -71,16 +71,17 @@ install_requires = [
     'matplotlib>=1.3.0',
     'astropy>=1.0',
     'gwpy>=0.3',
-    'trigfind>=0.2.1',
 ]
 requires = [
-    'glue',
     'numpy',
-    'matplotlib',
     'astropy',
+    'matplotlib',
+    'lscsoft-glue',
     'gwpy',
     'h5py',
+    'dqsegdb',
     'lxml',
+    'trigfind>=0.3',
 ]
 tests_require = [
     'pytest>=2.8'
@@ -229,8 +230,6 @@ setup(name=DISTNAME,
       requires=requires,
       extras_require=extras_require,
       dependency_links=[
-          'http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz',
-          'http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz',
           'https://github.com/ligovirgo/trigfind/archive/v0.3.tar.gz'
           '#egg=trigfind-0.3',
       ],


### PR DESCRIPTION
This PR updates the build/install infrastructure to reference the [`lscsoft-glue`](https://pypi.python.org/pypi/lscsoft-glue/) and [`dqsegdb`](https://pypi.python.org/pypi/dqsegdb/) packages on pypi.