### PR TITLE
Fixed corner-case failure in math operations

### DIFF
--- a/gwsumm/data/mathutils.py
+++ b/gwsumm/data/mathutils.py
@@ -220,7 +220,9 @@ def _join(a, b, op):
     outside
     """
     # crop time-axis to select overlapping data
-    if a.xunit.physical_type == 'time':
+    if a.xunit.physical_type == 'time' and (
+            abs(a.xspan) != abs(b.xspan) or a.shape[0] != b.shape[0]
+    ):
         overlap = a.xspan & b.xspan
         a = a.crop(*overlap)
         b = b.crop(*overlap)


### PR DESCRIPTION
This PR fixes a corner-case failure we have been seeing running the LIGO-Hanford summary pages, when trying to compute the ratio of the calibrated _h(t)_ data, and the front-end-calibrated `CAL-DELTAL_EXTERNAL` data.

These two channels come from different sources, and are stored in different GWF files, with (in general) differing availability (times when GWF files exist). In some situations this can lead to `gwsumm` loading data for a given segment where the spectrogram for one channel has the same time span as the other, but has an offset of a few seconds, because the GWF file boundaries are subtly different. The code would then try to crop both spectrograms to the intersection segment, which just ended up snipping a single time-bin from _only one_ of the spectrograms, meaning they then had different shapes, and the mathematical operation would fail.

The fix is to only reshape time-domain data (timeseries, spectrograms) if the data are different durations, _or_ the data have the same duration but the offset between them is greater than 1 X-axis sample.