### PR TITLE
Patched gwsumm.plot to only escape text when using tex via matplotlib

### DIFF
--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -36,7 +36,6 @@ from astropy.units import Quantity
 
 from gwpy.plot.colors import tint
 from gwpy.plot.gps import GPSTransform
-from gwpy.plot.tex import label_to_latex
 from gwpy.segments import SegmentList
 
 from .. import (globalv, io)
@@ -48,6 +47,7 @@ from ..data import (get_timeseries, get_spectrogram,
 from ..state import ALLSTATE
 from .registry import (get_plot, register_plot)
 from .mixins import DataLabelSvgMixin
+from .utils import usetex_tex
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -186,15 +186,15 @@ class TimeSeriesDataPlot(DataLabelSvgMixin, DataPlot):
                 label = pargs.pop('label')
             except KeyError:
                 try:
-                    label = label_to_latex(flatdata[0].name)
+                    label = usetex_tex(flatdata[0].name)
                 except IndexError:
                     label = clist[0]
                 else:
                     if self.fileformat == 'svg' and not label.startswith(
-                            label_to_latex(
+                            usetex_tex(
                             str(flatdata[0].channel)).split('.')[0]):
                         label += ' [%s]' % (
-                            label_to_latex(str(flatdata[0].channel)))
+                            usetex_tex(str(flatdata[0].channel)))
 
             # plot groups or single TimeSeries
             if len(clist) > 1:
@@ -462,7 +462,7 @@ class SpectrumDataPlot(DataPlot):
             self.pargs.setdefault(
                 'suptitle',
                 '[%s-%s, state: %s]' % (self.span[0], self.span[1],
-                                        label_to_latex(str(self.state))))
+                                        usetex_tex(str(self.state))))
         suptitle = self.pargs.pop('suptitle', None)
         if suptitle:
             plot.suptitle(suptitle, y=0.993, va='top')
@@ -650,7 +650,7 @@ class TimeSeriesHistogramPlot(DataPlot):
             self.pargs.setdefault(
                 'suptitle',
                 '[%s-%s, state: %s]' % (self.span[0], self.span[1],
-                                        label_to_latex(str(self.state))))
+                                        usetex_tex(str(self.state))))
         suptitle = self.pargs.pop('suptitle', None)
         if suptitle:
             plot.suptitle(suptitle, y=0.993, va='top')
@@ -759,8 +759,8 @@ class TimeSeriesHistogram2dDataPlot(TimeSeriesHistogramPlot):
 
     def _update_defaults_from_channels(self):
         c1, c2 = self.channels
-        self.pargs.setdefault('xlabel', label_to_latex(str(c1)))
-        self.pargs.setdefault('ylabel', label_to_latex(str(c2)))
+        self.pargs.setdefault('xlabel', usetex_tex(str(c1)))
+        self.pargs.setdefault('ylabel', usetex_tex(str(c2)))
         if hasattr(c1, 'amplitude_range'):
             self.pargs.setdefault('xlim', c1.amplitude_range)
         if hasattr(c2, 'amplitude_range'):
@@ -801,7 +801,7 @@ class TimeSeriesHistogram2dDataPlot(TimeSeriesHistogramPlot):
             self.pargs.setdefault(
                 'suptitle',
                 '[%s-%s, state: %s]' % (self.span[0], self.span[1],
-                                        label_to_latex(str(self.state))))
+                                        usetex_tex(str(self.state))))
         suptitle = self.pargs.pop('suptitle', None)
         if suptitle:
             plot.suptitle(suptitle, y=0.993, va='top')
@@ -887,7 +887,7 @@ class SpectralVarianceDataPlot(SpectrumDataPlot):
             self.pargs.setdefault(
                 'suptitle',
                 '[%s-%s, state: %s]' % (self.span[0], self.span[1],
-                                        label_to_latex(str(self.state))))
+                                        usetex_tex(str(self.state))))
         suptitle = self.pargs.pop('suptitle', None)
         if suptitle:
             plot.suptitle(suptitle, y=0.993, va='top')

