### PR TITLE
Do not process ETG table filters in-place

### DIFF
--- a/gwsumm/plot/triggers.py
+++ b/gwsumm/plot/triggers.py
@@ -198,8 +198,9 @@ class TriggerDataPlot(TriggerPlotMixin, TimeSeriesDataPlot):
                                  self.state and str(self.state) or 'All')
             else:
                 key = str(channel)
-            table = get_triggers(key, self.etg, valid,
-                                 filter=self.filterstr, query=False)
+            table = get_triggers(key, self.etg, valid, query=False)
+            if self.filterstr is not None:
+                table = table.filter(self.filterstr)
             ntrigs += len(table)
             # access channel parameters for limits
             for c, column in zip(('x', 'y', 'c'), (xcolumn, ycolumn, ccolumn)):
@@ -456,8 +457,9 @@ class TriggerHistogramPlot(TriggerPlotMixin, get_plot('histogram')):
                                  self.state and str(self.state) or 'All')
             else:
                 key = str(channel)
-            table_ = get_triggers(key, self.etg, valid,
-                                  filter=self.filterstr, query=False)
+            table_ = get_triggers(key, self.etg, valid, query=False)
+            if self.filterstr is not None:
+                table_ = table_.filter(self.filterstr)
             livetime.append(float(abs(table_.meta['segments'])))
             data.append(table_[self.column])
             # allow channel data to set parameters
@@ -591,8 +593,9 @@ class TriggerRateDataPlot(TriggerPlotMixin, TimeSeriesDataPlot):
                                  str(self.state) if self.state else 'All')
             else:
                 key = str(channel)
-            table_ = get_triggers(key, self.etg, valid,
-                                  filter=self.filterstr, query=False)
+            table_ = get_triggers(key, self.etg, valid, query=False)
+            if self.filterstr is not None:
+                table_ = table_.filter(self.filterstr)
             tcol_ = tcol or get_time_column(table_, self.etg)
             if self.column:
                 rates = table_.binned_event_rates(

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -368,8 +368,8 @@ class DataTab(ProcessedTab, ParentTab):
 
     def process_state(self, state, nds=None, nproc=1,
                       config=GWSummConfigParser(), datacache=None,
-                      trigcache=None, segmentcache=None, trigfilter=None,
-                      segdb_error='raise', datafind_error='raise'):
+                      trigcache=None, segmentcache=None, segdb_error='raise',
+                      datafind_error='raise'):
         """Process data for this tab in a given state
 
         Parameters
@@ -392,10 +392,6 @@ class DataTab(ProcessedTab, ParentTab):
             `Cache` of files from which to read event triggers
         segmentcache : `~glue.lal.Cache`, optional
             `Cache` of files from which to read segments
-        trigfilter : `str`, optional
-            event table filter, either as space-separated `str` or `list`
-            of `str` components of the form ``column>threshold``, e.g.
-            ``snr>10``
         segdb_error : `str`, optional
             if ``'raise'``: raise exceptions when the segment database
             reports exceptions, if ``'warn''`, print warnings but continue,
@@ -542,8 +538,7 @@ class DataTab(ProcessedTab, ParentTab):
                                               'trigger-histogram',
                                               all_data=all_data):
             get_triggers(channel, etg, state.active, config=config,
-                         cache=trigcache, nproc=nproc,
-                         filter=trigfilter, return_=False)
+                         cache=trigcache, nproc=nproc, return_=False)
 
         # --------------------------------------------------------------------
         # make plots

--- a/gwsumm/tabs/etg.py
+++ b/gwsumm/tabs/etg.py
@@ -303,7 +303,9 @@ class EventTriggerTab(get_tab('default')):
             if self.loudest:
                 # get triggers
                 table = get_triggers(self.channel, self.plots[0].etg, state,
-                                     filter=self.filterstr, query=False)
+                                     query=False)
+                if self.filterstr is not None:
+                    table = table.filter(self.filterstr)
                 tcol = get_time_column(table, self.etg)
                 # set table headers
                 headers = list(self.loudest['labels'])


### PR DESCRIPTION
On the production DetChar summary pages, there has been an issue with PyCBC Live triggers where the sub-tabs for [**short**](https://ldas-jobs.ligo-la.caltech.edu/~detchar/summary/day/20181109/detchar/pycbc_live_short/), [**medium**](https://ldas-jobs.ligo-la.caltech.edu/~detchar/summary/day/20181109/detchar/pycbc_live_medium/), and [**long**](https://ldas-jobs.ligo-la.caltech.edu/~detchar/summary/day/20181109/detchar/pycbc_live_long/)-template duration triggers all actually show short-duration triggers. @tjma12 and I tracked this down and determined that, whenever triggers from one ETG are read (from PyCBC Live, say), any `event-filter` gets applied to them in-place and all subsequent filters will be ignored.

This PR fixes the issue by applying ETG `event-filter`s only before plotting and constructing ranking tables. See [**this test output**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/summary/1225692018-1225692618/detchar/pycbc_live_long/) for validation that the proposed changes both fix the issue and are backwards-compatible with displaying Omicron triggers.

cc @tjma12, @duncanmmacleod 