### PR TITLE
Use verbose option in TimeSeries.fetch when using nds

### DIFF
--- a/gwsumm/data/timeseries.py
+++ b/gwsumm/data/timeseries.py
@@ -675,11 +675,9 @@ def _get_timeseries_dict(channels, segments, config=None,
                    continue
 
             if nds:  # fetch
-                vprint((vstr + '...').format(segment))
                 tsd = DictClass.fetch(qchannels, segment[0], segment[1],
                                       connection=ndsconnection, type=ndstype,
-                                      **ioargs)
-                vprint(' [Done]\n')
+                                      verbose=vstr.format(segment), **ioargs)
             else:  # read
                 # NOTE: this sieve explicitly casts our segment to
                 #       glue.segments.segment to prevent `TypeError` from


### PR DESCRIPTION
This PR modifies the call to `TimeSeriesDict.fetch` to use the `verbose` option. This will rely on gwpy/gwpy#938 making it into production to work as designed, but won't break anything before that (you'll just see more output than you want).