### PR TITLE
Highlight certain dates in the calendar datepicker

### DIFF
--- a/gwsumm/html/bootstrap.py
+++ b/gwsumm/html/bootstrap.py
@@ -76,7 +76,7 @@ def banner(title, subtitle=None, titleclass=None, subtitleclass=None):
 
 
 def calendar(date, tag='a', class_='navbar-brand dropdown-toggle',
-             id_='calendar', dateformat=None, mode=None):
+             id_='calendar', dateformat=None, mode=None, selecteddates=None):
     """Construct a bootstrap-datepicker calendar.
 
     Parameters
@@ -111,7 +111,8 @@ def calendar(date, tag='a', class_='navbar-brand dropdown-toggle',
            onclick='stepDate(-1)')
     page.a(id_=id_, class_=class_, title='Show/hide calendar',
            **{'data-date': data_date, 'data-date-format': 'dd-mm-yyyy',
-              'data-viewmode': '%ss' % mode.name})
+              'data-viewmode': '%ss' % mode.name,
+              'selected-dates': ','.join([str(seldate) for seldate in selected]) })
     page.add(datestring)
     page.b('', class_='caret')
     page.a.close()

--- a/gwsumm/html/bootstrap.py
+++ b/gwsumm/html/bootstrap.py
@@ -76,7 +76,8 @@ def banner(title, subtitle=None, titleclass=None, subtitleclass=None):
 
 
 def calendar(date, tag='a', class_='navbar-brand dropdown-toggle',
-             id_='calendar', dateformat=None, mode=None, selecteddates=None):
+             id_='calendar', dateformat=None, mode=None,
+             highlighteddates=None):
     """Construct a bootstrap-datepicker calendar.
 
     Parameters
@@ -109,10 +110,13 @@ def calendar(date, tag='a', class_='navbar-brand dropdown-toggle',
     page = markup.page()
     page.a('&laquo;', class_='navbar-brand step-back', title='Step back',
            onclick='stepDate(-1)')
+    attributekwargs = {'data-date': data_date,
+                       'data-date-format': 'dd-mm-yyyy',
+                       'data-viewmode': '%ss' % mode.name}
+    if highlighteddates is not None:
+        attributekwargs['highlighted-dates'] = highligheddates.replace('-', '')
     page.a(id_=id_, class_=class_, title='Show/hide calendar',
-           **{'data-date': data_date, 'data-date-format': 'dd-mm-yyyy',
-              'data-viewmode': '%ss' % mode.name,
-              'selected-dates': ','.join([str(seldate) for seldate in selected]) })
+           **attributekwargs)
     page.add(datestring)
     page.b('', class_='caret')
     page.a.close()

