### PR TITLE
Added plot autoscaling

### DIFF
--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -161,7 +161,9 @@ class TimeSeriesDataPlot(DataLabelSvgMixin, DataPlot):
         plot = self.plot
         ax = plot.axes[0]
         if 'xlim' not in self.pargs:
-            ax.set_xlim(float(self.start), float(self.end))
+            # add this to pargs to prevent autoscaling in DataPlot.finalize
+            self.pargs['xlim'] = (float(self.start), float(self.end))
+            ax.set_xlim(*self.pargs['xlim'])
         return super(TimeSeriesDataPlot, self).finalize(
                    outputfile=outputfile, close=close, **savekwargs)
 

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -844,22 +844,9 @@ class TimeSeriesHistogram2dDataPlot(TimeSeriesHistogramPlot):
         # plot
         pcmesh_kwargs = self.parse_pcmesh_kwargs()
         ax.pcolormesh(x, y, h.T, **pcmesh_kwargs)
+
         # customise plot
-        for key, val in self.pargs.iteritems():
-            try:
-                getattr(ax, 'set_%s' % key)(val)
-            except AttributeError:
-                if key == 'grid':
-                    if val == 'off':
-                        ax.grid('off')
-                    elif val in ['both', 'major', 'minor']:
-                        ax.grid('on', which=val)
-                    else:
-                        raise ValueError("Invalid ax.grid argument; "
-                                         "valid options are: 'off', "
-                                         "'both', 'major' or 'minor'")
-                else:
-                    setattr(ax, key, val)
+        self.apply_parameters(ax, **self.pargs)
         # add extra axes and finalise
         if not plot.colorbars:
             plot.add_colorbar(ax=ax, visible=False)

--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -531,6 +531,12 @@ class DataPlot(SummaryPlot):
             # move title up to create gap between axes
             if ax.get_title() and ax.title.get_position()[1] == 1.0:
                 ax.title.set_y(1.005)
+            # set tight limits around data
+            if 'xlim' not in self.pargs:
+                ax.autoscale(enable=True, axis='x', tight=True)
+            if 'ylim' not in self.pargs:
+                ax.autoscale(enable=True, axis='y', tight=True)
+
         # customise axes for mpl 1.x only
         if mpl_version < '2.0':
             for ax in self.plot.axes:

--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -577,17 +577,31 @@ class DataPlot(SummaryPlot):
             self.plot.close()
         return outputfile
 
-    def apply_parameters(self, ax, **pargs):
-        for key in pargs:
-            if key.startswith('no-'):  # skip no-xxx keys
-                continue
-            val = pargs[key]
-            if key in ['xlim', 'ylim'] and isinstance(val, string_types):
-                val = eval(val)
-            try:
-                getattr(ax, 'set_%s' % key)(val)
-            except AttributeError:
-                setattr(ax, key, val)
+    def apply_parameters(self, *axes, **pargs):
+        for ax in axes:
+            for key in pargs:
+                if key.startswith('no-'):  # skip no-xxx keys
+                    continue
+                val = pargs[key]
+                if key in ['xlim', 'ylim'] and isinstance(val, string_types):
+                    val = eval(val)
+                elif key == 'grid':
+                    self._apply_grid_params(ax, val)
+                    continue
+                try:
+                    getattr(ax, 'set_%s' % key)(val)
+                except AttributeError:
+                    setattr(ax, key, val)
+
+    def _apply_grid(self, ax, val):
+        if val == 'off':
+            ax.grid('off')
+        elif val in ['both', 'major', 'minor']:
+            ax.grid('on', which=val)
+        else:
+            raise ValueError("Invalid ax.grid argument; "
+                             "valid options are: 'off', "
+                             "'both', 'major' or 'minor'")
 
 
 register_plot(DataPlot)

--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -532,9 +532,9 @@ class DataPlot(SummaryPlot):
             if ax.get_title() and ax.title.get_position()[1] == 1.0:
                 ax.title.set_y(1.005)
             # set tight limits around data
-            if 'xlim' not in self.pargs:
+            if 'xlim' not in self.pargs and 'xbound' not in self.pargs:
                 ax.autoscale(enable=True, axis='x', tight=True)
-            if 'ylim' not in self.pargs:
+            if 'ylim' not in self.pargs and 'ybound' not in self.pargs:
                 ax.autoscale(enable=True, axis='y', tight=True)
 
         # customise axes for mpl 1.x only

--- a/gwsumm/plot/range.py
+++ b/gwsumm/plot/range.py
@@ -228,11 +228,7 @@ class SimpleTimeVolumeDataPlot(get_plot('segments')):
                         linestyle='--', color='red')
 
         # customise plot
-        for key, val in self.pargs.iteritems():
-            try:
-                getattr(ax, 'set_%s' % key)(val)
-            except AttributeError:
-                setattr(ax, key, val)
+        self.apply_parameters(ax, **self.pargs)
         if (len(self.channels) > 1 or plotargs[0].get('label', None) in
                 [re.sub(r'(_|\\_)', r'\_', str(self.channels[0])), None]):
             plot.add_legend(ax=ax, **legendargs)

--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -283,13 +283,9 @@ class SegmentDataPlot(SegmentLabelSvgMixin, TimeSeriesDataPlot):
             ax.set_xlim(*xlim)
 
         # customise plot
