### PR TITLE
Avoid build test failures

### DIFF
--- a/gwsumm/data/utils.py
+++ b/gwsumm/data/utils.py
@@ -29,27 +29,11 @@ except ImportError:
 from ligo.segments import segmentlist as LigoSegmentList
 
 from gwpy.segments import (DataQualityFlag, SegmentList, Segment)
-from gwpy.signal.spectral import (get_default_fft_api, _lal as fft_lal)
-from gwpy.signal.spectral._registry import get_method as get_fft_method
 
 from ..channels import get_channel
 from ..config import GWSummConfigParser
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
-
-FFT_API = get_default_fft_api()
-
-# get FFT scheme
-FFT_SCHEME = None
-if FFT_API.startswith('pycbc'):
-    from pycbc.scheme import (DefaultScheme, MKLScheme)
-    try:
-        FFT_SCHEME = MKLScheme()
-    except RuntimeError:
-        FFT_SCHEME = DefaultScheme()
-elif FFT_API == 'lal':
-    fft_lal.LAL_FFTPLAN_LEVEL = 2
-
 
 # -- method decorators --------------------------------------------------------
 
@@ -97,7 +81,6 @@ FFT_PARAMS = OrderedDict([
 
 DEFAULT_FFT_PARAMS = {
     'method': 'median',
-    'scheme': FFT_SCHEME,
 }
 
 
@@ -163,12 +146,6 @@ def get_fftparams(channel, **defaults):
     if fftparams.stride == 0:
         raise ZeroDivisionError("Cannot generate spectrogram with stride "
                                 "length of 0")
-
-    # unwrap method
-    method_func = get_fft_method(fftparams.method)
-    if method_func.__module__.rsplit('.', 1)[-1] == 'basic':
-        fftmod = FFT_API.split('.', 1)[0]
-        fftparams.method = '{0}-{1}'.format(fftmod, fftparams.method)
 
     return fftparams
 

--- a/gwsumm/data/utils.py
+++ b/gwsumm/data/utils.py
@@ -29,8 +29,8 @@ except ImportError:
 from ligo.segments import segmentlist as LigoSegmentList
 
 from gwpy.segments import (DataQualityFlag, SegmentList, Segment)
-from gwpy.signal.fft import (get_default_fft_api, lal as fft_lal)
-from gwpy.signal.fft.registry import get_method as get_fft_method
+from gwpy.signal.spectral import (get_default_fft_api, _lal as fft_lal)
+from gwpy.signal.spectral._registry import get_method as get_fft_method
 
 from ..channels import get_channel
 from ..config import GWSummConfigParser

--- a/gwsumm/plot/__init__.py
+++ b/gwsumm/plot/__init__.py
@@ -43,7 +43,7 @@ The available classes are:
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 from matplotlib import rcParams
-from gwpy.plot.tex import MACROS as GWPY_TEX_MACROS
+from gwpy.plot.tex import (has_tex, MACROS as GWPY_TEX_MACROS)
 
 from .registry import *
 from .utils import *
@@ -57,12 +57,6 @@ from .guardian import *
 from .sei import *
 
 rcParams.update({
-    # reproduce GWPY_TEX_PARAMS
-    'text.usetex': True,
-    'text.latex.preamble': (
-        rcParams.get('text.latex.preamble', []) + GWPY_TEX_MACROS),
-    'font.family': ['serif'],
-    'axes.formatter.use_mathtext': False,
     # custom GWSumm formatting
     'font.size': 10,
     'xtick.labelsize': 18,
@@ -73,3 +67,13 @@ rcParams.update({
     'figure.figsize': (12, 6),
     'svg.fonttype': 'none',
 })
+
+if has_tex():
+    rcParams.update({
+        # reproduce GWPY_TEX_RCPARAMS
+        'text.usetex': True,
+        'text.latex.preamble': (
+            rcParams.get('text.latex.preamble', []) + GWPY_TEX_MACROS),
+        'font.family': ['serif'],
+        'axes.formatter.use_mathtext': False,
+    })

--- a/gwsumm/tests/test_data.py
+++ b/gwsumm/tests/test_data.py
@@ -53,8 +53,6 @@ LOSC_DATA = {
 }
 LOSC_SEGMENTS = SegmentList([Segment(1126259446, 1126259478)])
 
-FFT_SCHEME_NAME = type(utils.FFT_SCHEME).__name__ if utils.FFT_SCHEME else ''
-
 
 def download(remote, target=None):
     """Download a file
@@ -127,7 +125,7 @@ class TestData(object):
             '',  # overlap
             'test-window',  # window
             '123.456',  # stride
-            FFT_SCHEME_NAME,  # FFT scheme
+            '',  # FFT scheme
         ])
 
     def test_get_fftparams(self):

--- a/gwsumm/tests/test_data.py
+++ b/gwsumm/tests/test_data.py
@@ -135,12 +135,8 @@ class TestData(object):
         assert isinstance(fftparams, utils.FftParams)
 
         for key in utils.FFT_PARAMS.keys():
-            if key == 'method':
-                assert fftparams.method == '{0}-{1}'.format(
-                    utils.FFT_API.split('.')[0], utils.DEFAULT_FFT_PARAMS[key])
-            else:
-                assert (getattr(fftparams, key) is
-                        utils.DEFAULT_FFT_PARAMS.get(key, None))
+            assert (getattr(fftparams, key) is
+                    utils.DEFAULT_FFT_PARAMS.get(key, None))
 
         fftparams = utils.get_fftparams('L1:TEST-CHANNEL', window='hanning',
                                         overlap=0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ enum34 ; python_version < '3'
 python-dateutil
 lxml
 numpy>=1.10
+scipy>=1.2.0
 matplotlib>=2.0
 astropy>=1.2.1
 lalsuite

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ install_requires = [
     'python-dateutil',
     'lxml',
     'numpy>=1.10',
+    'scipy>=1.2.0',
     'matplotlib>=2.2.0',
     'astropy>=1.2.1',
     'lalsuite',


### PR DESCRIPTION
This PR tweaks the `rcParams` to only use TeX to render plots if TeX is available on the local system, otherwise `text.usetex` is set to `False`.

Because `gwsumm` requires the development version of `gwpy`, which will soon be packaged into gwpy-0.14.0, this PR also makes the following changes:

* Switch out an import of `gwpy.signal.fft` with its replacement module in the pre-release branch, `gwpy.signal.spectral`
* Require `scipy>=1.2.0` in order to support median power spectral densities

cc @duncanmmacleod 