### PR TITLE
(Invert flags whose active state is) considered harmful

### DIFF
--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -130,7 +130,6 @@ class SegmentDataPlot(SegmentLabelSvgMixin, TimeSeriesDataPlot):
         super(SegmentDataPlot, self).__init__([], start, end, state=state,
                                               outdir=outdir, **kwargs)
         self._allflags = []
-        self._onisbad = self.pargs.get('on-is-bad', False)
         self.flags = flags
         self.preview_labels = False
         self.padding = padding
@@ -331,7 +330,7 @@ class SegmentDataPlot(SegmentLabelSvgMixin, TimeSeriesDataPlot):
                 valid = SegmentList([self.span])
             segs = get_segments(flag, validity=valid, query=False,
                                 padding=self.padding).coalesce()
-            if self._onisbad:
+            if self.pargs.get('on-is-bad', False):
                 segs = ~segs
             pargs.setdefault('known', None)
             pargs.setdefault('y', i)
@@ -493,7 +492,7 @@ class StateVectorDataPlot(TimeSeriesDataPlot):
                 if 'int' not in str(stateseries.dtype):
                     stateseries = stateseries.astype('uint32')
                 newflags = stateseries.to_dqflags().values()
-                if self._onisbad:
+                if self.pargs.get('on-is-bad', False):
                     for i, flag in enumerate(newflags):
                         newflags[i] = ~newflags[i]
                 if flags is None:

--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -130,7 +130,7 @@ class SegmentDataPlot(SegmentLabelSvgMixin, TimeSeriesDataPlot):
         super(SegmentDataPlot, self).__init__([], start, end, state=state,
                                               outdir=outdir, **kwargs)
         self._allflags = []
-        self._onisbad = self.pargs.pop('on-is-bad', False)
+        self._onisbad = self.pargs.get('on-is-bad', False)
         self.flags = flags
         self.preview_labels = False
         self.padding = padding
@@ -493,7 +493,7 @@ class StateVectorDataPlot(TimeSeriesDataPlot):
                 if 'int' not in str(stateseries.dtype):
                     stateseries = stateseries.astype('uint32')
                 newflags = stateseries.to_dqflags().values()
-                if self.pargs.get('on-is-bad', False):
+                if self._onisbad:
                     for i, flag in enumerate(newflags):
                         newflags[i] = ~newflags[i]
                 if flags is None:


### PR DESCRIPTION
This PR inverts bit streams configured to display '1' as a 'bad' state, rather than only inverting the colors. Test output is available [**here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/summary/day/20190319/sqz/overview/) (see the top-right statevector plot in particular).

cc @duncanmmacleod 