### PR TITLE
Allow user to configure custom 'all' state

### DIFF
--- a/gwsumm/config.py
+++ b/gwsumm/config.py
@@ -349,9 +349,8 @@ class GWSummConfigParser(ConfigParser):
         end = self.getint(section, 'gps-end-time')
         try:
             all_ = generate_all_state(start, end)
-        except ValueError:
+        except ValueError:  # user defined an all state themselves
             all_ = get_state(ALLSTATE)
-            pass
         else:
             states.insert(0, all_)
 

--- a/gwsumm/state/core.py
+++ b/gwsumm/state/core.py
@@ -196,7 +196,6 @@ class SummaryState(DataQualityFlag):
             a new state, with attributes set from the options in the
             configuration
         """
-        from .all import ALLSTATE, generate_all_state
         config = GWSummConfigParser.from_configparser(config)
         # get span times
         start = config.getint(section, 'gps-start-time')
@@ -240,10 +239,7 @@ class SummaryState(DataQualityFlag):
             for i, (h0, h1) in enumerate(hours):
                 hours[i] = (h0 - offset / 3600., h1 - offset / 3600.)
         # generate state
-        if name.lower() == ALLSTATE:
-            return generate_all_state(start, end, register=False, **params)
-        else:
-            return cls(name, known=[(start, end)], hours=hours, **params)
+        return cls(name, known=[(start, end)], hours=hours, **params)
 
     def _fetch_segments(self, config=GWSummConfigParser(), **kwargs):
         kwargs.setdefault('url', self.url)

--- a/gwsumm/state/registry.py
+++ b/gwsumm/state/registry.py
@@ -51,8 +51,8 @@ def register_state(state, key=None, force=False):
     key = key.lower()
     if key not in globalv.STATES or force:
         globalv.STATES[key] = state
-    else:
-        raise ValueError("State %r has already been registered." % key)
+        return state
+    raise ValueError("State %r has already been registered." % key)
 
 
 def get_state(key):


### PR DESCRIPTION
This PR fixes `gwsumm.config` and `gwsumm.state` so that a user can configure a custom definition of the 'all' state, to control what 'all' really means. This is useful for KAGRA where we define the 'all' state to be those times where data are available from the nds1 server.