### PR TITLE
Renamed multiprocess keyword to nproc everywhere

### DIFF
--- a/bin/gw_summary
+++ b/bin/gw_summary
@@ -437,10 +437,6 @@ elif duration > 40000:
 else:
      fft_lal.LAL_FFTPLAN_LEVEL = 1
 
-# set processing options
-if opts.multiprocess == 1:
-    opts.multiprocess = False
-
 # set global html only flag
 if opts.html_only:
     globalv.HTMLONLY = True
@@ -659,13 +655,13 @@ if opts.bulk_read and not opts.html_only:
                % len(allts))
         get_timeseries_dict(allts, allseg,
                             config=config, nds=opts.nds,
-                            multiprocess=opts.multiprocess, return_=False)
+                            nproc=opts.multiprocess, return_=False)
     if len(allsv):
         vprint("%d channels identified for StateVector from all tabs...\n"
                % len(allsv))
         get_timeseries_dict(allsv, allseg,
                             config=config, nds=opts.nds, statevector=True,
-                            multiprocess=opts.multiprocess, return_=False)
+                            nproc=opts.multiprocess, return_=False)
 
 # -----------------------------------------------------------------------------
 # Process all tabs
@@ -681,7 +677,7 @@ for tab in tablist:
     if not opts.html_only and isinstance(tab, get_tab('_processed')):
         vprint("Processing %s\n" % name)
         tab.process(config=config, nds=opts.nds,
-                    multiprocess=opts.multiprocess,
+                    nproc=opts.multiprocess,
                     segdb_error=opts.on_segdb_error,
                     datafind_error=opts.on_datafind_error, **cache)
     if not tab.hidden and not isinstance(tab, get_tab('link')):

--- a/bin/gwsumm-plot-guardian
+++ b/bin/gwsumm-plot-guardian
@@ -8,7 +8,6 @@ __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 import argparse
 import os
 import re
-from multiprocessing import cpu_count
 
 from collections import OrderedDict
 
@@ -27,8 +26,6 @@ from gwsumm.tabs import GuardianTab
 
 GWSummConfigParser.OPTCRE = re.compile(
     r'(?P<option>[^=\s][^=]*)\s*(?P<vi>[=])\s*(?P<value>.*)$')
-
-DEFAULT_NPROC = min(8, cpu_count())
 
 
 def safe_eval(val):
@@ -55,7 +52,7 @@ parser.add_argument('-t', '--epoch', type=to_gps,
                     help='Zero-time for plot, defaults to GPSSTART')
 parser.add_argument('-p', '--plot-params', action='append', default=[],
                     help='extra plotting keyword argument')