--- a/gwsumm/html/bootstrap.py
+++ b/gwsumm/html/bootstrap.py
@@ -77,7 +77,7 @@ def banner(title, subtitle=None, titleclass=None, subtitleclass=None):
 
 def calendar(date, tag='a', class_='navbar-brand dropdown-toggle',
              id_='calendar', dateformat=None, mode=None,
-             highlighteddates=None):
+             highlighteddates=None, highlightavailable=False):
     """Construct a bootstrap-datepicker calendar.
 
     Parameters
@@ -114,7 +114,10 @@ def calendar(date, tag='a', class_='navbar-brand dropdown-toggle',
                        'data-date-format': 'dd-mm-yyyy',
                        'data-viewmode': '%ss' % mode.name}
     if highlighteddates is not None:
-        attributekwargs['highlighted-dates'] = highlighteddates.replace('-', '')
+        attributekwargs['highlight-dates'] = highlighteddates.replace('-', '')
+    else:
+        if highlightavailable:
+            attributekwargs['highlight-available-dates'] = 'true'
     page.a(id_=id_, class_=class_, title='Show/hide calendar',
            **attributekwargs)
     page.add(datestring)

--- a/gwsumm/html/bootstrap.py
+++ b/gwsumm/html/bootstrap.py
@@ -114,7 +114,7 @@ def calendar(date, tag='a', class_='navbar-brand dropdown-toggle',
                        'data-date-format': 'dd-mm-yyyy',
                        'data-viewmode': '%ss' % mode.name}
     if highlighteddates is not None:
-        attributekwargs['highlighted-dates'] = highligheddates.replace('-', '')
+        attributekwargs['highlighted-dates'] = highlighteddates.replace('-', '')
     page.a(id_=id_, class_=class_, title='Show/hide calendar',
            **attributekwargs)
     page.add(datestring)

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -437,12 +437,17 @@ class BaseTab(object):
                 kwargs['duration'] = cp.getfloat(section, 'duration')
 
         # check for calendar dates to highlight
-        print(cp.has_option('calendar', 'highlighted-dates'))
-        if cp.has_option('calendar', 'highlighted-dates'):
-            try:
-                kwargs['highlighteddates']
-            except KeyError:
-                kwargs['highlighteddates'] = cp.get('calendar', 'highlighted-dates')
+        if cp.has_section('calendar'):
+            if cp.has_option('calendar', 'highlighted-dates'):
+                try:
+                    kwargs['highlighteddates']
+                except KeyError:
+                    kwargs['highlighteddates'] = cp.get('calendar', 'highlighted-dates')
+            elif cp.has_option('calendar', 'highlightavailable'):
+                try:
+                    kwargs['highlightavailable']
+                except KeyError:
+                    kwargs['highlightavailable'] = cp.getboolean('calendar', 'highlight-available')
 
         return cls(name, *args, **kwargs)
 
@@ -782,7 +787,6 @@ class GpsTab(BaseTab):
 class IntervalTab(GpsTab):
     """`Tab` defined within a GPS [start, end) interval
     """
-    #def __init__(self, highlighteddates=None, *args, **kwargs):
     def __init__(self, *args, **kwargs):
         try:
             span = kwargs.pop('span')
@@ -802,6 +806,11 @@ class IntervalTab(GpsTab):
             self.highlighteddates = kwargs.pop('highlighteddates')
         except KeyError:
             self.highlighteddates = None
+
+        try:
+            self.highlightavailable = kwargs.pop('highlightavailable')
+        except KeyError:
+            self.highlightavailable = False
 
         self.span = span
         super(IntervalTab, self).__init__(*args, **kwargs)
@@ -826,7 +835,8 @@ class IntervalTab(GpsTab):
                                % (self.path, requiredpath))
         # format calendar
         return html.calendar(date, mode=self.mode,
-                             highlighteddates=self.highlighteddates)
+                             highlighteddates=self.highlighteddates,
+                             highlightavailable=self.highlightavailable)
 
     def html_navbar(self, brand=None, calendar=True, **kwargs):
         """Build the navigation bar for this `Tab`.

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -792,7 +792,7 @@ class IntervalTab(GpsTab):
         super(IntervalTab, self).__init__(*args, **kwargs)
 
     @classmethod
-    def from_ini(cls, cp, section='calendar', *args, **kwargs):
+    def from_ini(cls, cp, section, *args, **kwargs):
         """Configure a new `IntervalTab` from a `ConfigParser` section
         Parameters
         ----------
@@ -808,20 +808,20 @@ class IntervalTab(GpsTab):
         Notes
         -----
         On top of the standard configuration options, the `IntervalTab` can
-        be configured with the ``selected-dates`` option, specifying dates to
-        be highlighted in the calendar:
+        be configured with the ``highlighted-dates`` option, specifying dates
+        to be highlighted in the calendar:
         .. code-block:: ini
            [calendar]
-           selected-dates = 2019-01-04,2019-01-07
+           highlighted-dates = 2019-01-04,2019-01-07
         """
