### PR TITLE
Fixed bugs in running in NDS mode

### DIFF
--- a/gwsumm/state/core.py
+++ b/gwsumm/state/core.py
@@ -276,7 +276,7 @@ class SummaryState(DataQualityFlag):
         return self
 
     def fetch(self, config=GWSummConfigParser(), segdb_error='raise',
-              datafind_error='raise', nproc=1, **kwargs):
+              datafind_error='raise', nproc=1, nds=None, **kwargs):
         """Finalise this state by fetching its defining segments,
         either from global memory, or from the segment database
         """
@@ -293,7 +293,7 @@ class SummaryState(DataQualityFlag):
             thresh = float(thresh.strip())
             self._fetch_data(channel, thresh, match.groups()[0], config=config,
                              datafind_error=datafind_error,
-                             nproc=nproc, **kwargs)
+                             nproc=nproc, nds=nds, **kwargs)
         # fetch segments
         elif self.definition:
             self._fetch_segments(config=config, segdb_error=segdb_error,

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -343,7 +343,7 @@ class DataTab(ProcessedTab, ParentTab):
         self.finalize_states(
             config=config, segdb_error=stateargs.get('segdb_error', 'raise'),
             datafind_error=stateargs.get('datafind_error', 'raise'),
-            nproc=nproc)
+            nproc=nproc, nds=stateargs.get('nds', None))
         vprint("States finalised [%d total]\n" % len(self.states))
         for state in self.states:
             vprint("    {0.name}: {1} segments | {2} seconds".format(


### PR DESCRIPTION
This PR fixes issues when trying to use the `--nds` option to `gw_summary`, which pushes the code to use the nds2-client for all data access queries. This is critical for production summary pages for KAGRA.