### PR TITLE
Python 3 compatibility fixes

### DIFF
--- a/bin/gw_summary
+++ b/bin/gw_summary
@@ -495,8 +495,7 @@ vprint("    Loaded %d rcParams\n" % len(rcp))
 tablist = TabList.from_ini(config, match=opts.process_tab,
                            path=path, plotdir=plotdir)
 tablist.sort(reverse=True)
-tabs = tablist.get_hierarchy()
-tabs.sort(key=tablist._sortkey)
+tabs = sorted(tablist.get_hierarchy(), key=tablist._sortkey)
 vprint("    Loaded %d tabs [%d parents overall]\n" % (len(tablist), len(tabs)))
 
 # read caches

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -67,7 +67,7 @@ class BaseTab(object):
     """
     def __init__(self, name, index=None,
                  shortname=None, parent=None, children=list(), group=None,
-                 path=os.curdir, mode=None, hidden=False):
+                 path=os.curdir, mode=None, hidden=False, **kwargs):
         # mode
         self.mode = mode
         # names

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -1072,8 +1072,7 @@ class TabList(list):
         """
         if key is None:
             key = self._sortkey
-        hlist = self.get_hierarchy()
-        hlist.sort(key=key)
+        hlist = sorted(self.get_hierarchy(), key=key)
         for tab in hlist:
             tab.children.sort(key=key)
         super(TabList, self).sort(key=key, reverse=reverse)


### PR DESCRIPTION
I've made a few changes that fix some problems that I was seeing when trying to run gwsummary in a Python 3.7 environment.