### PR TITLE
Improved access to state data

### DIFF
--- a/gwsumm/state/core.py
+++ b/gwsumm/state/core.py
@@ -251,6 +251,16 @@ class SummaryState(DataQualityFlag):
 
     def _fetch_data(self, channel, thresh, op, config=GWSummConfigParser(),
                     **kwargs):
+        # if 0 is out-of-state, allowing padding gaps with 0.
+        if (
+                (op == '<' and thresh <= 0.) or
+                (op == '<=' and thresh < 0.) or
+                (op == '>' and thresh >= 0.) or
+                (op == '>=' and thresh > 0.) or
+                (op in ('=', '==') and thresh != 0.) or
+                (op == '!=' and thresh == 0.)
+        ):
+            kwargs.setdefault('pad', 0.)
         data = get_timeseries(channel, self.known, config=config, **kwargs)
         for ts in data:
             if isinstance(thresh, (float, int)) and ts.unit is not None:

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -321,7 +321,7 @@ class DataTab(ProcessedTab, ParentTab):
             allstate = get_state(ALLSTATE)
         except ValueError:
             allstate = generate_all_state(self.start, self.end)
-        allstate.fetch(config=config)
+        allstate.fetch(config=config, segdb_error=segdb_error, **kwargs)
         for state in self.states:
             state.fetch(config=config, segdb_error=segdb_error, **kwargs)
 


### PR DESCRIPTION
This PR patches `gwsumm.state` such that, for a given state definition, if `0` will mean 'out-of-state', use `pad=0.` to ride through missing data so we can generate state information. this is extremely useful for KAGRA where we use the state system to find the gaps in the data in the first place.