### PR TITLE
Adjust plot settings for gwpy-0.13.0

### DIFF
--- a/gwsumm/plot/__init__.py
+++ b/gwsumm/plot/__init__.py
@@ -56,6 +56,14 @@ from .guardian import *
 from .sei import *
 
 rcParams.update({
+    'text.usetex': True,
+    'font.size': 10,
+    'font.family': ['serif'],
+    'xtick.labelsize': 18,
+    'ytick.labelsize': 18,
+    'axes.labelsize': 20,
+    'axes.titlesize': 24,
+    'grid.alpha': 0.5,
     'figure.figsize': (12, 6),
     'svg.fonttype': 'none',
 })


### PR DESCRIPTION
This pull request adjusts the summary page `rcParams` for gwpy-0.13.0 so that they continue to use LaTeX for plot rendering.

[**Here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/summary/formatting/1233522844-1233523759/) is a thorough example of pages with plots rendered under the proposed changes (requires `LIGO.ORG` credentials).

cc @duncanmmacleod, @tjma12 