### PR TITLE
Added shading of future times in TimeSeriesDataPlots

### DIFF
--- a/gwsumm/plot/range.py
+++ b/gwsumm/plot/range.py
@@ -241,6 +241,7 @@ class SimpleTimeVolumeDataPlot(get_plot('segments')):
         if not plot.colorbars:
             plot.add_colorbar(ax=ax, visible=False)
         self.add_state_segments(ax)
+        self.add_future_shade()
         return self.finalize(outputfile=outputfile)
 
 register_plot(SimpleTimeVolumeDataPlot)

--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -297,6 +297,7 @@ class SegmentDataPlot(SegmentLabelSvgMixin, TimeSeriesDataPlot):
             plot.add_bitmask(mask, topdown=True)
 
         self.add_state_segments(ax)
+        self.add_future_shade()
 
         rcParams['ytick.labelsize'] = _labelsize
         return self.finalize()
@@ -456,6 +457,7 @@ class StateVectorDataPlot(TimeSeriesDataPlot):
             plot.add_bitmask(mask, topdown=True)
 
         self.add_state_segments(ax)
+        self.add_future_shade()
 
         return self.finalize()
 
@@ -735,6 +737,7 @@ class DutyDataPlot(SegmentDataPlot):
                 plot.add_colorbar(ax=ax, visible=False)
 
         self.add_state_segments(axes[-1])
+        self.add_future_shade()
 
         return self.finalize(outputfile=outputfile)
 
@@ -918,6 +921,7 @@ class ODCDataPlot(SegmentLabelSvgMixin, StateVectorDataPlot):
         if not plot.colorbars:
             plot.add_colorbar(ax=ax, visible=False)
         self.add_state_segments(ax)
+        self.add_future_shade()
         out = self.finalize()
         rcParams['ytick.labelsize'] = _labelsize
         return out


### PR DESCRIPTION
This PR fixes #41 by adding an `axvspan` between GPS 'now' and the end of the plot to indicate that portion of the Axes that exist in the future, so that people don't get confused why the plot is half-empty.

This can be disabled using the `no-future-shade` plot configuration option.