-parser.add_argument('-m', '--multi-process', type=int, default=DEFAULT_NPROC,
+parser.add_argument('-m', '--multi-process', type=int, default=1,
                     dest='nproc',
                     help='number of processes to use, default: %(default)s')
 parser.add_argument('-o', '--output-file', default='trigs.png',
@@ -105,7 +102,7 @@ tab.plots[0].pargs['epoch'] = args.epoch
 
 # process
 vprint("Processing:\n")
-tab.process(multiprocess=args.nproc)
+tab.process(nproc=args.nproc)
 plotfile = tab.plots[0].outputfile
 os.rename(plotfile, args.output_file)
 vprint('Plot saved to %s\n' % args.output_file)

--- a/gwsumm/data/range.py
+++ b/gwsumm/data/range.py
@@ -53,7 +53,7 @@ def get_range_channel(channel, **rangekwargs):
 
 @use_segmentlist
 def get_range(channel, segments, config=None, cache=None,
-              query=True, nds=None, return_=True, multiprocess=True,
+              query=True, nds=None, return_=True, nproc=1,
               datafind_error='raise', frametype=None,
               stride=None, fftlength=None, overlap=None,
               method=None, **rangekwargs):
@@ -76,7 +76,7 @@ def get_range(channel, segments, config=None, cache=None,
     if query:
         # get spectrograms
         spectrograms = get_spectrogram(channel, new, config=config,
-                                       cache=cache, multiprocess=multiprocess,
+                                       cache=cache, nproc=nproc,
                                        frametype=frametype, format='psd',
                                        datafind_error=datafind_error, nds=nds,
                                        stride=stride, fftlength=fftlength,

--- a/gwsumm/state/core.py
+++ b/gwsumm/state/core.py
@@ -280,7 +280,7 @@ class SummaryState(DataQualityFlag):
         return self
 
     def fetch(self, config=GWSummConfigParser(), segdb_error='raise',
-              datafind_error='raise', multiprocess=True, **kwargs):
+              datafind_error='raise', nproc=1, **kwargs):
         """Finalise this state by fetching its defining segments,
         either from global memory, or from the segment database
         """
@@ -297,7 +297,7 @@ class SummaryState(DataQualityFlag):
             thresh = float(thresh.strip())
             self._fetch_data(channel, thresh, match.groups()[0], config=config,
                              datafind_error=datafind_error,
-                             multiprocess=multiprocess, **kwargs)
+                             nproc=nproc, **kwargs)
         # fetch segments
         elif self.definition:
             self._fetch_segments(config=config, segdb_error=segdb_error,

--- a/gwsumm/tabs/guardian.py
+++ b/gwsumm/tabs/guardian.py
@@ -155,7 +155,7 @@ class GuardianTab(DataTab):
             ))
         return new
 
-    def process(self, nds=None, multiprocess=True,
+    def process(self, nds=None, nproc=1,
                 config=GWSummConfigParser(), datacache=None,
                 segmentcache=Cache(), datafind_error='raise', **kwargs):
         """Process data for the given state.
@@ -181,7 +181,7 @@ class GuardianTab(DataTab):
         prefices = ['STATE_N', 'REQUEST_N', 'NOMINAL_N', 'OK', 'MODE', 'OP']
         alldata = get_timeseries_dict(
             [prefix % x for x in prefices],
-            state, config=config, nds=nds, multiprocess=multiprocess,
+            state, config=config, nds=nds, nproc=nproc,
             cache=datacache, datafind_error=datafind_error,
             dtype='int32').values()
         vprint("    All time-series data loaded\n")
@@ -225,7 +225,7 @@ class GuardianTab(DataTab):
             globalv.SEGMENTS += {self.segmenttag % 'OK': oksegs}
 
         super(GuardianTab, self).process(
-            config=config, nds=nds, multiprocess=multiprocess,
+            config=config, nds=nds, nproc=nproc,
             datacache=datacache, segmentcache=segmentcache, **kwargs)
 
     def write_state_html(self, state):

--- a/gwsumm/tabs/management.py
+++ b/gwsumm/tabs/management.py
@@ -130,7 +130,7 @@ class AccountingTab(ParentTab):
 
         return new
 
-    def process(self, nds=None, multiprocess=True,
+    def process(self, nds=None, nproc=1,
                 config=GWSummConfigParser(), datacache=None,
                 datafind_error='raise', **kwargs):
         """Process time accounting data
@@ -151,7 +151,7 @@ class AccountingTab(ParentTab):
         data = get_timeseries(self.channel, new,
                               config=config, nds=nds, dtype='int16',
                               datafind_error=datafind_error,
-                              multiprocess=multiprocess, cache=datacache)
+                              nproc=nproc, cache=datacache)
         vprint("    All time-series data loaded\n")
 
         # find segments
@@ -173,7 +173,7 @@ class AccountingTab(ParentTab):
 
         kwargs['segdb_error'] = 'ignore'
         super(AccountingTab, self).process(
-            config=config, nds=nds, multiprocess=multiprocess,
+            config=config, nds=nds, nproc=nproc,
             segmentcache=Cache(), datacache=datacache,
             datafind_error=datafind_error, **kwargs)
 

--- a/gwsumm/tests/test_data.py
+++ b/gwsumm/tests/test_data.py
@@ -200,16 +200,16 @@ class TestData(object):
         a = TimeSeries([1, 2, 3, 4, 5], name='test name', epoch=0,
                        sample_rate=1)
         data.add_timeseries(a)
-        b, = data.get_timeseries('test name', [(0, 5)], multiprocess=False)
+        b, = data.get_timeseries('test name', [(0, 5)], nproc=1)
         nptest.assert_array_equal(a.value, b.value)
         assert a.sample_rate.value == b.sample_rate.value
 
         # test more complicated add with a cache
         a, = data.get_timeseries('H1:LOSC-STRAIN', LOSC_SEGMENTS,
                                  cache=self.FRAMES['H1:LOSC-STRAIN'],
-                                 multiprocess=False)
+                                 nproc=1)
         b, = data.get_timeseries('H1:LOSC-STRAIN', LOSC_SEGMENTS,
-                                 multiprocess=False)
+                                 nproc=1)
         nptest.assert_array_equal(a.value, b.value)
 
     @empty_globalv_CHANNELS