-        
-        if cp.has_option(section, 'selected-dates'):
-            self.selecteddates = cp.get(section, 'selected-dates'))
-        else:
-            self.selecteddates = None
-        return super(IntervalTab, cls).from_ini(cp, section, url,
-                                                *args, **kwargs)
-        
+
+        # check for highlighted dates
+        self.highlightteddates = None
+        if cp.has_option('calendar', 'highlighted-dates'):
+            self.highlighteddates = cp.get(section, 'highlighted-dates'))
+
+        return super(IntervalTab, cls).from_ini(cp, section, *args, **kwargs)
+
     def html_calendar(self):
         """Build the datepicker calendar for this tab.
 
@@ -841,7 +841,8 @@ class IntervalTab(GpsTab):
                                "format including %r for archive calendar"
                                % (self.path, requiredpath))
         # format calendar
-        return html.calendar(date, mode=self.mode, selecteddates=self.selecteddates)
+        return html.calendar(date, mode=self.mode,
+                             highlighteddates=self.selecteddates)
 
     def html_navbar(self, brand=None, calendar=True, **kwargs):
         """Build the navigation bar for this `Tab`.

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -443,11 +443,12 @@ class BaseTab(object):
                     kwargs['highlighteddates']
                 except KeyError:
                     kwargs['highlighteddates'] = cp.get('calendar', 'highlighted-dates')
-            elif cp.has_option('calendar', 'highlightavailable'):
+            elif cp.has_option('calendar', 'highlight-available'):
                 try:
                     kwargs['highlightavailable']
                 except KeyError:
                     kwargs['highlightavailable'] = cp.getboolean('calendar', 'highlight-available')
+            print(kwargs)
 
         return cls(name, *args, **kwargs)
 

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -791,6 +791,37 @@ class IntervalTab(GpsTab):
         self.span = span
         super(IntervalTab, self).__init__(*args, **kwargs)
 
+    @classmethod
+    def from_ini(cls, cp, section='calendar', *args, **kwargs):
+        """Configure a new `IntervalTab` from a `ConfigParser` section
+        Parameters
+        ----------
+        cp : :class:`~gwsumm.config.ConfigParser`
+            configuration to parse.
+        section : `str`
+            name of section to read
+        See Also
+        --------
+        Tab.from_ini :
+            for documentation of the standard configuration
+            options
+        Notes
+        -----
+        On top of the standard configuration options, the `IntervalTab` can
+        be configured with the ``selected-dates`` option, specifying dates to
+        be highlighted in the calendar:
+        .. code-block:: ini
+           [calendar]
+           selected-dates = 2019-01-04,2019-01-07
+        """
+        
+        if cp.has_option(section, 'selected-dates'):
+            self.selecteddates = cp.get(section, 'selected-dates'))
+        else:
+            self.selecteddates = None
+        return super(IntervalTab, cls).from_ini(cp, section, url,
+                                                *args, **kwargs)
+        
     def html_calendar(self):
         """Build the datepicker calendar for this tab.
 
@@ -810,7 +841,7 @@ class IntervalTab(GpsTab):
                                "format including %r for archive calendar"
                                % (self.path, requiredpath))
         # format calendar
-        return html.calendar(date, mode=self.mode)
+        return html.calendar(date, mode=self.mode, selecteddates=self.selecteddates)
 
     def html_navbar(self, brand=None, calendar=True, **kwargs):
         """Build the navigation bar for this `Tab`.

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -818,7 +818,7 @@ class IntervalTab(GpsTab):
         # check for highlighted dates
         self.highlightteddates = None
         if cp.has_option('calendar', 'highlighted-dates'):
-            self.highlighteddates = cp.get(section, 'highlighted-dates'))
+            self.highlighteddates = cp.get(section, 'highlighted-dates')
 
         return super(IntervalTab, cls).from_ini(cp, section, *args, **kwargs)
 

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -436,6 +436,14 @@ class BaseTab(object):
             except KeyError:
                 kwargs['duration'] = cp.getfloat(section, 'duration')
 
+        # check for calendar dates to highlight
+        print(cp.has_option('calendar', 'highlighted-dates'))
+        if cp.has_option('calendar', 'highlighted-dates'):
+            try:
+                kwargs['highlighteddates']
+            except KeyError:
+                kwargs['highlighteddates'] = cp.get('calendar', 'highlighted-dates')
+
         return cls(name, *args, **kwargs)
 
     # -- HTML operations ------------------------
@@ -774,6 +782,7 @@ class GpsTab(BaseTab):
 class IntervalTab(GpsTab):
     """`Tab` defined within a GPS [start, end) interval
     """
