### PR TITLE
Re-order default tabs so Home is first

### DIFF
--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -1134,12 +1134,14 @@ class TabList(list):
 
     @staticmethod
     def _sortkey(tab):
-        if tab.shortname == 'Summary' and tab.parent is None:
+        if 'Home' in tab.shortname:
             return 1
-        elif tab.shortname == 'Summary':
+        if tab.shortname == 'Summary' and tab.parent is None:
             return 2
-        elif 'ODC' in tab.shortname:
+        elif tab.shortname == 'Summary':
             return 3
+        elif 'ODC' in tab.shortname:
+            return 4
         elif tab.shortname.islower():
             return tab.shortname.upper()
         else:


### PR DESCRIPTION
This PR re-orders "blessed" tabs so that `Home` comes first, followed by `Summary`. (Not very interesting) test output is available [**here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/summary/1236906455-1236906460/), the pertinent bit is the top navbar.

cc @duncanmmacleod 