### PR TITLE
Use gwdetchar for HTML package table

### DIFF
--- a/gwsumm/html/bootstrap.py
+++ b/gwsumm/html/bootstrap.py
@@ -28,6 +28,8 @@ from six import string_types
 
 from MarkupPy import markup
 
+from gwdetchar.io.html import package_table
+
 from .tables import table
 from .utils import highlight_syntax
 from ..mode import (Mode, get_mode)
@@ -460,20 +462,7 @@ def about_this_page(cmdline=True, config=None, packagelist=True):
             page.div.close()
         page.div.close()
     if packagelist:
-        try:
-            from pip import get_installed_distributions
-        except ImportError:
-            pass
-        else:
-            page.h2('Package list')
-            headers = ['Package name', 'Version']
-            data = sorted([(p.project_name, p.version) for p in
-                           get_installed_distributions(local_only=False)],
-                          key=lambda x: x[0].lower())
-            page.add(str(table(
-                headers, data, id='package-list',
-                caption=("The list of packages present on the "
-                         "system when this page was generated."))))
+        page.add(package_table())
 
     page.div.close()
     page.div.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ lscsoft-glue>=1.60.0
 ligo-segments
 pygments
 MarkupPy
+gwdetchar>=0.3.0
 # need development release of gwpy
 git+https://github.com/gwpy/gwpy.git
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,8 +19,7 @@ ligo-segments
 pygments
 MarkupPy
 gwdetchar>=0.3.0
-# need development release of gwpy
-git+https://github.com/gwpy/gwpy.git
+gwpy>=0.14.2
 
 # optional extras (not module-level imports)
 pykerberos

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ install_requires = [
     'lalsuite',
     'lscsoft-glue>=1.60.0',
     'ligo-segments',
-    'gwpy>=0.8.1',
+    'gwpy>=0.14.2',
     'gwtrigfind',
     'gwdatafind',
     'pygments',

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ install_requires = [
     'gwdatafind',
     'pygments',
     'MarkupPy',
+    'gwdetchar>=0.3.0',
 ]
 if sys.version < '3':
     install_requires.append('enum34')


### PR DESCRIPTION
This PR removes the custom (broken) calls to `pip` with calls out to `gwdetchar.io.html` to build an HTML table of the packages in the current environment.

As a result, this adds `gwdetchar >=0.3.0` as a dependency.