### PR TITLE
Resolve a bug in ISC noise budget plots

### DIFF
--- a/gwsumm/data/mathutils.py
+++ b/gwsumm/data/mathutils.py
@@ -245,11 +245,11 @@ def _join(a, b, op):
         if a.ndim == 1:  # frequencyseries
             nf = a.size - b.size
             if nf > 0:
-                b = numpy.require(b, requirements=['O'])
-                b.resize((b.size + nf,))
+                c = numpy.require(b, requirements=['O'])
+                b = numpy.resize(b, (c.size - nf,))
             elif nf < 0:
-                a = numpy.require(a, requirements=['O'])
-                a.resize((a.size - nf,))
+                c = numpy.require(a, requirements=['O'])
+                a = numpy.resize(a, (c.size - nf,))
         else:  # spectrogram
             nf = a.shape[1] - b.shape[1]
             new = numpy.zeros((a.shape[0], abs(nf)))

--- a/gwsumm/plot/noisebudget.py
+++ b/gwsumm/plot/noisebudget.py
@@ -124,8 +124,8 @@ class NoiseBudgetPlot(get_plot('spectrum')):
         n = max(x.size for x in sumdata)
         for i, d in enumerate(sumdata):
             if d.size < n:
-                sumdata[i] = numpy.require(d, requirements=['O'])
-                sumdata[i].resize((n,))
+                sumdata[i] = numpy.resize(
+                    numpy.require(d, requirements=['O']), (n,))
 
         # plot sum of noises
         sumargs = self.parse_sum_params()
@@ -216,8 +216,8 @@ class RelativeNoiseBudgetPlot(get_plot('spectrum')):
             n = target.size
             for i, d in enumerate(sumdata):
                 if d.size < n:
-                    sumdata[i] = numpy.require(d, requirements=['O'])
-                    sumdata[i].resize((n,))
+                    sumdata[i] = numpy.resize(
+                        numpy.require(d, requirements=['O']), (n,))
 
             # calculate sum of noises
             sum_ = sumdata[0] ** 2


### PR DESCRIPTION
This PR fixes a bug to allow noise budgets to actually run when we have `OBSERVATION_READY` data. [**Here**](https://ldas-jobs.ligo-la.caltech.edu/~detchar/summary/day/20190308/isc/noise_budget/) is a recent ISC noise budget page for Livingston (requires `LIGO.ORG` credentials), where I have applied these changes as a hotfix.

cc @duncanmmacleod 