### PR TITLE
Write HDF5 summary after every tab

### DIFF
--- a/bin/gw_summary
+++ b/bin/gw_summary
@@ -703,16 +703,14 @@ for tab in tablist:
                               ifomap=ifobases, about=about.index, base=base,
                               issues=issues, writedata=not opts.html_only,
                               writehtml=not opts.no_html)
+
+    # archive this tab
+    if opts.archive:
+        vprint("Writing data to archive...")
+        archive.write_data_archive(opts.archive)
+        vprint("Archive written in\n{}\n".format(
+            os.path.abspath(opts.archive)))
     vprint("%s complete!\n" % (name))
-
-# -----------------------------------------------------------------------------
-# Finalise
-
-if opts.archive:
-    vprint("\n-------------------------------------------------\n")
-    vprint("Writing data to archive...")
-    archive.write_data_archive(opts.archive)
-    vprint("Done. Archive written in\n%s\n" % os.path.abspath(opts.archive))
 
 vprint("""
 ------------------------------------------------------------------------------


### PR DESCRIPTION
This PR improves condor checkpointing by writing an HDF5 summary after processing every tab, rather than only once at the very end. This will help speed up processing whenever one tab fails.

This fixes #243.

cc @duncanmmacleod