--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -37,7 +37,6 @@ from matplotlib import (rcParams, rc_context)
 from gwpy.segments import Segment
 from gwpy.detector import (Channel, ChannelList)
 from gwpy.plot import Plot
-from gwpy.plot.tex import label_to_latex
 
 from ..channels import (get_channel, split as split_channels,
                         split_combination as split_channel_combination)
@@ -63,7 +62,7 @@ NON_PLOT_PARAMS = set(putils.FIGURE_PARAMS + putils.AXES_PARAMS)
 def format_label(l):
     l = str(l).strip('\n ')
     l = re_quote.sub('', l)
-    return label_to_latex(l)
+    return putils.usetex_tex(l)
 
 
 # -- basic Plot object --------------------------------------------------------

--- a/gwsumm/plot/mixins.py
+++ b/gwsumm/plot/mixins.py
@@ -27,7 +27,7 @@ from six.moves import StringIO
 
 from lxml import etree
 
-from gwpy.plot.tex import label_to_latex
+from .utils import usetex_tex
 
 re_bit_label = re.compile('\[(?P<idx>.*)\] (?P<label>.*)')
 re_source_label = re.compile('(?P<label>.*) \[(?P<flag>.*)\]')
@@ -131,7 +131,7 @@ class DataLabelSvgMixin(SvgMixin):
                         text.get_text()).groups()
                 except (AttributeError, ValueError):
                     continue
-                channel = label_to_latex(str(source))
+                channel = usetex_tex(str(source))
                 text.set_text(label)
                 t2 = ax.text(
                     0.994, 1.02, channel, ha='right', va='bottom',

--- a/gwsumm/plot/noisebudget.py
+++ b/gwsumm/plot/noisebudget.py
@@ -25,11 +25,11 @@ import re
 
 import numpy
 
-from gwpy.plot.tex import label_to_latex
 from gwpy.segments import SegmentList
 
 from ..data import get_spectrum
 from .registry import (get_plot, register_plot)
+from .utils import usetex_tex
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -80,7 +80,7 @@ class NoiseBudgetPlot(get_plot('spectrum')):
             self.pargs.setdefault(
                 'suptitle',
                 '[%s-%s, state: %s]' % (self.span[0], self.span[1],
-                                        label_to_latex(str(self.state))))
+                                        usetex_tex(str(self.state))))
         suptitle = self.pargs.pop('suptitle', None)
         if suptitle:
             plot.suptitle(suptitle, y=0.993, va='top')
@@ -180,7 +180,7 @@ class RelativeNoiseBudgetPlot(get_plot('spectrum')):
             self.pargs.setdefault(
                 'suptitle',
                 '[%s-%s, state: %s]' % (self.span[0], self.span[1],
-                                        label_to_latex(str(self.state))))
+                                        usetex_tex(str(self.state))))
         suptitle = self.pargs.pop('suptitle', None)
         if suptitle:
             plot.suptitle(suptitle, y=0.993, va='top')

--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -43,7 +43,6 @@ from matplotlib.colors import (rgb2hex, is_color_like)
 from matplotlib.patches import Rectangle
 
 from gwpy.plot.colors import (GW_OBSERVATORY_COLORS, tint)
-from gwpy.plot.tex import label_to_latex
 from gwpy.plot.segments import SegmentRectangle
 from gwpy.segments import (Segment, SegmentList, DataQualityFlag)
 from gwpy.time import (from_gps, to_gps)
@@ -59,6 +58,7 @@ from ..state import ALLSTATE
 from .core import (BarPlot, PiePlot, format_label)
 from .registry import (get_plot, register_plot)
 from .mixins import SegmentLabelSvgMixin
+from .utils import usetex_tex
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -983,7 +983,7 @@ class SegmentPiePlot(PiePlot, SegmentDataPlot):
             self.pargs.setdefault(
                 'suptitle',
                 '[%s-%s, state: %s]' % (self.span[0], self.span[1],
-                                        label_to_latex(str(self.state))))
+                                        usetex_tex(str(self.state))))
         else:
             self.pargs.setdefault(
                 'suptitle', '[%s-%s]' % (self.span[0], self.span[1]))
