### PR TITLE
Simplified trigger reading in read_cache() method

### DIFF
--- a/gwsumm/triggers.py
+++ b/gwsumm/triggers.py
@@ -480,14 +480,6 @@ def read_cache(cache, segments, etg, nproc=1, timecolumn=None, **kwargs):
 
     if len(cache) == 0:
         return
-    # use multiprocessing except for ascii reading
-    # (since astropy doesn't allow it)
-    if kwargs.get('format', 'none').startswith('ascii.'):
-        cache = cache.pfnlist()
-    else:
-        kwargs['nproc'] = nproc
-    if len(cache) == 1:
-        cache = cache[0]
 
     # read triggers
     table = EventTable.read(cache, **kwargs)

--- a/gwsumm/triggers.py
+++ b/gwsumm/triggers.py
@@ -474,10 +474,10 @@ def read_cache(cache, segments, etg, nproc=1, timecolumn=None, **kwargs):
         cache = cache.sieve(segmentlist=segments)
         cache = cache.checkfilesexist()[0]
         cache.sort(key=lambda x: x.segment[0])
-        if etg == 'pycbc_live':  # remove empty HDF5 files
-            cache = type(cache)(
-                filter_pycbc_live_files(cache, ifo=kwargs['ifo']))
-    # if no files, skip
+        cache = cache.pfnlist()  # some readers only like filenames
+    if etg == 'pycbc_live':  # remove empty HDF5 files
+        cache = filter_pycbc_live_files(cache, ifo=kwargs['ifo'])
+
     if len(cache) == 0:
         return
     # use multiprocessing except for ascii reading


### PR DESCRIPTION
This PR simplifies some of the (now) unnecessary logic in `gwsumm.triggers.read_cache` now that GWpy provides a generic multiprocessing I/O interface for all file formats.