### PR TITLE
Included gwsumm-plot-* executables in CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,8 @@ script:
   # test executables
   - coverage run --append `which gw_summary` --help
   - coverage run --append `which gw_summary_pipe` --help
+  - coverage run --append `which gwsumm-plot-triggers` --help
+  - coverage run --append `which gwsumm-plot-guardian` --help
 
 after_success:
   - coveralls

--- a/bin/gwsumm-plot-triggers
+++ b/bin/gwsumm-plot-triggers
@@ -14,7 +14,6 @@ from matplotlib.colors import LogNorm
 from glue.lal import Cache
 
 from gwpy.segments import Segment
-from gwpy.table.utils import get_row_value
 from gwpy.time import to_gps
 from gwpy.plotter import EventTablePlot
 


### PR DESCRIPTION
This PR adds the two `gwsumm-plot-*` executables to the `script:` portion of the CI build, allowing a simple test that they link properly (i.e. imports work).