### PR TITLE
Use backports configparser package for python < 3.6

### DIFF
--- a/bin/gw_summary
+++ b/bin/gw_summary
@@ -47,12 +47,11 @@ import os
 import re
 import warnings
 from collections import OrderedDict
+from configparser import (DEFAULTSECT, NoOptionError, NoSectionError)
 try:
     from urllib.parse import urlparse
-    from configparser import (DEFAULTSECT, NoOptionError, NoSectionError)
 except ImportError:  # python < 3
     from urlparse import urlparse
-    from ConfigParser import (DEFAULTSECT, NoOptionError, NoSectionError)
 
 from dateutil.relativedelta import relativedelta
 

--- a/bin/gwsumm-plot-guardian
+++ b/bin/gwsumm-plot-guardian
@@ -11,9 +11,9 @@ import argparse
 import os
 import re
 from collections import OrderedDict
+from configparser import DEFAULTSECT
 
 from six import text_type
-from six.moves.configparser import DEFAULTSECT
 
 from matplotlib import use
 use('agg')

--- a/gwsumm/config.py
+++ b/gwsumm/config.py
@@ -19,6 +19,7 @@
 """Thin wrapper around configparser
 """
 
+import configparser
 import os.path
 import re
 from collections import OrderedDict
@@ -27,7 +28,6 @@ from importlib import import_module
 from six import string_types
 from six.moves import (
     StringIO,
-    configparser,
     http_client as httplib,
 )
 

--- a/gwsumm/data/timeseries.py
+++ b/gwsumm/data/timeseries.py
@@ -28,12 +28,9 @@ import warnings
 from math import (floor, ceil)
 from time import sleep
 from collections import OrderedDict
+from configparser import (NoSectionError, NoOptionError)
 
 from six.moves import reduce
-from six.moves.configparser import (
-    NoSectionError,
-    NoOptionError,
-)
 from six.moves.urllib.parse import urlparse
 
 from astropy import units

--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -25,9 +25,9 @@ import bisect
 from itertools import (cycle, combinations)
 from numbers import Number
 from collections import OrderedDict
+from configparser import NoOptionError
 
 from six import string_types
-from six.moves.configparser import NoOptionError
 
 import numpy
 

--- a/gwsumm/plot/sei.py
+++ b/gwsumm/plot/sei.py
@@ -20,8 +20,7 @@
 """
 
 import re
-
-from six.moves.configparser import NoOptionError
+from configparser import NoOptionError
 
 from matplotlib.pyplot import subplots
 from matplotlib.ticker import NullLocator

--- a/gwsumm/segments.py
+++ b/gwsumm/segments.py
@@ -24,15 +24,15 @@ import operator
 import sys
 import warnings
 from collections import OrderedDict
-
-from six import string_types
-from six.moves import reduce
-from six.moves.configparser import (
+from configparser import (
     DEFAULTSECT,
     ConfigParser,
     NoSectionError,
     NoOptionError,
 )
+
+from six import string_types
+from six.moves import reduce
 
 from astropy.io.registry import IORegistryError
 

--- a/gwsumm/state/core.py
+++ b/gwsumm/state/core.py
@@ -22,10 +22,7 @@
 import datetime
 import re
 import operator
-try:
-    from configparser import (NoOptionError, DEFAULTSECT)
-except ImportError:  # python < 3
-    from ConfigParser import (NoOptionError, DEFAULTSECT)
+from configparser import (NoOptionError, DEFAULTSECT)
 
 from astropy.time import Time
 

--- a/gwsumm/tabs/builtin.py
+++ b/gwsumm/tabs/builtin.py
@@ -29,9 +29,9 @@ The `builtin` classes provide interfaces for simple operations including
 
 import os.path
 import warnings
+from configparser import NoOptionError
 
 from six import string_types
-from six.moves.configparser import NoOptionError
 
 from MarkupPy import markup
 

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -36,10 +36,10 @@ keyword arguments.
 import os
 import re
 from collections import OrderedDict
+from configparser import NoOptionError
 from shutil import copyfile
 
 from six import string_types
-from six.moves.configparser import NoOptionError
 from six.moves.urllib.parse import urlparse
 
 from MarkupPy import markup

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -28,16 +28,15 @@ from __future__ import print_function
 import os.path
 import getpass
 import re
-
-from copy import copy
-from datetime import timedelta
-
-from six.moves import StringIO
-from six.moves.configparser import (
+from configparser import (
     ConfigParser,
     NoOptionError,
     NoSectionError,
 )
+from copy import copy
+from datetime import timedelta
+
+from six.moves import StringIO
 
 from MarkupPy import markup
 

--- a/gwsumm/tabs/etg.py
+++ b/gwsumm/tabs/etg.py
@@ -20,10 +20,10 @@
 """
 
 import os
