### PR TITLE
Bugfix for coherencegram segment overlaps

### DIFF
--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -436,7 +436,7 @@ def _get_from_list(serieslist, segment):
     Should only be used in situations where the existence of the target
     data within the list is guaranteed
     """
-    spans = SegmentList([series.span for series in serieslist])
+    spans = [series.span for series in serieslist]
     try:  # take the union of all segments
         outseg = reduce(operator.and_, spans, segment)
     except ValueError:  # raise exception if segments do not overlap

--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -240,10 +240,10 @@ def _get_coherence_spectrogram(channel_pair, segments, config=None,
                 if len(tslist1) + len(tslist2):
                     vprint('\n')
 
-        spans = [[  # record spectrogaram spans
+        spans = [SegmentList([  # record spectrogaram spans
             spec.span for spec in globalv.COHERENCE_COMPONENTS[ck]
-        ] for ck in ckeys]
-        new = _get_common_segments(new, spans)
+        ]) for ck in ckeys]
+        new = reduce(operator.and_, spans, new).coalesce()
         for seg in new:  # compute coherence from components
             cxy, cxx, cyy = [_get_from_list(
                 globalv.COHERENCE_COMPONENTS[ck], seg) for ck in ckeys]
@@ -432,29 +432,6 @@ def get_coherence_spectrograms(channel_pairs, segments, config=None,
             nds=nds, nproc=nproc, return_=return_,
             datafind_error=datafind_error, **fftparams)
     return out
-
-
-def _get_common_segments(segments, spans):
-    """Internal function to find the union of a collection of segments
-
-    Parameters
-    ----------
-    segments : `SegmentList`
-        list of `~gwpy.segments.Segment`
-
-    spans : `list` of `SegmentList`
-        list of time-domain spans of `~gwpy.types.Series` objects
-
-    Returns
-    -------
-    outsegs : `SegmentList`
-        list of segments common between `spans` and `segments`
-    """
-    # coalesce all segments
-    segments = SegmentList(segments).coalesce()
-    spans = [SegmentList(s).coalesce() for s in spans]
-    # return the coalesced union of all segments
-    return reduce(operator.and_, spans, segments).coalesce()
 
 
 def _get_from_list(serieslist, segment):

--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -241,13 +241,14 @@ def _get_coherence_spectrogram(channel_pair, segments, config=None,
                     vprint('\n')
 
         # store coherence in globalv
-        spans = [  # record data spans
+        spans = SegmentList([  # record data spans
             series.span for series in globalv.COHERENCE_COMPONENTS[ck] for
-            ck in ckeys]
-        for seg in new:  # compute coherence from components
-            if all([seg.intersects(span) for span in spans]):
-                cxy, cxx, cyy = [
-                    _get_from_list(globalv.COHERENCE_COMPONENTS[ck], seg) for
+            ck in ckeys])
+        for seg in new:  # compute coherence
+            if spans.intersects_segment(seg):
+                outseg = reduce(operator.and_, spans, seg)
+                cxy, cxx, cyy = [_get_from_list(
+                    globalv.COHERENCE_COMPONENTS[ck], outseg) for
                     ck in ckeys]
                 csg = abs(cxy)**2 / cxx / cyy
                 globalv.SPECTROGRAMS[key].append(csg)

--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -439,7 +439,8 @@ def _get_from_list(serieslist, segment):
     data within the list is guaranteed
     """
     for series in serieslist:
-        if segment in series.span:
+        if segment.intersects(series.span):
+            segment = segment & series.span
             return series.crop(*segment)
     raise ValueError("Cannot crop series for segment %s from list"
                      % str(segment))