-        for key, val in self.pargs.iteritems():
-            try:
-                getattr(ax, 'set_%s' % key)(val)
-            except AttributeError:
-                setattr(ax, key, val)
         if 'ylim' not in self.pargs:
-            ax.set_ylim(-0.5, len(self.flags) - 0.5)
+            self.pargs['ylim'] = (-.5, len(self.flags) - 0.5)
+        self.apply_parameters(ax, **self.pargs)
 
         # add bit mask axes and finalise
         if mask is None and not plot.colorbars:
@@ -443,13 +439,9 @@ class StateVectorDataPlot(TimeSeriesDataPlot):
                 ax.plot(flag, **kwargs)
 
         # customise plot
-        for key, val in self.pargs.iteritems():
-            try:
-                getattr(ax, 'set_%s' % key)(val)
-            except AttributeError:
-                setattr(ax, key, val)
         if 'ylim' not in self.pargs:
-            ax.set_ylim(-0.5, nflags - 0.5)
+            self.pargs['ylim'] = (-5, nflags-.5)
+        self.apply_parameters(ax, **self.pargs)
 
         # add bit mask axes and finalise
         if mask is None and not plot.colorbars:
@@ -910,13 +902,9 @@ class ODCDataPlot(SegmentLabelSvgMixin, StateVectorDataPlot):
         ax.set_xlim(*xlim)
 
         # customise plot
-        for key, val in self.pargs.iteritems():
-            try:
-                getattr(ax, 'set_%s' % key)(val)
-            except AttributeError:
-                setattr(ax, key, val)
         if 'ylim' not in self.pargs:
-            ax.set_ylim(-nflags+0.5, 0.5)
+            self.pargs['ylim'] = (-nflags+.5, .5)
+        self.apply_parameters(ax, **self.pargs)
 
         # add bit mask axes and finalise
         if not plot.colorbars:

--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -678,12 +678,7 @@ class DutyDataPlot(SegmentDataPlot):
                 bottom += height
 
         # customise plot
-        for key, val in self.pargs.iteritems():
-            for ax in axes:
-                try:
-                    getattr(ax, 'set_%s' % key)(val)
-                except AttributeError:
-                    setattr(ax, key, val)
+        self.apply_parameters(ax, **self.pargs)
         if 'hours' in self.pargs.get('ylabel', ''):
             ax.get_yaxis().get_major_locator().set_params(
                 steps=[1, 2, 4, 8, 12, 24])
@@ -1042,11 +1037,7 @@ class SegmentPiePlot(PiePlot, SegmentDataPlot):
         legt.set_ha('left')
 
         # customise plot
-        for key, val in self.pargs.iteritems():
-            try:
-                getattr(ax, 'set_%s' % key)(val)
-            except AttributeError:
-                setattr(ax, key, val)
+        self.apply_parameters(ax, **self.pargs)
 
         # copy title and move axes
         if ax.get_title():
@@ -1237,11 +1228,7 @@ class SegmentBarPlot(BarPlot, SegmentDataPlot):
         self.pargs.setdefault('xlim', (-.5, len(data)-.5))
 
         # customise plot
-        for key, val in self.pargs.iteritems():
-            try:
-                getattr(ax, 'set_%s' % key)(val)
-            except AttributeError:
-                setattr(ax, key, val)
+        self.apply_parameters(ax, **self.pargs)
 
         # add bit mask axes and finalise
         self.pargs['xlim'] = None

--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -440,7 +440,7 @@ class StateVectorDataPlot(TimeSeriesDataPlot):
 
         # customise plot
         if 'ylim' not in self.pargs:
-            self.pargs['ylim'] = (-5, nflags-.5)
+            self.pargs['ylim'] = (-.5, nflags-.5)
         self.apply_parameters(ax, **self.pargs)
 
         # add bit mask axes and finalise

--- a/gwsumm/plot/triggers.py
+++ b/gwsumm/plot/triggers.py
@@ -252,7 +252,7 @@ class TriggerDataPlot(TriggerPlotMixin, TimeSeriesDataPlot):
                           label=label, **pargs)
 
         # customise plot
-        legendargs = self.parse_legend_kwargs(markerscale=4)
+        legendargs = self.parse_legend_kwargs(markerscale=3)
         logx = self.pargs.pop('logx', self.pargs.pop('xscale', None) == 'log')
         logy = self.pargs.pop('logy', self.pargs.pop('yscale', None) == 'log')
         if len(self.channels) == 1:

--- a/gwsumm/plot/triggers.py
+++ b/gwsumm/plot/triggers.py
@@ -380,11 +380,7 @@ class TriggerTimeSeriesDataPlot(TimeSeriesDataPlot):
 
         # customise plot
         legendargs = self.parse_legend_kwargs()
-        for key, val in self.pargs.iteritems():
-            try:
-                getattr(ax, 'set_%s' % key)(val)
-            except AttributeError:
-                setattr(ax, key, val)
+        self.apply_parameters(ax, **self.pargs)
         if len(self.channels) > 1:
             plot.add_legend(ax=ax, **legendargs)
 


### PR DESCRIPTION
This PR implements tight autoscaling for X and Y axes for all plots by default, which is disabled for a given plot/axes if the user specifies a limit (or a bound) for that axis in the configuration.