### PR TITLE
Reproduce GWPY_TEX_RCPARAMS for use with gwpy-0.13+

### DIFF
--- a/gwsumm/plot/__init__.py
+++ b/gwsumm/plot/__init__.py
@@ -43,6 +43,7 @@ The available classes are:
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 from matplotlib import rcParams
+from gwpy.plot.tex import MACROS as GWPY_TEX_MACROS
 
 from .registry import *
 from .utils import *
@@ -56,9 +57,14 @@ from .guardian import *
 from .sei import *
 
 rcParams.update({
+    # reproduce GWPY_TEX_PARAMS
     'text.usetex': True,
-    'font.size': 10,
+    'text.latex.preamble': (
+        rcParams.get('text.latex.preamble', []) + GWPY_TEX_MACROS),
     'font.family': ['serif'],
+    'axes.formatter.use_mathtext': False,
+    # custom GWSumm formatting
+    'font.size': 10,
     'xtick.labelsize': 18,
     'ytick.labelsize': 18,
     'axes.labelsize': 20,


### PR DESCRIPTION
This PR reproduces the `GWPY_TEX_RCPARAMS` settings so that summary page plots are rendered with LaTeX, as before. Example output made with these changes is available [**here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/summary/1233522844-1233523759/cal/h_t_generation/).

cc @duncanmmacleod