### PR TITLE
Export HTML tables to CSV using javascript

### DIFF
--- a/gwsumm/html/tables.py
+++ b/gwsumm/html/tables.py
@@ -62,19 +62,12 @@ def table(headers, data, caption=None, separator='', id=None, **class_):
     p = page(separator=separator)
     if id is not None:
         kwargs['table']['id_'] = id
+        p.button('Export to CSV', class_='btn btn-default',
+            onclick="exportTableToCSV('{name}.csv', '{name}')".format(
+                name=id))
     p.table(**kwargs['table'])
     if caption:
-        if id is not None:
-            p.div(class_='col-md-8')
-            p.caption(caption, **kwargs['caption'])
-            p.div.close()  # col-md-8
-            p.div(class_='col-md-4')
-            p.button('Export to CSV', class_='btn btn-default',
-                     onclick="exportTableToCSV('{name}.csv', '{name}')".format(
-                         name=id))
-            p.div.close()  # col-md-4
-        else:
-            p.caption(caption, **kwargs['caption'])
+        p.caption(caption, **kwargs['caption'])
 
     # write headers
     p.thead(**kwargs['thead'])

--- a/gwsumm/html/tables.py
+++ b/gwsumm/html/tables.py
@@ -62,7 +62,8 @@ def table(headers, data, caption=None, separator='', id=None, **class_):
     p = page(separator=separator)
     if id is not None:
         kwargs['table']['id_'] = id
