### PR TITLE
Added plot configuration option to hide state segments Axes

### DIFF
--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -100,23 +100,19 @@ class TimeSeriesDataPlot(DataLabelSvgMixin, DataPlot):
             kwargs.setdefault('facecolor', GREEN)
             kwargs.setdefault('known', {'facecolor': 'red',
                                         'edgecolor': 'darkred'})
-            sax = self.plot.add_state_segments(self.state, ax, plotargs=kwargs)
+            sax = self.plot.add_state_segments(self.state, ax, height=.2,
+                                               pad=.1,  plotargs=kwargs)
             ax.set_epoch(epoch)
             sax.set_epoch(epoch)
             sax.tick_params(axis='y', which='major', labelsize=12)
             sax.yaxis.set_ticks_position('none')
             sax.set_epoch(epoch)
+            ax.set_xlim(xlim)
+            ax.set_epoch(epoch)
+            return sax
         else:
-            try:
-                div = ax.get_axes_locator()._axes_divider
-            except AttributeError:
-                div = make_axes_locatable(ax)
-            div.append_axes('bottom', 0.2, 0.1, axes_class=SegmentAxes,
-                            sharex=ax, add_to_figure=False)
-            sax = None
-        ax.set_xlim(xlim)
-        ax.set_epoch(epoch)
-        return sax
+            self.plot.subplots_adjust(bottom=0.18)
+            return None
 
     def init_plot(self, plot=TimeSeriesPlot, geometry=(1, 1), **kwargs):
         """Initialise the Figure and Axes objects for this

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -118,15 +118,15 @@ class TimeSeriesDataPlot(DataLabelSvgMixin, DataPlot):
         ax.set_epoch(epoch)
         return sax
 
-    def init_plot(self, plot=TimeSeriesPlot, geometry=(1, 1)):
+    def init_plot(self, plot=TimeSeriesPlot, geometry=(1, 1), **kwargs):
         """Initialise the Figure and Axes objects for this
         `TimeSeriesDataPlot`.
         """
-        figsize = self.pargs.pop('figsize', [12, 6])
+        figsize = self.pargs.pop('figsize', kwargs.pop('figsize', [12, 6]))
         self.plot, axes = subplots(
             nrows=geometry[0], ncols=geometry[1], sharex=True,
             subplot_kw={'projection': plot._DefaultAxesClass.name},
-            FigureClass=plot, figsize=figsize, squeeze=True)
+            FigureClass=plot, figsize=figsize, squeeze=True, **kwargs)
         if geometry[0] * geometry[1] == 1:
             axes = [axes]
         for ax in axes:

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -91,6 +91,9 @@ class TimeSeriesDataPlot(DataLabelSvgMixin, DataPlot):
             :meth:`~gwpy.plotter.timeseries.TimeSeriesPlot.add_state_segments`
             method.
         """
+        # allow user to disable the state segments axes
+        if self.pargs.pop('no-state-segments', False):
+            visible = False
         epoch = ax.get_epoch()
         xlim = ax.get_xlim()
         if visible is None:

--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -573,6 +573,8 @@ class DataPlot(SummaryPlot):
 
     def apply_parameters(self, ax, **pargs):
         for key in pargs:
+            if key.startswith('no-'):  # skip no-xxx keys
+                continue
             val = pargs[key]
             if key in ['xlim', 'ylim'] and isinstance(val, string_types):
                 val = eval(val)


### PR DESCRIPTION
This PR improves the way state segment Axes are configured, including the addition of a new plot configuration option `no-state-segments` which if set to `True` will force the `TimeSeriesDataPlot.add_state_segments` method to use `visible=False`.

The motivation for this is to hide the state segments bar on those plots where the state is a fake, allowing data from the 'locked' or 'observing' states for each interferometer to be shown together, for example.