### PR TITLE
Patch ETG reading to support direct local filenames

### DIFF
--- a/gwsumm/triggers.py
+++ b/gwsumm/triggers.py
@@ -21,6 +21,8 @@
 
 import warnings
 
+from six.moves.urllib.parse import urlparse
+
 from astropy.table import vstack as vstack_tables
 
 from glue.lal import (Cache, CacheEntry)
@@ -418,6 +420,8 @@ def read_cache(cache, segments, etg, nproc=1, timecolumn=None, **kwargs):
         cache = cache.checkfilesexist()[0]
         cache.sort(key=lambda x: x.segment[0])
         cache = cache.pfnlist()  # some readers only like filenames
+    else:
+        cache = [urlparse(url).path for url in cache]
     if etg == 'pycbc_live':  # remove empty HDF5 files
         cache = filter_pycbc_live_files(cache, ifo=kwargs['ifo'])
 


### PR DESCRIPTION
This PR patches ETG reading to support direct local filenames from URLs, as well as caches. This turns out to be necessary in order to read and plot triggers from PyCBC-Live.

Example output for the full day (UTC) on [**20181108**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/summary/day/20181108/detchar/pycbc_live_long/) is available, as is [**another test**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/summary/1225692018-1225692618/) on a shorter data stretch during the same day, just to be sure that these changes do not adversely affect other ETGs such as Omicron.

This PR was co-authored by @duncanmmacleod.