### PR TITLE
Use superevents in gracedb queries

### DIFF
--- a/gwsumm/tabs/gracedb.py
+++ b/gwsumm/tabs/gracedb.py
@@ -88,6 +88,7 @@ class GraceDbTab(get_tab('default')):
     def process(self, config=GWSummConfigParser(), **kwargs):
         try:
             from ligo.gracedb.rest import GraceDb
+            from ligo.gracedb.exceptions import HTTPError
         except ImportError as e:
             e.args = ('%s, this module is required to generate a GraceDbTab'
                       % str(e),)
@@ -106,7 +107,7 @@ class GraceDbTab(get_tab('default')):
                     e['labels'] = ', '.join(connection.superevent(
                         e['graceid']).json()['labels'])
                 vprint("Downloaded labels\n")
-        except:
+        except HTTPError:
             self.events[None] = list(connection.events(querystr))
             vprint("Recovered %d events for query %r\n"
                    % (len(self.events[None]), querystr))

--- a/gwsumm/tabs/gracedb.py
+++ b/gwsumm/tabs/gracedb.py
@@ -95,16 +95,26 @@ class GraceDbTab(get_tab('default')):
         # query gracedb
         service_url = '%s/api/' % self.url
         connection = GraceDb(service_url=service_url)
-        vprint("Connected to gracedb at %s\n" % connection.service_url)
+        vprint("Connected to gracedb at %s\n" % connection._service_url)
         querystr = '%s %d .. %d' % (self.query, self.start, self.end)
-        self.events[None] = list(connection.events(querystr))
-        vprint("Recovered %d events for query %r\n"
-               % (len(self.events[None]), querystr))
-        if 'labels' in self.columns:
-            for e in self.events[None]:
-                e['labels'] = ', '.join(connection.event(
-                    e['graceid']).json()['labels'])
-            vprint("Downloaded labels\n")
+        try:
+            self.events[None] = list(connection.superevents(querystr))
+            vprint("Recovered %d events for query %r\n"
+                   % (len(self.events[None]), querystr))
+            if 'labels' in self.columns:
+                for e in self.events[None]:
+                    e['labels'] = ', '.join(connection.superevent(
+                        e['graceid']).json()['labels'])
+                vprint("Downloaded labels\n")
+        except:
+            self.events[None] = list(connection.events(querystr))
+            vprint("Recovered %d events for query %r\n"
+                   % (len(self.events[None]), querystr))
+            if 'labels' in self.columns:
+                for e in self.events[None]:
+                    e['labels'] = ', '.join(connection.event(
+                        e['graceid']).json()['labels'])
+                vprint("Downloaded labels\n")
         return super(GraceDbTab, self).process(config=config, **kwargs)
 
     def process_state(self, state, **kwargs):

--- a/gwsumm/tabs/gracedb.py
+++ b/gwsumm/tabs/gracedb.py
@@ -96,26 +96,21 @@ class GraceDbTab(get_tab('default')):
         # query gracedb
         service_url = '%s/api/' % self.url
         connection = GraceDb(service_url=service_url)
-        vprint("Connected to gracedb at %s\n" % connection._service_url)
+        vprint("Connected to gracedb at %s\n" % service_url)
         querystr = '%s %d .. %d' % (self.query, self.start, self.end)
         try:
             self.events[None] = list(connection.superevents(querystr))
-            vprint("Recovered %d events for query %r\n"
-                   % (len(self.events[None]), querystr))
-            if 'labels' in self.columns:
-                for e in self.events[None]:
-                    e['labels'] = ', '.join(connection.superevent(
-                        e['graceid']).json()['labels'])
-                vprint("Downloaded labels\n")
+            event_method = connection.superevent
         except HTTPError:
             self.events[None] = list(connection.events(querystr))
-            vprint("Recovered %d events for query %r\n"
-                   % (len(self.events[None]), querystr))
-            if 'labels' in self.columns:
-                for e in self.events[None]:
-                    e['labels'] = ', '.join(connection.event(
-                        e['graceid']).json()['labels'])
-                vprint("Downloaded labels\n")
+            event_method = connection.event
+        vprint("Recovered %d events for query %r\n"
+               % (len(self.events[None]), querystr))
+        if 'labels' in self.columns:
+            for e in self.events[None]:
+                e['labels'] = ', '.join(event_method(
+                    e['graceid']).json()['labels'])
+            vprint("Downloaded labels\n")
         return super(GraceDbTab, self).process(config=config, **kwargs)
 
     def process_state(self, state, **kwargs):


### PR DESCRIPTION
This PR adjusts `gwsumm.tabs.gracedb` so that requested GraceDb queries look for superevents first, and if that fails, fall back to "standard" events (which allows us to still support external triggers).

[**Here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/summary/day/20190319/analysis/gw_events/) is a (so far empty) page of GW events, and [**here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/summary/day/20190319/analysis/exttrig/) is a page of GRBs demonstrating the query still works.

cc @duncanmmacleod 