### PR TITLE
Simplified metadata for tables read with get_triggers

### DIFF
--- a/gwsumm/triggers.py
+++ b/gwsumm/triggers.py
@@ -260,7 +260,9 @@ def get_triggers(channel, etg, segments, config=GWSummConfigParser(),
         else:  # map to LIGO_LW table with full column listing
             tab = EventTable(lsctables.New(TableClass))
         tab.meta['segments'] = SegmentList()
-        tab.meta['timecolumn'] = read_kw.get('timecolumn')
+        for metakey in ('timecolumn', 'tablename',):
+            if metakey in read_kw:
+                tab.meta[metakey] = read_kw[metakey]
         add_triggers(tab, key)
 
     # work out time function


### PR DESCRIPTION
This PR simplifies the `.meta` dict for tables read with `gwsumm.triggers.get_triggers`, mainly to prevent errors when writing these tables to the HDF5 archives.