### PR TITLE
 Use pygments to render config files

### DIFF
--- a/gwsumm/html/bootstrap.py
+++ b/gwsumm/html/bootstrap.py
@@ -445,7 +445,7 @@ def about_this_page(cmdline=True, config=None, packagelist=True):
             page.a.close()
             page.div(id_='file%d' % i, class_='panel-collapse collapse')
             page.div(class_='panel-body')
-            page.pre(highlight_syntax(cpfile, 'ini'))
+            page.add(highlight_syntax(cpfile, 'ini'))
             page.div.close()
             page.div.close()
             page.div.close()

--- a/gwsumm/html/utils.py
+++ b/gwsumm/html/utils.py
@@ -19,26 +19,23 @@
 """Utilties for HTML generation
 """
 
-import subprocess
+from pygments import highlight
+from pygments.lexers import get_lexer_by_name
+from pygments.formatters import HtmlFormatter
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+__credits__ = 'Alex Urban <alexander.urban@ligo.org>'
+
+
+# configure syntax highlighting
+FORMATTER = HtmlFormatter(noclasses=True)
 
 
 def highlight_syntax(filepath, format_):
     """Return an HTML-formatted copy of the file with syntax highlighting
     """
-    highlight = ['highlight', '--out-format', 'html', '--syntax', format_,
-                 '--inline-css', '--fragment', '--input', filepath]
-    try:
-        process = subprocess.Popen(highlight, stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE)
-    except OSError:
-        with open(filepath, 'r') as fobj:
-            return fobj.read()
-    else:
-        out, err = process.communicate()
-        if process.returncode != 0:
-            with open(filepath, 'r') as fobj:
-                return fobj.read()
-        else:
-            return out
+    lexer = get_lexer_by_name(format_, stripall=True)
+    with open(filepath, 'r') as fobj:
+        contents = fobj.read()
+    out = highlight(contents, lexer, FORMATTER)
+    return out

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ gwtrigfind
 gwdatafind
 lscsoft-glue>=1.60.0
 ligo-segments
+pygments
 # need development release of gwpy
 git+https://github.com/gwpy/gwpy.git
 

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ install_requires = [
     'gwpy>=0.8.1',
     'gwtrigfind',
     'gwdatafind',
+    'pygments',
 ]
 if sys.version < '3':
     install_requires.append('enum34')


### PR DESCRIPTION
This PR uses the `pygments` package to render `about` pages with syntax highlighting in configuration files. This does away with a call to `subprocess` and resolves a python3 compatibility issue, as we've seen elsewhere that the `highlight` command line tool leads to malformed html in python-3.x.

Note, `pygments` is available through both PyPI (`pip install pygments`) and Conda (`conda install pygments`) and is compatible with python-3.x. These changes are also consistent with gwdetchar/gwdetchar#251 and gwdetchar/hveto#112.

Test `gw_summary` output is available [**here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/summary/day/20190223/about/index.html), made within an environment running python-2.7 (requires `LIGO.ORG` credentials).

cc @duncanmmacleod 