@@ -1032,7 +1032,7 @@ class SegmentPiePlot(PiePlot, SegmentDataPlot):
                     pc = d/tot * 100
                 except ZeroDivisionError:
                     pc = 0.0
-                pclabels.append(label_to_latex(
+                pclabels.append(usetex_tex(
                     '%s [%1.1f%%]' % (label, pc)).replace(r'\\', '\\'))
 
         # add time to top
@@ -1185,7 +1185,7 @@ class SegmentBarPlot(BarPlot, SegmentDataPlot):
             self.pargs.setdefault(
                 'suptitle',
                 '[%s-%s, state: %s]' % (self.span[0], self.span[1],
-                                        label_to_latex(str(self.state))))
+                                        usetex_tex(str(self.state))))
         else:
             self.pargs.setdefault(
                 'suptitle', '[%s-%s]' % (self.span[0], self.span[1]))
@@ -1279,7 +1279,7 @@ class SegmentHistogramPlot(get_plot('histogram'), SegmentDataPlot):
             self.pargs.setdefault(
                 'suptitle',
                 '[%s-%s, state: %s]' % (self.span[0], self.span[1],
-                                        label_to_latex(str(self.state))))
+                                        usetex_tex(str(self.state))))
         else:
             self.pargs.setdefault(
                 'suptitle', '[%s-%s]' % (self.span[0], self.span[1]))

--- a/gwsumm/plot/triggers.py
+++ b/gwsumm/plot/triggers.py
@@ -35,7 +35,6 @@ from astropy.units import Quantity
 from gwpy.detector import (Channel, ChannelList)
 from gwpy.segments import SegmentList
 from gwpy.plot.gps import GPSTransform
-from gwpy.plot.tex import label_to_latex
 from gwpy.plot.utils import (color_cycle, marker_cycle)
 
 from .. import globalv
@@ -43,7 +42,7 @@ from ..utils import re_cchar
 from ..data import (get_channel, get_timeseries, add_timeseries)
 from ..triggers import (get_triggers, get_time_column)
 from .registry import (get_plot, register_plot)
-from .utils import get_column_string
+from .utils import (get_column_string, usetex_tex)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -229,7 +228,7 @@ class TriggerDataPlot(TriggerPlotMixin, TimeSeriesDataPlot):
         # customise plot
         legendargs = self.parse_legend_kwargs(markerscale=3)
         if len(self.channels) == 1:
-            self.pargs.setdefault('title', label_to_latex(
+            self.pargs.setdefault('title', usetex_tex(
                 '%s (%s)' % (str(self.channels[0]), self.etg)))
         for axis in ('x', 'y'):  # prevent zeros on log scale
             scale = getattr(ax, 'get_{0}scale'.format(axis))()

--- a/gwsumm/plot/utils.py
+++ b/gwsumm/plot/utils.py
@@ -24,6 +24,7 @@ import re
 
 from matplotlib import rcParams
 
+from gwpy.plot.tex import label_to_latex
 from gwpy.plot.utils import (FIGURE_PARAMS, AXES_PARAMS)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -140,5 +141,13 @@ def get_column_string(column):
             else:
                 words[i] = word.title()
             # escape underscore
-            words[i] = re.sub(r'(?<!\\)_', r'\_', words[i])
+            words[i] = usetex_tex(re.sub(r'(?<!\\)_', r'\_', words[i]))
     return ' '.join(words)
+
+
+def usetex_tex(text):
+    """Format text for TeX if `text.usetex` is True
+    """
+    if rcParams['text.usetex']:
+        return label_to_latex(text)
+    return text


### PR DESCRIPTION
This PR replaces all calls to `gwpy.plot.tex.label_to_latex` with a wrapper that checks `matplotlib.rcParams['text.usetex']`, and just returns the input when TeX is not used.