### PR TITLE
Use CacheEntry from lal.utils

### DIFF
--- a/gwsumm/tests/test_data.py
+++ b/gwsumm/tests/test_data.py
@@ -32,7 +32,9 @@ import pytest
 
 from numpy import (arange, testing as nptest)
 
-from glue.lal import (Cache, CacheEntry)
+from lal.utils import CacheEntry
+
+from glue.lal import Cache
 
 from gwpy.timeseries import TimeSeries
 from gwpy.detector import Channel

--- a/gwsumm/triggers.py
+++ b/gwsumm/triggers.py
@@ -25,7 +25,9 @@ from six.moves.urllib.parse import urlparse
 
 from astropy.table import vstack as vstack_tables
 
-from glue.lal import (Cache, CacheEntry)
+from lal.utils import CacheEntry
+
+from glue.lal import Cache
 from glue.ligolw import lsctables
 
 from gwpy.io.cache import cache_segments


### PR DESCRIPTION
This PR modifies the necessary modules to import `CacheEntry` from `lal.utils` and not from `glue.lal` where it has been deprecated.