### PR TITLE
Reworked dependency specification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ matrix:
 
 before_install:
   - python -m pip install --upgrade pip
-  - python -m pip install ${PIP_FLAGS} lalsuite
   - python -m pip install ${PIP_FLAGS} -r requirements.txt
 
 install:

--- a/gwsumm/tests/common.py
+++ b/gwsumm/tests/common.py
@@ -16,16 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Compatibility module to import unittest
+"""Compatibility module
 """
 
 import sys
 from functools import wraps
-
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
 
 from gwsumm import globalv
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,31 @@
-numpy>=1.10
-astropy>=1.2.1
-matplotlib>=2.0
-enum34
-pykerberos
-h5py
-lxml
-lscsoft-glue>=1.56.0
-dqsegdb>=1.4.2
-https://github.com/ligovirgo/trigfind/archive/v0.5.tar.gz
-gwpy>=0.8.1
+# build requirements
+setuptools
 libsass
 jsmin
+
+# core requirements
+enum34 ; python_version < '3'
+dateutil
+lxml
+numpy>=1.10
+matplotlib>=2.0
+astropy>=1.2.1
+lalsuite
+lscsoft-glue>=1.56.0
+gwpy>=0.8.1
+
+# optional extras (not module-level imports)
+pykerberos
+h5py
+dqsegdb>=1.4.2
+https://github.com/gwpy/trigfind/archive/v0.5.tar.gz
+ligo-gracedb
+
+# testing extras
+pytest>=2.8
+mock ; python_version < '3'
+
+# docs extras
+sphinx
 astropy_helpers < 3.0 ; python_version < '3'
 astropy_helpers ; python_version >= '3'
-ligo_gracedb

--- a/setup.py
+++ b/setup.py
@@ -61,41 +61,44 @@ else:
 
 # -- dependencies -------------------------------------------------------------
 
+# build requirements
 setup_requires = [
-    'pytest-runner',
     'libsass',
     'jsmin',
 ]
+
+# install requirements (module-level imported packages)
 install_requires = [
-    'numpy>=1.10',
-    'matplotlib>=1.3.0',
-    'astropy>=1.2.1',
-    'gwpy>=0.9.0',
-]
-requires = [
-    'numpy',
-    'astropy',
-    'matplotlib',
-    'lscsoft_glue',
-    'gwpy',
-    'h5py',
-    'dqsegdb',
+    'dateutil',
     'lxml',
-    'trigfind',
+    'numpy>=1.10',
+    'matplotlib>=2.0',
+    'astropy>=1.2.1',
+    'lalsuite',
+    'lscsoft-glue>=1.56.0',
+    'gwpy>=0.8.1',
 ]
+if sys.version < '3':
+    install_requires.append('enum34')
+
+# testing requirements
+if {'pytest', 'test'}.intersection(sys.argv):
+    setup_requires.append('pytest_runner')  # python setup.py test
 tests_require = [
     'pytest>=2.8'
 ]
-extras_require = {
-    'doc': ['sphinx', 'numpydoc', 'sphinx-bootstrap-theme', 'astropy_helpers'],
-}
-
-# version-specific packages
 if sys.version < '3':
-    install_requires.append('enum34')
-    requires.append('enum34')
-if sys.version < '2.7':
-    tests_require.append('unittest2')
+    tests_require.append('mock')
+
+# extras
+extras_require = {
+    'docs': [
+        'sphinx',
+        'numpydoc',
+        'sphinx-bootstrap-theme',
+        'astropy_helpers',
+    ],
+}
 
 # -- data files ---------------------------------------------------------------
 
@@ -228,11 +231,11 @@ setup(name=DISTNAME,
       scripts=scripts,
       setup_requires=setup_requires,
       install_requires=install_requires,
-      requires=requires,
+      tests_require=tests_require,
       extras_require=extras_require,
       dependency_links=[
-          'https://github.com/ligovirgo/trigfind/archive/v0.3.tar.gz'
-          '#egg=trigfind-0.3',
+          'https://github.com/gwpy/trigfind/archive/v0.6.1.tar.gz'
+          '#egg=trigfind-0.6.1',
       ],
       data_files=data_files,
       use_2to3=True,


### PR DESCRIPTION
This PR updates updates `requirements.txt` and `setup.py` to include all module-level imports as `install_requires`, and everything else as `requires`, and removes any python2.6 specials.