+from configparser import NoOptionError
 from warnings import warn
 
 from six import string_types
-from six.moves.configparser import NoOptionError
 
 from MarkupPy import markup
 

--- a/gwsumm/tabs/gracedb.py
+++ b/gwsumm/tabs/gracedb.py
@@ -20,10 +20,7 @@
 """
 
 from collections import OrderedDict
-try:
-    from configparser import NoOptionError
-except ImportError:  # python < 3
-    from ConfigParser import NoOptionError
+from configparser import NoOptionError
 
 from MarkupPy import markup
 

--- a/gwsumm/tabs/guardian.py
+++ b/gwsumm/tabs/guardian.py
@@ -21,10 +21,7 @@
 
 import re
 from collections import OrderedDict
-try:
-    from configparser import NoOptionError
-except ImportError:
-    from ConfigParser import NoOptionError
+from configparser import NoOptionError
 
 from dateutil import tz
 

--- a/gwsumm/tabs/management.py
+++ b/gwsumm/tabs/management.py
@@ -21,10 +21,7 @@
 
 import re
 from collections import OrderedDict
-try:
-    from configparser import NoOptionError
-except ImportError:
-    from ConfigParser import NoOptionError
+from configparser import NoOptionError
 
 from glue.lal import Cache
 

--- a/gwsumm/tabs/sei.py
+++ b/gwsumm/tabs/sei.py
@@ -24,10 +24,7 @@ from __future__ import print_function
 import os
 import re
 from collections import OrderedDict
-try:
-    from configparser import NoOptionError
-except ImportError:  # python < 3
-    from ConfigParser import NoOptionError
+from configparser import NoOptionError
 
 from dateutil import tz
 

--- a/gwsumm/tests/test_config.py
+++ b/gwsumm/tests/test_config.py
@@ -22,9 +22,9 @@
 import os.path
 import tempfile
 from collections import OrderedDict
+from configparser import (DEFAULTSECT, ConfigParser)
 
 from six.moves import StringIO
-from six.moves.configparser import (DEFAULTSECT, ConfigParser)
 
 import pytest
 

--- a/gwsumm/tests/test_plot.py
+++ b/gwsumm/tests/test_plot.py
@@ -22,10 +22,7 @@
 
 import os
 
-try:
-    from configparser import ConfigParser
-except ImportError:  # python < 3
-    from ConfigParser import ConfigParser
+from configparser import ConfigParser
 
 from matplotlib import use
 use('agg')  # noqa

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ libsass
 jsmin
 
 # core requirements
-enum34 ; python_version < '3'
+enum34 ; python_version < '3.4'
 python-dateutil
 lxml
 numpy>=1.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ pygments
 MarkupPy
 gwdetchar>=0.4.0
 gwpy>=0.14.2
+configparser ; python_version < '3.6'
 
 # optional extras (not module-level imports)
 pykerberos

--- a/setup.py
+++ b/setup.py
@@ -86,9 +86,8 @@ install_requires = [
     'MarkupPy',
     'gwdetchar>=0.4.0',
     'configparser ; python_version < \'3.6\'',
+    'enum34 ; python_version < \'3.4\''
 ]
-if sys.version < '3':
-    install_requires.append('enum34')
 
 # testing requirements
 if {'pytest', 'test'}.intersection(sys.argv):

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ install_requires = [
     'pygments',
     'MarkupPy',
     'gwdetchar>=0.4.0',
+    'configparser ; python_version < \'3.6\'',
 ]
 if sys.version < '3':
     install_requires.append('enum34')


### PR DESCRIPTION
This PR updates the dependencies to use the backports `configparser` package for python < 3.6. This allows us to simplify the imports of that module to use up-to-date ('python3') names, removing the need for `six` at least in this case, and removing ambiguity about which package (stdlib `configparser`, backports `configparser`, or stdlib `ConfigParser`) will be used at runtime.