### PR TITLE
Cast sieve segment to glue.segments.segment

### DIFF
--- a/gwsumm/data/timeseries.py
+++ b/gwsumm/data/timeseries.py
@@ -38,7 +38,7 @@ from astropy import units
 
 from lal.utils import CacheEntry
 
-from glue import (datafind, lal as glue_lal)
+from glue import (datafind, lal as glue_lal, segments as glue_segments)
 
 from gwpy.io import nds2 as io_nds2
 from gwpy.io.cache import cache_segments
@@ -654,7 +654,11 @@ def _get_timeseries_dict(channels, segments, config=None,
                                       **ioargs)
                 vprint(' [Done]\n')
             else:  # read
-                segcache = fcache.sieve(segment=segment)
+                # NOTE: this sieve explicitly casts our segment to
+                #       glue.segments.segment to prevent `TypeError` from
+                #       a mismatch with ligo.segments.segment
+                segcache = fcache.sieve(
+                    segment=glue_segments.segment(*segment))
                 segstart, segend = map(float, segment)
                 tsd = DictClass.read(segcache, qchannels, start=segstart,
                                      end=segend, nproc=nproc,


### PR DESCRIPTION
This PR fixes a `TypeError` when sieve a `Cache` of GWF file paths, because of the mismatch between the two segments libraries in C. This can be removed when `glue.segments` just points at `ligo.segments`