### PR TITLE
Apply axis scale first when finalising plot parameters

### DIFF
--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -775,8 +775,10 @@ class DataPlot(SummaryPlot):
         return outputfile
 
     def apply_parameters(self, *axes, **pargs):
+        keys = sorted(pargs.keys(),
+                      key=lambda x: 1 if x in ('xscale', 'yscale') else 2)
         for ax in axes:
-            for key in pargs:
+            for key in keys:
                 if key.startswith('no-'):  # skip no-xxx keys
                     continue
                 val = pargs[key]


### PR DESCRIPTION
This PR modifies `DataPlot.apply_parameters` to apply axis scales (`xscale`, etc) _first_, so that limits and bounds don't get ignored because the scale gets reset after them.