### PR TITLE
Warn about noop resampling in gwsumm.data, but don't error

### DIFF
--- a/gwsumm/data/timeseries.py
+++ b/gwsumm/data/timeseries.py
@@ -867,7 +867,13 @@ def resample_timeseries_dict(tsd, nproc=1, **sampling_dict):
     # define resample function (must take single argument)
     def _resample(args):
         ts, fs = args
-        if fs:
+        if fs and units.Quantity(fs, "Hz") == ts.sample_rate:
+            warnings.warn(
+                "requested resample rate for {0} matches native rate ({1}), "
+                "please update configuration".format(ts.name, ts.sample_rate),
+                UserWarning,
+            )
+        elif fs:
             return ts.resample(fs, ftype='fir', window='hamming')
         return ts
 


### PR DESCRIPTION
This PR updates `gwsumm.data.timeseries` to detect when the requested resample rate matches the current rate, emit a warning, and then just skip it, rather than attempting to resample and erroring (as of gwpy-0.14.0, see gwpy/gwpy#1073).