@@ -217,30 +217,30 @@ class TestData(object):
         with pytest.raises(TypeError):
             data.get_spectrogram('H1:LOSC-STRAIN', LOSC_SEGMENTS,
                                  cache=self.FRAMES['H1:LOSC-STRAIN'],
-                                 multiprocess=False)
+                                 nproc=1)
         a = data.get_spectrogram('H1:LOSC-STRAIN', LOSC_SEGMENTS,
                                  cache=self.FRAMES['H1:LOSC-STRAIN'],
                                  stride=4, fftlength=2, overlap=1,
-                                 multiprocess=False)
+                                 nproc=1)
 
     def test_get_spectrum(self):
         a, _, _ = data.get_spectrum('H1:LOSC-STRAIN', LOSC_SEGMENTS,
                                     cache=self.FRAMES['H1:LOSC-STRAIN'],
-                                    multiprocess=False)
+                                    nproc=1)
         b, _, _ = data.get_spectrum('H1:LOSC-STRAIN', LOSC_SEGMENTS,
                                     format='asd',
                                     cache=self.FRAMES['H1:LOSC-STRAIN'],
-                                    multiprocess=False)
+                                    nproc=1)
         nptest.assert_array_equal(a.value ** (1/2.), b.value)
 
     def test_get_coherence_spectrogram(self):
         cache = Cache([e for c in self.FRAMES for e in self.FRAMES[c]])
         a = data.get_coherence_spectrogram(
             ('H1:LOSC-STRAIN', 'L1:LOSC-STRAIN'), LOSC_SEGMENTS, cache=cache,
-            stride=4, fftlength=2, overlap=1, multiprocess=False)
+            stride=4, fftlength=2, overlap=1, nproc=1)
 
     def test_get_coherence_spectrum(self):
         cache = Cache([e for c in self.FRAMES for e in self.FRAMES[c]])
         a = data.get_coherence_spectrogram(
             ('H1:LOSC-STRAIN', 'L1:LOSC-STRAIN'), LOSC_SEGMENTS, cache=cache,
-            stride=4, fftlength=2, overlap=1, multiprocess=False)
+            stride=4, fftlength=2, overlap=1, nproc=1)

--- a/gwsumm/tests/test_utils.py
+++ b/gwsumm/tests/test_utils.py
@@ -97,11 +97,6 @@ def test_which():
         os.environ = environ
 
 
-def test_count_free_cores():
-    assert utils.count_free_cores() == cpu_count() - 2
-    assert utils.count_free_cores(2) == 0
-
-
 @pytest.mark.parametrize('chan, mask', [
     ('L1:TEST-ODC_CHANNEL_OUT_DQ', 'L1:TEST-ODC_CHANNEL_BITMASK'),
     ('L1:TEST-ODC_CHANNEL_OUTMON', 'L1:TEST-ODC_CHANNEL_BITMASK'),

--- a/gwsumm/triggers.py
+++ b/gwsumm/triggers.py
@@ -35,7 +35,7 @@ from gwpy.segments import (DataQualityFlag, SegmentList)
 import trigfind
 
 from . import globalv
-from .utils import (re_cchar, vprint, count_free_cores, safe_eval)
+from .utils import (re_cchar, vprint, safe_eval)
 from .config import (GWSummConfigParser, NoSectionError)
 from .channels import get_channel
 
@@ -134,7 +134,7 @@ def get_etg_table(etg):
 
 def get_triggers(channel, etg, segments, config=GWSummConfigParser(),
                  cache=None, columns=None, format=None, query=True,
-                 multiprocess=False, ligolwtable=None, filter=None,
+                 nproc=1, ligolwtable=None, filter=None,
                  timecolumn=None, return_=True):
     """Read a table of transient event triggers for a given channel.
     """
@@ -143,14 +143,6 @@ def get_triggers(channel, etg, segments, config=GWSummConfigParser(),
     if isinstance(segments, DataQualityFlag):
         segments = segments.active
     segments = SegmentList(segments)
-
-    # get processes
-    if multiprocess is True:
-        nproc = count_free_cores()
-    elif multiprocess is False:
-        nproc = 1
-    else:
-        nproc = multiprocess
 
     # get read keywords for this etg
     read_kw = get_etg_read_kwargs(etg, config=config, exclude=[])

--- a/gwsumm/utils.py
+++ b/gwsumm/utils.py
@@ -22,7 +22,6 @@
 import os
 import sys
 import re
-from multiprocessing import (cpu_count, active_children)
 from socket import getfqdn
 
 from six import string_types
@@ -132,15 +131,6 @@ def which(program):
             exe_file = os.path.join(path, program)
             if is_exe(exe_file):
                 return exe_file
-
-
-def count_free_cores(max=cpu_count()):
-    """Count the number of CPU cores not currently used by this job.
-    """
-    if max is True:
-        max = cpu_count()
-    active = 1
-    return max - (active + 1)
 
 
 _re_odc = re.compile('(OUTMON|OUT_DQ|LATCH)')


### PR DESCRIPTION
This PR changes `multiprocess={False,True}` to `nproc=1` across the board, bringing the keyword name more in line with gwpy, and setting a standard default of serial processing across the board, which is easier to maintain.