### PR TITLE
Added package listing to About tab

### DIFF
--- a/gwsumm/html/bootstrap.py
+++ b/gwsumm/html/bootstrap.py
@@ -27,6 +27,7 @@ import os.path
 from six import string_types
 
 from . import markup
+from .tables import table
 from .utils import highlight_syntax
 from ..mode import (Mode, get_mode)
 from ..utils import re_cchar
@@ -390,7 +391,7 @@ def state_switcher(states, default=0):
     return page
 
 
-def about_this_page(cmdline=True, config=None):
+def about_this_page(cmdline=True, config=None, packagelist=True):
     """Write a blurb about the generation of this page, including the
     command-line arguments used, and the content of the configuration
     files.
@@ -449,6 +450,21 @@ def about_this_page(cmdline=True, config=None):
             page.div.close()
             page.div.close()
         page.div.close()
+    if packagelist:
+        try:
+            from pip import get_installed_distributions
+        except ImportError:
+            pass
+        else:
+            page.h2('Package list')
+            headers = ['Package name', 'Version']
+            data = sorted([(p.project_name, p.version) for p in
+                           get_installed_distributions(local_only=False)],
+                          key=lambda x: x[0].lower())
+            page.add(str(table(
+                headers, data, id='package-list',
+                caption=("The list of packages present on the "
+                         "system when this page was generated."))))
 
     page.div.close()
     page.div.close()


### PR DESCRIPTION
This PR modifies `gwsumm.html.bootstrap` to use `pip.get_installed_distributions` to produce a complete package listing that is printed to a new _Package List_ section of the _About_ page.