### PR TITLE
Fixed bugs in testing archive module

### DIFF
--- a/gwsumm/archive.py
+++ b/gwsumm/archive.py
@@ -269,7 +269,7 @@ def _write_object(data, *args, **kwargs):
     except ValueError as e:
         warnings.warn(str(e))
     except RuntimeError as e:
-        if 'Name already exists' in str(e):
+        if 'name already exists' in str(e).lower():
             warnings.warn(str(e))
         else:
             raise

--- a/gwsumm/tests/test_archive.py
+++ b/gwsumm/tests/test_archive.py
@@ -49,6 +49,7 @@ TEST_DATA.channel = channels.get_channel(TEST_DATA.channel)
 
 def empty_globalv():
     globalv.DATA = type(globalv.DATA)()
+    globalv.SPECTROGRAMS = type(globalv.SPECTROGRAMS)()
     globalv.SEGMENTS = type(globalv.SEGMENTS)()
     globalv.TRIGGERS = type(globalv.TRIGGERS)()
 


### PR DESCRIPTION
This PR fixes some bugs in the testing of the `gwsumm.archive` module

- [a0d8a1d] compare error messages using lower case
- [f9a3433] empty `globalv.SPECTROGRAMS` between tests

The use of the `empty_globalv` is still quicky hacky, and could probably do with being cleaned up, but it works to purpose at the moment.