### PR TITLE
Update the hard-coded Report an Issue link

### DIFF
--- a/bin/gw_summary
+++ b/bin/gw_summary
@@ -585,6 +585,12 @@ else:
     urlbase = None
     base = None
 
+# get link to issues report page
+try:
+    issues = config.get('html', 'issues')
+except:
+    issues = True
+
 # write 404 error page
 if not opts.no_htaccess and not opts.no_html and urlbase:
     top = os.path.join(urlbase, path)
@@ -593,7 +599,8 @@ if not opts.no_htaccess and not opts.no_html and urlbase:
     four0four.write_html(css=css, js=javascript, tabs=tabs, ifo=ifo,
                          ifomap=ifobases, top=top, base=base,
                          writedata=not opts.html_only,
-                         writehtml=not opts.no_html)
+                         writehtml=not opts.no_html,
+                         issues=issues)
     url404 = os.path.join(urlbase, four0four.index)
     with open(os.path.join(path, '.htaccess'), 'w') as htaccess:
         print('Options -Indexes', file=htaccess)
@@ -606,7 +613,7 @@ if not opts.no_html:
     mkdir(about.path)
     about.write_html(css=css, js=javascript, tabs=tabs, config=config.files,
                      ifo=ifo, ifomap=ifobases, about=about.index, base=base,
-                     writedata=not opts.html_only,
+                     issues=issues, writedata=not opts.html_only,
                      writehtml=not opts.no_html)
 
 # -----------------------------------------------------------------------------
@@ -684,7 +691,7 @@ for tab in tablist:
         mkdir(tab.href)
         page = tab.write_html(css=css, js=javascript, tabs=tabs, ifo=ifo,
                               ifomap=ifobases, about=about.index, base=base,
-                              writedata=not opts.html_only,
+                              issues=issues, writedata=not opts.html_only,
                               writehtml=not opts.no_html)
     vprint("%s complete!\n" % (name))
 

--- a/gwsumm/html/bootstrap.py
+++ b/gwsumm/html/bootstrap.py
@@ -314,6 +314,8 @@ def footer(user=True, about=None, issues=True, content=None, span=12,
     ----------
     user : `bool`, optional, default: `True`
         print details of user running this job
+    issues : `str`, optional, default: 'https://github.com/gwpy/gwsumm/issues'
+        external link to a webpage where issues can be posted
     span : `int`
         column span of content, default: 'full' (``12``)
 
@@ -341,6 +343,8 @@ def footer(user=True, about=None, issues=True, content=None, span=12,
         page.p('This page was created by %s at %s.'
                % (getpass.getuser(),
                   datetime.datetime.now().strftime('%H:%m on %B %d %Y')))
+    if issues is True:
+        issues = 'https://github.com/gwpy/gwsumm/issues'
     if issues:
         version = get_versions()['version']
         commit = get_versions()['full-revisionid']
@@ -348,8 +352,7 @@ def footer(user=True, about=None, issues=True, content=None, span=12,
         page.p()
         page.a('View GWSumm %s on GitHub' % version, href=url, target='_blank')
         page.add('|')
-        page.a('Report an issue', href='https://github.com/gwpy/gwsumm/issues',
-               target='_blank')
+        page.a('Report an issue', href=issues, target='_blank')
         page.p.close()
     if about is not None:
         page.p(markup.oneliner.a('How was this page generated?', href=about))

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -521,7 +521,7 @@ class BaseTab(object):
         user : `bool`, default: `True`
             print details of user running this job
 
-        issues : `bool`, default: `True`
+        issues : `bool` or `str`, default: `True`
             print link to github.com issue tracker for this package
 
         about : `str`
@@ -713,7 +713,8 @@ class BaseTab(object):
 
     def write_html(self, maincontent, title=None, subtitle=None, tabs=list(),
                    ifo=None, ifomap=dict(), brand=None, base=None,
-                   css=None, js=None, about=None, footer=None, **inargs):
+                   css=None, js=None, about=None, footer=None, issues=True,
+                   **inargs):
         """Write the HTML page for this `Tab`.
 
         Parameters
@@ -755,6 +756,9 @@ class BaseTab(object):
         footer : `str`, `~gwsumm.html.markup.page`
             user-defined content for the footer (placed below everything else)
 
+        issues : `bool` or `str`, default: `True`
+            print link to github.com issue tracker for this package
+
         **inargs
             other keyword arguments to pass to the
             :meth:`~Tab.build_inner_html` method
@@ -786,7 +790,7 @@ class BaseTab(object):
 
         self.page.div.close()  # container
         # close page and write
-        self.html_finalize(about=about, content=footer)
+        self.html_finalize(about=about, content=footer, issues=issues)
         with open(self.index, 'w') as fobj:
             fobj.write(str(self.page))
         return


### PR DESCRIPTION
By request of the LIGO commissioning team, this PR updates the hard-coded `Report an Issue` link at the bottom of the output page, making this a configurable option that by default points to [`https://github.com/gwpy/gwsumm/issues`](https://github.com/gwpy/gwsumm/issues).