### PR TITLE
Added more protection against empty data in plotting

### DIFF
--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -360,8 +360,14 @@ class SpectrogramDataPlot(TimeSeriesDataPlot):
             specgrams = get_coherence_spectrogram(self.channels, valid,
                                                   query=False)
         else:
-            specgrams = get_spectrogram(channel, valid, query=False,
-                                        format=sdform)
+            try:
+                specgrams = get_spectrogram(channel, valid, query=False,
+                                            format=sdform)
+            except ValueError as exc:
+                if not 'need more than 0 values' in str(exc):
+                    raise
+                # attempted to do math but one input has zero size
+                specgrams = []
 
         # get ratio as FrequencySeries
         ratio = self.get_ratio(specgrams)


### PR DESCRIPTION
This PR is similar to 31b89d296e59e9f64fe192c0f906d94d94eb5d68 (#215) but for the spectrogram case.