### PR TITLE
Updated trigfind -> gwtrigfind

### DIFF
--- a/bin/gw_scan_loudest
+++ b/bin/gw_scan_loudest
@@ -37,8 +37,9 @@ from glue import pipeline
 
 from gwpy.segments import (Segment, SegmentList, DataQualityFlag)
 from gwpy.table.lsctables import SnglBurstTable
-from gwpy.table.io import trigfind
 from gwpy.time import to_gps
+
+import gwtrigfind
 
 from gwsumm import __version__
 
@@ -245,8 +246,8 @@ print('%d segments found, %ds livetime' % (len(segments.active),
 # -----------------------------------------------------------------------------
 # Read triggers
 
-cache = trigfind.find_trigger_urls(args.channel, args.trigger_generator,
-                                   args.gpsstart, args.gpsend, verbose=True)
+cache = gwtrigfind.find_trigger_files(args.channel, args.trigger_generator,
+                                      args.gpsstart, args.gpsend, verbose=True)
 
 # check files
 if len(cache) == 0:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -294,4 +294,5 @@ intersphinx_mapping = {
     'astropy': ('http://docs.astropy.org/en/stable/', None),
     'gwpy': ('https://gwpy.github.io/docs/stable/',
              None),
+    'gwtrigfind': ('https://gwtrigfind.readthedocs.io/en/stable/', None),
 }

--- a/gwsumm/tabs/etg.py
+++ b/gwsumm/tabs/etg.py
@@ -72,7 +72,7 @@ class EventTriggerTab(get_tab('default')):
     cache : `~glue.lal.Cache`, `str`, optional
         `Cache` object, or path to a LAL-format cache file on disk,
         from which to read the event triggers. If no cache is given,
-        the ~gwpy.table.io.trigfind` module will be used to automatically
+        the `gwtrigfind` module will be used to automatically
         locate the trigger files.
     url : `str`, optional
         URL for linking to more details results for this tab.

--- a/gwsumm/triggers.py
+++ b/gwsumm/triggers.py
@@ -32,7 +32,7 @@ from gwpy.table.filter import parse_column_filters
 from gwpy.table.io.pycbc import filter_empty_files as filter_pycbc_live_files
 from gwpy.segments import (DataQualityFlag, SegmentList)
 
-import trigfind
+import gwtrigfind
 
 from . import globalv
 from .utils import (re_cchar, vprint, safe_eval)
@@ -219,7 +219,7 @@ def get_triggers(channel, etg, segments, config=GWSummConfigParser(),
                 # find trigger files
                 if cache is None and not etg.lower() == 'hacr':
                     try:
-                        segcache = trigfind.find_trigger_files(
+                        segcache = gwtrigfind.find_trigger_files(
                             str(channel), trigfindetg, segment[0], segment[1],
                             **trigfindkwargs)
                     except ValueError as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ matplotlib>=2.0
 astropy>=1.2.1
 lalsuite
 lscsoft-glue>=1.56.0
+gwtrigfind
 # need development release of gwpy
 git+https://github.com/gwpy/gwpy.git
 
@@ -19,7 +20,6 @@ git+https://github.com/gwpy/gwpy.git
 pykerberos
 h5py
 dqsegdb>=1.4.2
-https://github.com/gwpy/trigfind/archive/v0.5.tar.gz
 ligo-gracedb
 
 # testing extras

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ install_requires = [
     'lalsuite',
     'lscsoft-glue>=1.56.0',
     'gwpy>=0.8.1',
+    'gwtrigfind',
 ]
 if sys.version < '3':
     install_requires.append('enum34')
@@ -233,10 +234,6 @@ setup(name=DISTNAME,
       install_requires=install_requires,
       tests_require=tests_require,
       extras_require=extras_require,
-      dependency_links=[
-          'https://github.com/gwpy/trigfind/archive/v0.6.1.tar.gz'
-          '#egg=trigfind-0.6.1',
-      ],
       data_files=data_files,
       use_2to3=True,
       classifiers=[


### PR DESCRIPTION
This PR updates all references to `trigfind` to [`gwtrigfind`](https://gwtrigfind.readthedocs.io).