### PR TITLE
Use trusty dist for Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 
+sudo: false
+dist: trusty
+
 addons:
   apt:
     sources:


### PR DESCRIPTION
This PR modifies the travis-ci configuration to use the `trusty` ubuntu distributions, which should resolve LAL src build timeouts for py35.