### PR TITLE
Use codecov for coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  precision: 2
+  range: 50..100
+  round: nearest
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1
+    patch:
+      default:
+        target: 90

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ script:
   - python -m coverage run --append $(which gwsumm-plot-guardian) --help
 
 after_success:
-  - python -m pip install ${PIP_FLAGS} coveralls
-  - coveralls
+  - python -m pip install ${PIP_FLAGS} codecov
+  - python -m codecov --flags $(uname) python${TRAVIS_PYTHON_VERSION/./}
 
 cache:
   pip: true

--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ Gravitational-wave Summary Information Generator
 GWSumm is a python toolbox used by the LIGO Scientific Collaboration to summarise and archive myriad facets of the performance of the LIGO instruments, and archive these data in a nested HTML structure.
 
 [![Build Status](https://travis-ci.org/gwpy/gwsumm.svg?branch=master)](https://travis-ci.org/gwpy/gwsumm)
-[![Coverage Status](https://coveralls.io/repos/github/gwpy/gwsumm/badge.svg?branch=master)](https://coveralls.io/github/gwpy/gwsumm?branch=master)
+[![codecov](https://codecov.io/gh/gwpy/gwsumm/branch/master/graph/badge.svg)](https://codecov.io/gh/gwpy/gwsumm)
 [![Code Climate](https://codeclimate.com/github/gwpy/gwsumm/badges/gpa.svg)](https://codeclimate.com/github/gwpy/gwsumm)  


### PR DESCRIPTION
This PR updates the CI to use codecov, it's a bit more feature-complete compared to coveralls.