### PR TITLE
Upgrade to using gwdatafind for URL discovery

### DIFF
--- a/gwsumm/data/timeseries.py
+++ b/gwsumm/data/timeseries.py
@@ -588,7 +588,6 @@ def _get_timeseries_dict(channels, segments, config=None,
 
             if cache is not None:
                 fcache = sieve_cache(cache, ifo=ifo[0], tag=frametype)
-                frametype = 'cache'
             else:
                 fcache = []
 
@@ -623,7 +622,8 @@ def _get_timeseries_dict(channels, segments, config=None,
         # loop through segments, recording data for each
         if len(new):
             vprint("    Fetching data (from %s) for %d channels [%s]:\n"
-                   % (source, len(qchannels), nds and ndstype or frametype))
+                   % (source, len(qchannels),
+                      nds and ndstype or frametype or ''))
         vstr = "        [{0[0]}, {0[1]})"
         for segment in new:
             # force reading integer-precision segments

--- a/gwsumm/state/core.py
+++ b/gwsumm/state/core.py
@@ -285,8 +285,10 @@ class SummaryState(DataQualityFlag):
             self.active = segs.active
         return self
 
-    def fetch(self, config=GWSummConfigParser(), segdb_error='raise',
-              datafind_error='raise', nproc=1, nds=None, **kwargs):
+    def fetch(self, config=GWSummConfigParser(),
+              segmentdcache=None, segdb_error='raise',
+              datacache=None, datafind_error='raise', nproc=1, nds=None,
+              **kwargs):
         """Finalise this state by fetching its defining segments,
         either from global memory, or from the segment database
         """
@@ -302,12 +304,12 @@ class SummaryState(DataQualityFlag):
             channel = channel.rstrip()
             thresh = float(thresh.strip())
             self._fetch_data(channel, thresh, match.groups()[0], config=config,
-                             datafind_error=datafind_error,
-                             nproc=nproc, nds=nds, **kwargs)
+                             cache=datacache, nproc=nproc, nds=nds,
+                             datafind_error=datafind_error, **kwargs)
         # fetch segments
         elif self.definition:
-            self._fetch_segments(config=config, segdb_error=segdb_error,
-                                 **kwargs)
+            self._fetch_segments(config=config, cache=segmentcache,
+                                 segdb_error=segdb_error, **kwargs)
         # fetch null
         else:
             start = config.getfloat(DEFAULTSECT, 'gps-start-time')

--- a/gwsumm/state/core.py
+++ b/gwsumm/state/core.py
@@ -286,7 +286,7 @@ class SummaryState(DataQualityFlag):
         return self
 
     def fetch(self, config=GWSummConfigParser(),
-              segmentdcache=None, segdb_error='raise',
+              segmentcache=None, segdb_error='raise',
               datacache=None, datafind_error='raise', nproc=1, nds=None,
               **kwargs):
         """Finalise this state by fetching its defining segments,

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -341,7 +341,8 @@ class DataTab(ProcessedTab, ParentTab):
         config = GWSummConfigParser.from_configparser(config)
         # load state segments
         self.finalize_states(
-            config=config, segdb_error=stateargs.get('segdb_error', 'raise'),
+            config=config, datacache=stateargs.get('datacache', None),
+            segdb_error=stateargs.get('segdb_error', 'raise'),
             datafind_error=stateargs.get('datafind_error', 'raise'),
             nproc=nproc, nds=stateargs.get('nds', None))
         vprint("States finalised [%d total]\n" % len(self.states))

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ astropy>=1.2.1
 lalsuite
 lscsoft-glue>=1.56.0
 gwtrigfind
+gwdatafind
 # need development release of gwpy
 git+https://github.com/gwpy/gwpy.git
 

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ install_requires = [
     'lscsoft-glue>=1.56.0',
     'gwpy>=0.8.1',
     'gwtrigfind',
+    'gwdatafind',
 ]
 if sys.version < '3':
     install_requires.append('enum34')


### PR DESCRIPTION
This PR upgrades `gwsumm.data` from `glue.datafind` to `gwdatafind` for file discovery. The new package is backwards incompatible with the old one, so this requires a bit of reengineering to handle simple path lists instead of structured URLs.

This might mean, in combination with #193, that we can eliminate the dependence on `lscsoft-glue` altogether, which would be nice. Almost.