-        p.button('Export to CSV', class_='btn btn-default',
+        p.button(
+            'Export to CSV', class_='btn btn-default',
             onclick="exportTableToCSV('{name}.csv', '{name}')".format(
                 name=id))
     p.table(**kwargs['table'])

--- a/gwsumm/html/tables.py
+++ b/gwsumm/html/tables.py
@@ -62,10 +62,6 @@ def table(headers, data, caption=None, separator='', id=None, **class_):
     p = page(separator=separator)
     if id is not None:
         kwargs['table']['id_'] = id
-        p.button(
-            'Export to CSV', class_='btn btn-default',
-            onclick="exportTableToCSV('{name}.csv', '{name}')".format(
-                name=id))
     p.table(**kwargs['table'])
     if caption:
         p.caption(caption, **kwargs['caption'])
@@ -88,4 +84,10 @@ def table(headers, data, caption=None, separator='', id=None, **class_):
     p.tbody.close()
 
     p.table.close()
+
+    if id is not None:
+        p.button(
+            'Export to CSV', class_='btn btn-default',
+            onclick="exportTableToCSV('{name}.csv', '{name}')".format(
+                name=id))
     return p

--- a/gwsumm/html/tables.py
+++ b/gwsumm/html/tables.py
@@ -87,7 +87,7 @@ def table(headers, data, caption=None, separator='', id=None, **class_):
 
     if id is not None:
         p.button(
-            'Export to CSV', class_='btn btn-default',
+            'Export to CSV', class_='btn btn-default btn-table',
             onclick="exportTableToCSV('{name}.csv', '{name}')".format(
                 name=id))
     return p

--- a/gwsumm/html/tables.py
+++ b/gwsumm/html/tables.py
@@ -64,7 +64,17 @@ def table(headers, data, caption=None, separator='', id=None, **class_):
         kwargs['table']['id_'] = id
     p.table(**kwargs['table'])
     if caption:
-        p.caption(caption, **kwargs['caption'])
+        if id is not None:
+            p.div(class_='col-md-8')
+            p.caption(caption, **kwargs['caption'])
+            p.div.close()  # col-md-8
+            p.div(class_='col-md-4')
+            p.button('Export to CSV', class_='btn btn-default',
+                     onclick="exportTableToCSV('{name}.csv', '{name}')".format(
+                         name=id))
+            p.div.close()  # col-md-4
+        else:
+            p.caption(caption, **kwargs['caption'])
 
     # write headers
     p.thead(**kwargs['thead'])

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -859,8 +859,8 @@ class DataTab(ProcessedTab, ParentTab):
                 data.append([
                     dtype(seg[0]),
                     dtype(seg[1]),
-                    from_gps(seg[0]).strftime('%B %d %Y, %H:%M:%S.%f')[:-3],
-                    from_gps(seg[1]).strftime('%B %d %Y, %H:%M:%S.%f')[:-3],
+                    from_gps(seg[0]).strftime('%B %d %Y %H:%M:%S.%f')[:-3],
+                    from_gps(seg[1]).strftime('%B %d %Y %H:%M:%S.%f')[:-3],
                     dtype(abs(seg)),
                 ])
             return html.table(headers, data, id='state-information',

--- a/gwsumm/tabs/etg.py
+++ b/gwsumm/tabs/etg.py
@@ -344,7 +344,7 @@ class EventTriggerTab(get_tab('default')):
                                 1, from_gps(row[tcol]).strftime(
                                        '%B %d %Y, %H:%M:%S.%f')[:-3])
                     page.add(str(html.table(
-                        headers, data,
+                        headers, data, id='%s-loudest-table' % self.etg,
                         caption=("%d loudest <samp>%s</samp> (%s) events "
                                  "by %s with minimum %ss separation"
                                  % (self.loudest['N'], self.channel, self.etg,

--- a/gwsumm/tabs/etg.py
+++ b/gwsumm/tabs/etg.py
@@ -342,7 +342,7 @@ class EventTriggerTab(get_tab('default')):
                         if date:
                             data[-1].insert(
                                 1, from_gps(row[tcol]).strftime(
-                                       '%B %d %Y, %H:%M:%S.%f')[:-3])
+                                       '%B %d %Y %H:%M:%S.%f')[:-3])
                     page.add(str(html.table(
                         headers, data, id='%s-loudest-table' % self.etg,
                         caption=("%d loudest <samp>%s</samp> (%s) events "

--- a/gwsumm/tabs/gracedb.py
+++ b/gwsumm/tabs/gracedb.py
@@ -176,7 +176,7 @@ class GraceDbTab(get_tab('default')):
                 if col == 'date':
                     gpskey = 't_0' if 'superevent_id' in event else 'gpstime'
                     page.td(from_gps(event[gpskey]).strftime(
-                        '%B %d %Y, %H:%M:%S.%f',
+                        '%B %d %Y %H:%M:%S.%f',
                     )[:-3])
                     continue
                 try:

--- a/gwsumm/tabs/gracedb.py
+++ b/gwsumm/tabs/gracedb.py
@@ -203,10 +203,11 @@ class GraceDbTab(get_tab('default')):
         page.table.close()
         if len(self.events[str(state)]) == 0:
             page.p("No events were recovered for this state.")
-        page.button(
-            'Export to CSV', class_='btn btn-default',
-            onclick="exportTableToCSV('{name}.csv', '{name}')".format(
-                name='gracedb'))
+        else:
+            page.button(
+                'Export to CSV', class_='btn btn-default btn-table',
+                onclick="exportTableToCSV('{name}.csv', '{name}')".format(
+                    name='gracedb'))
         page.div.close()  # scaffold well
 
         # query doc

--- a/gwsumm/tabs/gracedb.py
+++ b/gwsumm/tabs/gracedb.py
@@ -144,7 +144,11 @@ class GraceDbTab(get_tab('default')):
         page = markup.page()
         # build table of events
         page.div(class_='scaffold well')
-        page.table(class_='table table-condensed table-hover table-striped')
+        page.table(class_='table table-condensed table-hover table-striped',
+                   id_='gracedb')
+        p.button('Export to CSV', class_='btn btn-default',
+            onclick="exportTableToCSV('{name}.csv', '{name}')".format(
+                name='gracedb'))
         # thead
         page.thead()
         page.tr()

--- a/gwsumm/tabs/gracedb.py
+++ b/gwsumm/tabs/gracedb.py
@@ -146,9 +146,6 @@ class GraceDbTab(get_tab('default')):
         page.div(class_='scaffold well')
         page.table(class_='table table-condensed table-hover table-striped',
                    id_='gracedb')
-        page.button('Export to CSV', class_='btn btn-default',
-            onclick="exportTableToCSV('{name}.csv', '{name}')".format(
-                name='gracedb'))
         # thead
         page.thead()
         page.tr()
@@ -206,6 +203,10 @@ class GraceDbTab(get_tab('default')):
         page.table.close()
         if len(self.events[str(state)]) == 0:
             page.p("No events were recovered for this state.")
+        page.button(
+            'Export to CSV', class_='btn btn-default',
+            onclick="exportTableToCSV('{name}.csv', '{name}')".format(
+                name='gracedb'))
         page.div.close()  # scaffold well
 
         # query doc

--- a/gwsumm/tabs/gracedb.py
+++ b/gwsumm/tabs/gracedb.py
@@ -146,7 +146,7 @@ class GraceDbTab(get_tab('default')):
         page.div(class_='scaffold well')
         page.table(class_='table table-condensed table-hover table-striped',
                    id_='gracedb')
-        p.button('Export to CSV', class_='btn btn-default',
+        page.button('Export to CSV', class_='btn btn-default',
             onclick="exportTableToCSV('{name}.csv', '{name}')".format(
                 name='gracedb'))
         # thead

--- a/gwsumm/tabs/guardian.py
+++ b/gwsumm/tabs/guardian.py
@@ -247,8 +247,12 @@ class GuardianTab(DataTab):
 
         # draw table
         page.h2('%s state transitions' % self.node)
+        id_ = '{}-state-transitions'.format(self.ifo)
         page.table(class_='table table-condensed table-hover '
-                          'table-responsive transitions')
+                          'table-responsive transitions', id_=id_)
+        p.button('Export to CSV', class_='btn btn-default',
+            onclick="exportTableToCSV('{name}.csv', '{name}')".format(
+                name=id_))
         page.caption("Transitions into each state (row) from each other "
                      "state (column). Only those states named in the "
                      "configuration are shown, but the 'Total' includes "

--- a/gwsumm/tabs/guardian.py
+++ b/gwsumm/tabs/guardian.py
@@ -250,7 +250,8 @@ class GuardianTab(DataTab):
         id_ = '{}-state-transitions'.format(self.ifo)
         page.table(class_='table table-condensed table-hover '
                           'table-responsive transitions', id_=id_)
-        page.button('Export to CSV', class_='btn btn-default',
+        page.button(
+            'Export to CSV', class_='btn btn-default',
             onclick="exportTableToCSV('{name}.csv', '{name}')".format(
                 name=id_))
         page.caption("Transitions into each state (row) from each other "

--- a/gwsumm/tabs/guardian.py
+++ b/gwsumm/tabs/guardian.py
@@ -247,7 +247,7 @@ class GuardianTab(DataTab):
 
         # draw table
         page.h2('%s state transitions' % self.node)
-        id_ = '{}-state-transitions'.format(self.ifo)
+        id_ = '{}-state-transitions'.format(self.ifo.lower())
         page.table(class_='table table-condensed table-hover '
                           'table-responsive transitions', id_=id_)
         page.button(

--- a/gwsumm/tabs/guardian.py
+++ b/gwsumm/tabs/guardian.py
@@ -250,7 +250,7 @@ class GuardianTab(DataTab):
         id_ = '{}-state-transitions'.format(self.ifo)
         page.table(class_='table table-condensed table-hover '
                           'table-responsive transitions', id_=id_)
-        p.button('Export to CSV', class_='btn btn-default',
+        page.button('Export to CSV', class_='btn btn-default',
             onclick="exportTableToCSV('{name}.csv', '{name}')".format(
                 name=id_))
         page.caption("Transitions into each state (row) from each other "

--- a/gwsumm/tabs/guardian.py
+++ b/gwsumm/tabs/guardian.py
@@ -250,10 +250,6 @@ class GuardianTab(DataTab):
         id_ = '{}-state-transitions'.format(self.ifo.lower())
         page.table(class_='table table-condensed table-hover '
                           'table-responsive transitions', id_=id_)
-        page.button(
-            'Export to CSV', class_='btn btn-default',
-            onclick="exportTableToCSV('{name}.csv', '{name}')".format(
-                name=id_))
         page.caption("Transitions into each state (row) from each other "
                      "state (column). Only those states named in the "
                      "configuration are shown, but the 'Total' includes "
@@ -284,6 +280,10 @@ class GuardianTab(DataTab):
             page.tr.close()
         page.tbody.close()
         page.table.close()
+        page.button(
+            'Export to CSV', class_='btn btn-default',
+            onclick="exportTableToCSV('{name}.csv', '{name}')".format(
+                name=id_))
         page.div.close()
         page.div.close()
 

--- a/gwsumm/tabs/guardian.py
+++ b/gwsumm/tabs/guardian.py
@@ -322,7 +322,7 @@ class GuardianTab(DataTab):
                     '%s [%d]' % (self.grdstates.get(from_, 'Unknown'), from_),
                     '%s [%d]' % (self.grdstates.get(to_, 'Unknown'), to_)))
             page.add(str(html.table(
-                headers, data,
+                headers, data, id='%s-guardian-transitions' % self.ifo.lower(),
                 caption="Transitions for %s %r state" % (self.node, name))))
 
             # print segments

--- a/gwsumm/tabs/guardian.py
+++ b/gwsumm/tabs/guardian.py
@@ -281,7 +281,7 @@ class GuardianTab(DataTab):
         page.tbody.close()
         page.table.close()
         page.button(
-            'Export to CSV', class_='btn btn-default',
+            'Export to CSV', class_='btn btn-default btn-table',
             onclick="exportTableToCSV('{name}.csv', '{name}')".format(
                 name=id_))
         page.div.close()

--- a/gwsumm/tabs/guardian.py
+++ b/gwsumm/tabs/guardian.py
@@ -327,7 +327,8 @@ class GuardianTab(DataTab):
                     '%s [%d]' % (self.grdstates.get(from_, 'Unknown'), from_),
                     '%s [%d]' % (self.grdstates.get(to_, 'Unknown'), to_)))
             page.add(str(html.table(
-                headers, data, id='%s-guardian-transitions' % self.ifo.lower(),
+                headers, data,
+                id='%s-guardian-%s' % (self.ifo.lower(), str(bit)),
                 caption="Transitions for %s %r state" % (self.node, name))))
 
             # print segments

--- a/gwsumm/tabs/management.py
+++ b/gwsumm/tabs/management.py
@@ -196,9 +196,11 @@ class AccountingTab(ParentTab):
             not name.startswith('*'))
         headers = ['Index', 'Name', 'Active seconds',
                    'Hours', '%']
-        for flags, title in zip(
+        prefix = self.ifo.lower()
+        for flags, title, id in zip(
                 [groups, modes],
-                ['Top-level mode information', 'Detailed mode information']):
+                ['Top-level mode information', 'Detailed mode information'],
+                ['%s-top-level-mode' % prefix, '%s-detailed-mode' % prefix]):
             page.h1(title)
             data = []
             pc = float(abs(state.active) / 100.)
@@ -223,7 +225,7 @@ class AccountingTab(ParentTab):
                 lambda x: '<strong>%s</strong>' % x,
                 ['', 'Total:', '%.1f' % tots, '%.1f' % toth, '%.1f' % totp]))
             page.add(str(html.table(
-                headers, data,
+                headers, data, id=id,
                 caption="%s observatory mode statistics as recorded in "
                         "<samp>%s</samp>" % (title.split()[0], self.channel))))
         return super(ParentTab, self).write_state_html(state, plots=False,

--- a/gwsumm/tabs/sei.py
+++ b/gwsumm/tabs/sei.py
@@ -261,10 +261,6 @@ class SEIWatchDogTab(base):
         id_ = '{}-{}'.format(self.ifo.lower(), chambertype.lower())
         page.table(
             class_='table table-condensed table-hover watchdog', id_=id_)
-        page.button(
-            'Export to CSV', class_='btn btn-default',
-            onclick="exportTableToCSV('{name}.csv', '{name}')".format(
-                name=id_))
         page.caption("Number of watch-dog trips per %s chamber (column) and "
                      "trigger (row)" % (chambertype))
         page.thead()
@@ -318,6 +314,10 @@ class SEIWatchDogTab(base):
         page.tr.close()
         page.thead.close()
         page.table.close()
+        page.button(
+            'Export to CSV', class_='btn btn-default',
+            onclick="exportTableToCSV('{name}.csv', '{name}')".format(
+                name=id_))
         page.div.close()
 
         # build trip groups

--- a/gwsumm/tabs/sei.py
+++ b/gwsumm/tabs/sei.py
@@ -261,7 +261,8 @@ class SEIWatchDogTab(base):
         id_ = '{}-{}'.format(self.ifo, chambertype)
         page.table(
             class_='table table-condensed table-hover watchdog', id_=id_)
-        page.button('Export to CSV', class_='btn btn-default',
+        page.button(
+            'Export to CSV', class_='btn btn-default',
             onclick="exportTableToCSV('{name}.csv', '{name}')".format(
                 name=id_))
         page.caption("Number of watch-dog trips per %s chamber (column) and "

--- a/gwsumm/tabs/sei.py
+++ b/gwsumm/tabs/sei.py
@@ -258,7 +258,7 @@ class SEIWatchDogTab(base):
         # build summary table
         page.div(class_='well')
         chambertype = self.chambers[0][:-1]
-        id_ = '{}-{}'.format(self.ifo, chambertype)
+        id_ = '{}-{}'.format(self.ifo.lower(), chambertype.lower())
         page.table(
             class_='table table-condensed table-hover watchdog', id_=id_)
         page.button(

--- a/gwsumm/tabs/sei.py
+++ b/gwsumm/tabs/sei.py
@@ -379,7 +379,7 @@ class SEIWatchDogTab(base):
             else:
                 rows[-1].append('-')
         page.add(str(html.table(
-            headers, rows,
+            headers, rows, id='%s-watchdog-trips' % self.ifo.lower(),
             caption=('List of %s watch-dog trips in interval [%d .. %d) - '
                      'trips are considered \'associated\' if they fall within '
                      '%s seconds of each other.'

--- a/gwsumm/tabs/sei.py
+++ b/gwsumm/tabs/sei.py
@@ -261,7 +261,7 @@ class SEIWatchDogTab(base):
         id_ = '{}-{}'.format(self.ifo, chambertype)
         page.table(
             class_='table table-condensed table-hover watchdog', id_=id_)
-        p.button('Export to CSV', class_='btn btn-default',
+        page.button('Export to CSV', class_='btn btn-default',
             onclick="exportTableToCSV('{name}.csv', '{name}')".format(
                 name=id_))
         page.caption("Number of watch-dog trips per %s chamber (column) and "

--- a/gwsumm/tabs/sei.py
+++ b/gwsumm/tabs/sei.py
@@ -385,7 +385,7 @@ class SEIWatchDogTab(base):
             else:
                 rows[-1].append('-')
         page.add(str(html.table(
-            headers, rows, id='%s-watchdog-trips' % self.ifo.lower(),
+            headers, rows,
             caption=('List of %s watch-dog trips in interval [%d .. %d) - '
                      'trips are considered \'associated\' if they fall within '
                      '%s seconds of each other.'

--- a/gwsumm/tabs/sei.py
+++ b/gwsumm/tabs/sei.py
@@ -315,7 +315,7 @@ class SEIWatchDogTab(base):
         page.thead.close()
         page.table.close()
         page.button(
-            'Export to CSV', class_='btn btn-default',
+            'Export to CSV', class_='btn btn-default btn-table',
             onclick="exportTableToCSV('{name}.csv', '{name}')".format(
                 name=id_))
         page.div.close()

--- a/gwsumm/tabs/sei.py
+++ b/gwsumm/tabs/sei.py
@@ -257,8 +257,13 @@ class SEIWatchDogTab(base):
 
         # build summary table
         page.div(class_='well')
-        page.table(class_='table table-condensed table-hover watchdog')
         chambertype = self.chambers[0][:-1]
+        id_ = '{}-{}'.format(self.ifo, chambertype)
+        page.table(
+            class_='table table-condensed table-hover watchdog', id_=id_)
+        p.button('Export to CSV', class_='btn btn-default',
+            onclick="exportTableToCSV('{name}.csv', '{name}')".format(
+                name=id_))
         page.caption("Number of watch-dog trips per %s chamber (column) and "
                      "trigger (row)" % (chambertype))
         page.thead()

--- a/share/js/gwsumm.js
+++ b/share/js/gwsumm.js
@@ -245,3 +245,34 @@ $(window).resize(function() {
   // set short month date
   if ($('#calendar').length){ shortenDate();}
 });
+
+// download a CSV table
+function downloadCSV(csv, filename) {
+  var csvFile;
+  var downloadLink;
+  // set download attributes
+  csvFile = new Blob([csv], {type: "text/csv"});
+  downloadLink = document.createElement("a");
+  downloadLink.download = filename;
+  downloadLink.href = window.URL.createObjectURL(csvFile);
+  downloadLink.style.display = "none";
+  document.body.appendChild(downloadLink);
+  // download action
+  downloadLink.click();
+}
+
+// export a table to CSV
+function exportTableToCSV(filename, tableId) {
+  var csv = [];
+  var table = document.getElementById(tableId);
+  var rows = table.querySelectorAll("table tr");
+  // get table rows
+  for (var i = 0; i < rows.length; i++) {
+    var row = [], cols = rows[i].querySelectorAll("td, th");
+    for (var j = 0; j < cols.length; j++) 
+        row.push(cols[j].innerText);
+    csv.push(row.join(","));        
+  }
+  // download CSV record
+  downloadCSV(csv.join("\n"), filename);
+}

--- a/share/sass/gwsumm.scss
+++ b/share/sass/gwsumm.scss
@@ -50,6 +50,12 @@ body {
 		}
 }
 
+// handle buttons attached to tables
+.btn-table {
+		margin-top: -15px;
+		margin-bottom: 15px;
+}
+
 // put images in the middle of their container
 img {
 		margin: 0 auto;


### PR DESCRIPTION
By request of the Livingston management, this PR allows users to export HTML tables to a CSV file. The idea is to only perform this action when it's requested, by providing a bootstrap button whose `onclick` action converts the HTML to CSV using javascript.

The following changes are included:

* Include javascript tools that identify HTML table elements by ID, parse them, and convert to a downloadable CSV blob
* Whenever an `id` is assigned to an HTML table element, include a bootstrap button whose `onclick` action invokes these javascript tools
* Assign `id`s to all HTML tables except the SEI watchdog trips, since they already have a downloadable file
* Remove commas from date formatting, since they pollute the CSV

A full suite of test pages, with several tabs showing a CSV button in action, is available [**here**](https://ldas-jobs.ligo.caltech.edu/~alexander.urban/summary/ER14-test/1237989618-1237993218/time_accounting/llo/) (requires `LIGO.ORG` credentials). On my MacBook, the CSVs are easily parsed by Apple Numbers and Microsoft Excel.

cc @duncanmmacleod