### PR TITLE
Label graceDB events just by GCN_PRELIM_SENT label

### DIFF
--- a/gwsumm/tabs/gracedb.py
+++ b/gwsumm/tabs/gracedb.py
@@ -49,10 +49,7 @@ LABELS["warning"] = {
     "INJ",
 }
 LABELS["success"] = {
-    'EM_READY',
-    'PASTRO_READY',
-    'PE_READY',
-    'SKYMAP_READY',
+    'GCN_PRELIM_SENT',
 }
 
 


### PR DESCRIPTION
This PR updates the logic in the context settings for the GraceDBTab so that an event is labelled with the 'success' context, designed to highlight interesting events, if it has the `GCN_PRELIM_SENT` label, without requiring any others.