### PR TITLE
Improved parsing of ETG options in gwsumm.triggers

### DIFF
--- a/gwsumm/triggers.py
+++ b/gwsumm/triggers.py
@@ -263,6 +263,8 @@ def get_triggers(channel, etg, segments, config=GWSummConfigParser(),
         else:  # map to LIGO_LW table with full column listing
             tab = EventTable(lsctables.New(TableClass), get_as_columns=True)
         tab.meta['segments'] = SegmentList()
+        if read_kw.get('timecolumn'):
+            tab.meta['timecolumn'] = read_kw['timecolumn']
         add_triggers(tab, key)
 
     # work out time function

--- a/gwsumm/triggers.py
+++ b/gwsumm/triggers.py
@@ -160,6 +160,22 @@ def get_triggers(channel, etg, segments, config=GWSummConfigParser(),
           read_kw['columns'] = columns
     columns = read_kw.pop('columns', None)
 
+    # override with user options
+    if format:
+        read_kw['format'] = format
+    elif not read_kw.get('format', None):
+        read_kw['format'] = etg.lower()
+    if timecolumn:
+        read_kw['timecolumn'] = timecolumn
+    elif columns is not None and 'time' in columns:
+        read_kw['timecolumn'] = 'time'
+
+    # replace columns keyword
+    if read_kw['format'].startswith('ascii.'):
+        read_kw['include_names'] = columns
+    else:
+        read_kw['columns'] = columns
+
     # parse filters
     if filter:
         read_kw['selection'].extend(parse_column_filters(filter))
@@ -184,22 +200,6 @@ def get_triggers(channel, etg, segments, config=GWSummConfigParser(),
              (k[9:], read_kw.pop(k)) for k in read_kw.keys() if
              k.startswith('trigfind-'))
         trigfindetg = trigfindkwargs.pop('etg', etg)
-
-        # override with user options
-        if format:
-            read_kw['format'] = format
-        elif not read_kw.get('format', None):
-            read_kw['format'] = etg.lower()
-        if timecolumn:
-            read_kw['timecolumn'] = timecolumn
-        elif columns is not None and 'time' in columns:
-            read_kw['timecolumn'] = 'time'
-
-        # replace columns keyword
-        if read_kw['format'].startswith('ascii.'):
-            read_kw['include_names'] = columns
-        else:
-            read_kw['columns'] = columns
 
         # customise kwargs for this ETG
         if etg.lower().replace('-', '_') in ['pycbc_live']:

--- a/gwsumm/triggers.py
+++ b/gwsumm/triggers.py
@@ -439,7 +439,7 @@ def read_cache(cache, segments, etg, nproc=1, timecolumn=None, **kwargs):
     # append new events to existing table
     try:
         csegs = cache_segments(cache) & segments
-    except (AttributeError, TypeError):
+    except (AttributeError, TypeError, ValueError):
         csegs = SegmentList()
     table.meta['segments'] = csegs
 


### PR DESCRIPTION
This PR improves the parsing and defaults for ETG I/O options, mainly to support the following combination of options

```
etg = cwb
format = cwb.ascii
```

By default the code used to presume `etg='cwb'` always meant the ROOT format, which meant the I/O keywords were getting overloaded with `treename='waveburst'`, which doesn't work when reading the ASCII format.