+    #def __init__(self, highlighteddates=None, *args, **kwargs):
     def __init__(self, *args, **kwargs):
         try:
             span = kwargs.pop('span')
@@ -788,39 +797,14 @@ class IntervalTab(GpsTab):
                                 % (type(self).__name__, mode))
             else:
                 span = (start, end)
+
+        try:
+            self.highlighteddates = kwargs.pop('highlighteddates')
+        except KeyError:
+            self.highlighteddates = None
+
         self.span = span
         super(IntervalTab, self).__init__(*args, **kwargs)
-
-    @classmethod
-    def from_ini(cls, cp, section, *args, **kwargs):
-        """Configure a new `IntervalTab` from a `ConfigParser` section
-        Parameters
-        ----------
-        cp : :class:`~gwsumm.config.ConfigParser`
-            configuration to parse.
-        section : `str`
-            name of section to read
-        See Also
-        --------
-        Tab.from_ini :
-            for documentation of the standard configuration
-            options
-        Notes
-        -----
-        On top of the standard configuration options, the `IntervalTab` can
-        be configured with the ``highlighted-dates`` option, specifying dates
-        to be highlighted in the calendar:
-        .. code-block:: ini
-           [calendar]
-           highlighted-dates = 2019-01-04,2019-01-07
-        """
-
-        # check for highlighted dates
-        self.highlightteddates = None
-        if cp.has_option('calendar', 'highlighted-dates'):
-            self.highlighteddates = cp.get(section, 'highlighted-dates')
-
-        return super(IntervalTab, cls).from_ini(cp, section, *args, **kwargs)
 
     def html_calendar(self):
         """Build the datepicker calendar for this tab.
@@ -842,7 +826,7 @@ class IntervalTab(GpsTab):
                                % (self.path, requiredpath))
         # format calendar
         return html.calendar(date, mode=self.mode,
-                             highlighteddates=self.selecteddates)
+                             highlighteddates=self.highlighteddates)
 
     def html_navbar(self, brand=None, calendar=True, **kwargs):
         """Build the navigation bar for this `Tab`.

