### PR TITLE
Fixed some issues with channels

### DIFF
--- a/gwsumm/archive.py
+++ b/gwsumm/archive.py
@@ -92,7 +92,7 @@ def write_data_archive(outfile, channels=True, timeseries=True,
                         chan.ndsname,
                         chan.sample_rate.to('Hz').value if
                             chan.sample_rate else 0,
-                        getattr(chan, 'frametype', None) or '',
+                        str(getattr(chan, 'frametype', None)) or '',
                         str(chan.unit) if chan.unit else '',
                     ))
                 Table(names=cols, rows=rows).write(h5file, 'channels')

--- a/gwsumm/archive.py
+++ b/gwsumm/archive.py
@@ -36,6 +36,8 @@ import os
 
 from numpy import (unicode_, ndarray)
 
+from astropy.table import Table
+
 from gwpy.time import (from_gps, to_gps)
 from gwpy.timeseries import (StateVector, TimeSeries)
 from gwpy.spectrogram import Spectrogram
@@ -51,8 +53,8 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 re_rate = re.compile('_EVENT_RATE_')
 
 
-def write_data_archive(outfile, timeseries=True, spectrogram=True,
-                       segments=True, triggers=True):
+def write_data_archive(outfile, channels=True, timeseries=True,
+                       spectrogram=True, segments=True, triggers=True):
     """Build and save an HDF archive of data processed in this job.
 
     Parameters
@@ -79,6 +81,21 @@ def write_data_archive(outfile, timeseries=True, spectrogram=True,
 
     try:
         with File(outfile, 'w') as h5file:
+
+            # -- channels -----------------------
+
+            if channels:
+                cols = ('name', 'sample_rate', 'frametype', 'unit')
+                rows = []
+                for chan in globalv.CHANNELS:
+                    rows.append((
+                        chan.ndsname,
+                        chan.sample_rate.to('Hz').value if
+                            chan.sample_rate else 0,
+                        getattr(chan, 'frametype', None) or '',
+                        str(chan.unit) if chan.unit else '',
+                    ))
+                Table(names=cols, rows=rows).write(h5file, 'channels')
 
             # -- timeseries ---------------------
 
@@ -164,6 +181,19 @@ def read_data_archive(sourcefile):
     from h5py import File
 
     with File(sourcefile, 'r') as h5file:
+
+        # -- channels ---------------------------
+
+        try:
+            ctable = Table.read(h5file['channels'])
+        except KeyError:
+            pass
+        else:
+            for row in ctable:
+                chan = get_channel(row['name'])
+                for p in ctable.colnames[1:]:
+                    if row[p]:
+                        setattr(chan, p, row[p])
 
         # -- timeseries -------------------------
 

--- a/gwsumm/data/spectral.py
+++ b/gwsumm/data/spectral.py
@@ -348,7 +348,7 @@ def get_spectrum(channel, segments, config=None, cache=None,
 
     # read data for all sub-channels
     specs = []
-    channels = list(zip(*parse_math_definition(str(channel))[0]))[0]
+    channels = parse_math_definition(str(channel))[0].keys()
     if len(channels) == 0:
         channels = [channel]
     for c in channels:

--- a/gwsumm/data/timeseries.py
+++ b/gwsumm/data/timeseries.py
@@ -863,6 +863,7 @@ def add_timeseries(timeseries, key=None, coalesce=True):
         coalesce contiguous series after adding, defaults to `True`
     """
     if timeseries.channel is not None:
+        # transfer parameters from timeseries.channel to the globalv channel
         update_missing_channel_params(timeseries.channel)
     if key is None:
         key = timeseries.name or timeseries.channel.ndsname

--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -39,8 +39,10 @@ from gwpy.detector import (Channel, ChannelList)
 from gwpy.plot import Plot
 from gwpy.plot.tex import label_to_latex
 
-from ..channels import (get_channel, split as split_channels)
+from ..channels import (get_channel, split as split_channels,
+                        split_combination as split_channel_combination)
 from ..config import GWSummConfigParser
+from ..data import parse_math_definition
 from ..state import get_state
 from ..utils import (vprint, safe_eval, re_quote)
 from . import utils as putils
@@ -292,13 +294,10 @@ class DataPlot(SummaryPlot):
     def allchannels(self):
         """List of all unique channels for this plot
         """
-        out = type(self.channels)()
-        for c in self.channels:
-            for m in Channel.MATCH.finditer(c.ndsname):
-                c2 = get_channel(c.ndsname[m.start():m.end()])
-                if c2 not in out:
-                    out.append(c2)
-        return out
+        return type(self.channels)(OrderedDict.fromkeys(
+            c2 for c in self.channels for
+            c2 in split_channel_combination(c.ndsname)
+        ).keys())
 
     @property
     def ifos(self):

--- a/gwsumm/tests/test_channels.py
+++ b/gwsumm/tests/test_channels.py
@@ -24,6 +24,8 @@ import pytest
 
 from astropy import units
 
+from gwpy.detector import ChannelList
+
 from gwsumm import (globalv, channels)
 from gwsumm.mode import (get_mode, set_mode)
 
@@ -135,4 +137,6 @@ def test_split(cstr, clist):
      ['G1:DER_DATA_H-rms', 'G1:DER_DATA_BLAH']),
 ])
 def test_split_combination(cstr, clist):
-    assert channels.split_combination(cstr) == clist
+    split = channels.split_combination(cstr)
+    assert isinstance(split, ChannelList)
+    assert map(str, split), clist

--- a/gwsumm/tests/test_data.py
+++ b/gwsumm/tests/test_data.py
@@ -24,6 +24,7 @@ import os.path
 import operator
 import tempfile
 import shutil
+from collections import OrderedDict
 
 from six.moves.urllib.request import urlopen
 
@@ -151,21 +152,19 @@ class TestData(object):
 
     @pytest.mark.parametrize('definition, math', [
         ('L1:TEST + L1:TEST2', (
-            [('L1:TEST', []),
-             ('L1:TEST2', [])],
+            [('L1:TEST', 'L1:TEST2'), ([], [])],
             [operator.add])),
         ('L1:TEST + L1:TEST2 * 2', (
-            [('L1:TEST', []),
-             ('L1:TEST2', [(operator.mul, 2)])],
+            [('L1:TEST', 'L1:TEST2'), ([], [(operator.mul, 2)])],
             [operator.add])),
        ('L1:TEST * 2 + L1:TEST2 ^ 5', (
-            [('L1:TEST', [(operator.mul, 2)]),
-             ('L1:TEST2', [(operator.pow, 5)])],
+            [('L1:TEST', 'L1:TEST2'),
+             ([(operator.mul, 2)], [(operator.pow, 5)])],
             [operator.add])),
     ])
     def test_parse_math_definition(self, definition, math):
         chans, operators = mathutils.parse_math_definition(definition)
-        assert chans == math[0]
+        assert chans == OrderedDict(zip(*math[0]))
         assert operators == math[1]
 
     # -- test add/get methods -------------------


### PR DESCRIPTION
This PR implements two updates to channel interactions

- archive the channel list in a table, which means data-based parameters (`sample_rate`, etc) are restored on each run
- link math channels (`X1:TEST * 2`) back to the real channel (`X1:TEST`) so that declared parameters are copied from one to the other.