### PR TITLE
Support float operations by assigning them the same unit as the base Series

### DIFF
--- a/gwsumm/data/mathutils.py
+++ b/gwsumm/data/mathutils.py
@@ -19,6 +19,7 @@
 """Handle arbitrary mathematical operations applied to data series
 """
 
+import numbers
 import operator
 import re
 from collections import OrderedDict
@@ -194,6 +195,9 @@ def get_with_math(channel, segments, load_func, get_func, **ioargs):
         # apply math to this channel
         cmath = singleops[names[0]]
         for op_, val_ in cmath:
+            if op_ in {operator.add, operator.sub} and \
+                    isinstance(val_, numbers.Number):
+                val_ *= ts.unit
             ts = op_(ts, val_)
         # for each other channel do the same
         for joinop, name in zip(joinoperators, names[1:]):


### PR DESCRIPTION
This PR attempts to resolve an issue with gwpy-0.13.0/astropy. It allows `gwsumm.data.mathutils` to support adding floats to channels by assigning them the same unit as the base `Series` object.

cc @duncanmmacleod 