--- a/share/js/gwsumm.js
+++ b/share/js/gwsumm.js
@@ -196,14 +196,15 @@ $(window).load(function() {
       // highlight selected dates if given
       if ( document.getElementById('calendar').hasAttribute('selected-dates') ){
         var selected_dates = document.getElementById('calendar').getAttribute('selected-dates').split(',');
-        var calendar_date = date.getUTCFullYear() + ('0'+(date.getMonth()+1)).slice(-2) + ('0'+date.getDate()).slice(-2);
-        var search_index = highlightdays.indexOf(calendar_date);
-        if ( search_index == -1 ){
-          // disable dates that are not given
-          return {enabled: false, tooltip: 'Date not available'};
-        }
-        else{
-          return {classes: 'highlighted', enabled: true};
+        if (selected_dates.length > 0 ){
+          var calendar_date = date.getUTCFullYear() + ('0'+(date.getMonth()+1)).slice(-2) + ('0'+date.getDate()).slice(-2);
+          if ( selected_dates.indexOf(calendar_date) == -1 ){
+            // disable dates that are not given
+            return {enabled: false, tooltip: 'Date not available'};
+          }
+          else{
+            return {classes: 'highlighted', enabled: true};
+          }
         }
       }
     }

--- a/share/js/gwsumm.js
+++ b/share/js/gwsumm.js
@@ -193,11 +193,11 @@ $(window).load(function() {
     todayHighlight: true,
     todayBtn: "linked",
     beforeShowDay: function(date) {
-      // highlight selected dates if given
-      if ( document.getElementById('calendar').hasAttribute('highlighted-dates') ){
-        var selected_dates = document.getElementById('calendar').getAttribute('highlighted-dates').split(',');
+      var calendar_date = date.getUTCFullYear() + ('0'+(date.getMonth()+1)).slice(-2) + ('0'+date.getDate()).slice(-2);
+      if ( document.getElementById('calendar').hasAttribute('highlight-dates') ){
+        // highlight selected dates if given
+        var selected_dates = document.getElementById('calendar').getAttribute('highlight-dates').split(',');
         if (selected_dates.length > 0 ){
-          var calendar_date = date.getUTCFullYear() + ('0'+(date.getMonth()+1)).slice(-2) + ('0'+date.getDate()).slice(-2);
           if ( selected_dates.indexOf(calendar_date) == -1 ){
             // disable dates that are not given
             return {enabled: false, tooltip: 'Date not available'};
@@ -205,6 +205,20 @@ $(window).load(function() {
           else{
             return {classes: 'highlighted', enabled: true};
           }
+        }
+      }
+      else if ( document.getElementById('calendar').hasAttribute('highlight-available-dates') ) {
+        // highlight dates for which the URL exists (this is slow)
+        var cururl = window.location.href
+        var dateurl = cururl.slice(0, -9) + calendar_date;
+        var request = new XMLHttpRequest();
+        request.open('HEAD', dateurl, false);
+        request.send()
+        if ( request.status == 404 ){
+          return {enabled: false, tooltip: 'Date not available'};
+        }
+        else {
+          return {classes: 'highlighted', enabled: true};
         }
       }
     }

--- a/share/js/gwsumm.js
+++ b/share/js/gwsumm.js
@@ -191,7 +191,22 @@ $(window).load(function() {
     weekStart: 1,
     endDate: moment().utc().format('DD/MM/YYYY'),
     todayHighlight: true,
-    todayBtn: "linked"
+    todayBtn: "linked",
+    beforeShowDay: function(date) {
+      // highlight selected dates if given
+      if ( document.getElementById('calendar').hasAttribute('selected-dates') ){
+        var selected_dates = document.getElementById('calendar').getAttribute('selected-dates').split(',');
+        var calendar_date = date.getUTCFullYear() + ('0'+(date.getMonth()+1)).slice(-2) + ('0'+date.getDate()).slice(-2);
+        var search_index = highlightdays.indexOf(calendar_date);
+        if ( search_index == -1 ){
+          // disable dates that are not given
+          return {enabled: false, tooltip: 'Date not available'};
+        }
+        else{
+          return {classes: 'highlighted', enabled: true};
+        }
+      }
+    }
   }).on('changeDate', move_to_date);
 
   // load correct run type

--- a/share/js/gwsumm.js
+++ b/share/js/gwsumm.js
@@ -194,8 +194,8 @@ $(window).load(function() {
     todayBtn: "linked",
     beforeShowDay: function(date) {
       // highlight selected dates if given
-      if ( document.getElementById('calendar').hasAttribute('selected-dates') ){
-        var selected_dates = document.getElementById('calendar').getAttribute('selected-dates').split(',');
+      if ( document.getElementById('calendar').hasAttribute('highlighted-dates') ){
+        var selected_dates = document.getElementById('calendar').getAttribute('highlighted-dates').split(',');
         if (selected_dates.length > 0 ){
           var calendar_date = date.getUTCFullYear() + ('0'+(date.getMonth()+1)).slice(-2) + ('0'+date.getDate()).slice(-2);
           if ( selected_dates.indexOf(calendar_date) == -1 ){


### PR DESCRIPTION
I'm using `gw_summary` to show summary pages that will only be produced on certain dates. This PR allows you to specify in the configuration file either a selection of specific dates to highlight, or whether the page will check URLs for dates that exist (non-highlighted dates will be disabled).

In both methods I have it so that the requested dates are highlighted and other dates are not enabled. The latter method, which checks the URLs can be a bit slow in rendering the page, as it has to check the URLs synchronously before rendering.

To select the former option you would add e.g. (the dates can be with or without the hyphens)

```
[calendar]
highlighted-dates = 2019-01-02,2019-01-05
```

and for the latter option you would add

```
[calendar]
highlight-available = True
```

If you have the `highlighted-dates` option, then that is favoured over the `highlight-available` option. If you have neither of these then things should render as normal.

Currently, the options in the `calendar` section are read in in the `from_ini` class method of the `BaseTab`, as I couldn't find a better way to do it. I'd tried adding a `from_ini` method to the `IntervalTab` in which to read in the values, but couldn't get that to work.

Does this patch look ok/useful?
