### PR TITLE
Added --section option to gwsumm-plot-guardian

### DIFF
--- a/bin/gwsumm-plot-guardian
+++ b/bin/gwsumm-plot-guardian
@@ -50,6 +50,10 @@ parser.add_argument('gpsstart', type=to_gps)
 parser.add_argument('gpsend', type=to_gps)
 parser.add_argument('config', help='config-file defining guardian node')
 parser.add_argument('-i', '--ifo', type=text_type, default='L1')
+parser.add_argument('-s', '--section', type=text_type,
+                    help='suffix of INI tab section to read, e.g. give '
+                         '--section=\'ISC_LOCK\' to read [tab-ISC_LOCK] '
+                         'section, defaults to {node}')
 parser.add_argument('-t', '--epoch', type=to_gps,
                     help='Zero-time for plot, defaults to GPSSTART')
 parser.add_argument('-p', '--plot-params', action='append', default=[],
@@ -88,7 +92,7 @@ config.read([args.config])
 config.set(DEFAULTSECT, 'gps-start-time', text_type(int(args.gpsstart)))
 config.set(DEFAULTSECT, 'gps-end-time', text_type(int(args.gpsend)))
 config.set(DEFAULTSECT, 'IFO', args.ifo)
-sec = 'tab-%s' % args.node
+sec = 'tab-%s' % (args.section or args.node)
 
 # read archive
 if args.archive and not args.read_only_archive:


### PR DESCRIPTION
This PR adds a `-s/--section` command-line option to the `gwsumm-plot-guardian` script, to allow using a section not named `tab-{node}`.