--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -456,12 +456,12 @@ def _get_common_segments(segments, spans):
     individually have the same number of elements as `segments`.
     """
     outsegs = SegmentList([])
-    for i, segment in enumerate(segments):
-        spanlist = SegmentList([s[i] for s in spans])
-        try:  # take the intersection of all segments
-            outsegs.append(reduce(operator.and_, spanlist, segment))
-        except ValueError:
-            pass  # ignore non-overlapping segments
+    for segment in segments:
+        for spanlist in zip_longest(*spans, fillvalue=segment):
+            try:  # take the intersection of all segments
+                outsegs.append(reduce(operator.and_, spanlist, segment))
+            except ValueError:
+                pass  # ignore non-overlapping segments
     return outsegs.coalesce()
 
 

--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -240,6 +240,7 @@ def _get_coherence_spectrogram(channel_pair, segments, config=None,
                 if len(tslist1) + len(tslist2):
                     vprint('\n')
 
+        # store coherence in globalv
         spans = [  # record data spans
             series.span for series in globalv.COHERENCE_COMPONENTS[ck] for
             ck in ckeys]

--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -242,7 +242,7 @@ def _get_coherence_spectrogram(channel_pair, segments, config=None,
 
         spans = [SegmentList([  # record spectrogaram spans
             spec.span for spec in globalv.COHERENCE_COMPONENTS[ck]
-        ]) for ck in ckeys]
+        ]).coalesce() for ck in ckeys]
         new = _get_common_segments(new, spans)
         for seg in new:  # compute coherence from components
             cxy, cxx, cyy = [_get_from_list(
@@ -458,8 +458,11 @@ def _get_common_segments(segments, spans):
     outsegs = SegmentList([])
     for i, segment in enumerate(segments):
         spanlist = SegmentList([s[i] for s in spans])
-        outsegs.append(reduce(operator.and_, spanlist, segment))
-    return outsegs
+        try:
+            outsegs.append(reduce(operator.and_, spanlist, segment))
+        except ValueError:
+            pass
+    return outsegs.coalesce()
 
 
 def _get_from_list(serieslist, segment):

--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -244,9 +244,12 @@ def _get_coherence_spectrogram(channel_pair, segments, config=None,
         spans = SegmentList([  # record data spans
             series.span for series in globalv.COHERENCE_COMPONENTS[ck] for
             ck in ckeys])
-        for seg in new:  # compute coherence
-            if spans.intersects_segment(seg):
+        for seg in new:
+            try:  # take the union of all segments
                 outseg = reduce(operator.and_, spans, seg)
+            except ValueError:
+                outseg = None
+            if outseg:  # compute coherence
                 cxy, cxx, cyy = [_get_from_list(
                     globalv.COHERENCE_COMPONENTS[ck], outseg) for
                     ck in ckeys]

--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -240,9 +240,9 @@ def _get_coherence_spectrogram(channel_pair, segments, config=None,
                 if len(tslist1) + len(tslist2):
                     vprint('\n')
 
-        spans = [SegmentList([  # record spectrogaram spans
+        spans = [[  # record spectrogaram spans
             spec.span for spec in globalv.COHERENCE_COMPONENTS[ck]
-        ]).coalesce() for ck in ckeys]
+        ] for ck in ckeys]
         new = _get_common_segments(new, spans)
         for seg in new:  # compute coherence from components
             cxy, cxx, cyy = [_get_from_list(
@@ -450,14 +450,11 @@ def _get_common_segments(segments, spans):
     outsegs : `SegmentList`
         list of segments common between `spans` and `segments`
     """
-    outsegs = SegmentList([])
-    for segment in segments:
-        for spanlist in zip_longest(*spans, fillvalue=segment):
-            try:  # take the intersection of all segments
-                outsegs.append(reduce(operator.and_, spanlist, segment))
-            except ValueError:
-                pass  # ignore non-overlapping segments
-    return outsegs.coalesce()
+    # coalesce all segments
+    segments = SegmentList(segments).coalesce()
+    spans = [SegmentList(s).coalesce() for s in spans]
+    # return the coalesced union of all segments
+    return reduce(operator.and_, spans, segments).coalesce()
 
 
 def _get_from_list(serieslist, segment):

--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -240,14 +240,17 @@ def _get_coherence_spectrogram(channel_pair, segments, config=None,
                 if len(tslist1) + len(tslist2):
                     vprint('\n')
 
-        # calculate coherence from the components and store in globalv
-        for seg in new:
-            cxy, cxx, cyy = [
-                _get_from_list(globalv.COHERENCE_COMPONENTS[ck], seg) for
-                ck in ckeys]
-            csg = abs(cxy)**2 / cxx / cyy
-            globalv.SPECTROGRAMS[key].append(csg)
-            globalv.SPECTROGRAMS[key].coalesce()
+        spans = [  # record data spans
+            series.span for series in globalv.COHERENCE_COMPONENTS[ck] for
+            ck in ckeys]
+        for seg in new:  # compute coherence from components
+            if all([seg.intersects(span) for span in spans]):
+                cxy, cxx, cyy = [
+                    _get_from_list(globalv.COHERENCE_COMPONENTS[ck], seg) for
+                    ck in ckeys]
+                csg = abs(cxy)**2 / cxx / cyy
+                globalv.SPECTROGRAMS[key].append(csg)
+                globalv.SPECTROGRAMS[key].coalesce()
 
     if not return_:
         return

--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -449,11 +449,6 @@ def _get_common_segments(segments, spans):
     -------
     outsegs : `SegmentList`
         list of segments common between `spans` and `segments`
-
-    Notes
-    -----
-    The `spans` object is a list of `SegmentList`, each of which should
-    individually have the same number of elements as `segments`.
     """
     outsegs = SegmentList([])
     for segment in segments:

--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -458,10 +458,10 @@ def _get_common_segments(segments, spans):
     outsegs = SegmentList([])
     for i, segment in enumerate(segments):
         spanlist = SegmentList([s[i] for s in spans])
-        try:
+        try:  # take the intersection of all segments
             outsegs.append(reduce(operator.and_, spanlist, segment))
         except ValueError:
-            pass
+            pass  # ignore non-overlapping segments
     return outsegs.coalesce()
 
 


### PR DESCRIPTION
This PR fixes a corner case in coherencegrams, where segments that are a superset of the spans of individual inputs lead to a `ValueError`. The fix crops channels using the intersection of all inputs, something like:

```python
# imports
import operator
from functools import reduce

# collect spans of input data
spans = [series.span for series in inputs]

# iteratively find the union of all segments
reduce(operator.and_, spans, new_segment)
```

cc @duncanmmacleod 