### PR TITLE
Drop explicit support for python2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 dist: xenial
 
 python:
-  - '2.7'
+  - '3.5'
   - '3.6'
   - '3.7'
 

--- a/bin/gw_scan_loudest
+++ b/bin/gw_scan_loudest
@@ -26,8 +26,6 @@ HTCondor Directed Acyclic Graph (DAG) to generate an Omega scan report of
 each.
 """
 
-from __future__ import print_function
-
 import os
 import argparse
 

--- a/bin/gw_summary
+++ b/bin/gw_summary
@@ -29,8 +29,6 @@ Run 'gw_summary <mode> --help' for details of the specific arguments and
 options acceptable for each mode.
 """
 
-from __future__ import (division, print_function)
-
 # XXX HACK XXX
 # plots don't work with multiprocessing with lal.LIGOTimeGPS
 from gwpy import time

--- a/bin/gwsumm-plot-guardian
+++ b/bin/gwsumm-plot-guardian
@@ -3,8 +3,6 @@
 """Script to plot h(t) triggers for some epoch
 """
 
-from __future__ import unicode_literals
-
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
 import argparse
@@ -12,8 +10,6 @@ import os
 import re
 from collections import OrderedDict
 from configparser import DEFAULTSECT
-
-from six import text_type
 
 from matplotlib import use
 use('agg')
@@ -50,8 +46,8 @@ parser.add_argument('node')
 parser.add_argument('gpsstart', type=to_gps)
 parser.add_argument('gpsend', type=to_gps)
 parser.add_argument('config', help='config-file defining guardian node')
-parser.add_argument('-i', '--ifo', type=text_type, default='L1')
-parser.add_argument('-s', '--section', type=text_type,
+parser.add_argument('-i', '--ifo', type=str, default='L1')
+parser.add_argument('-s', '--section', type=str,
                     help='suffix of INI tab section to read, e.g. give '
                          '--section=\'ISC_LOCK\' to read [tab-ISC_LOCK] '
                          'section, defaults to {node}')
@@ -90,8 +86,8 @@ for input_ in args.plot_params:
 # read config
 config = GWSummConfigParser(dict_type=OrderedDict)
 config.read([args.config])
-config.set(DEFAULTSECT, 'gps-start-time', text_type(int(args.gpsstart)))
-config.set(DEFAULTSECT, 'gps-end-time', text_type(int(args.gpsend)))
+config.set(DEFAULTSECT, 'gps-start-time', str(int(args.gpsstart)))
+config.set(DEFAULTSECT, 'gps-end-time', str(int(args.gpsend)))
 config.set(DEFAULTSECT, 'IFO', args.ifo)
 sec = 'tab-%s' % (args.section or args.node)
 

--- a/bin/gwsumm-plot-triggers
+++ b/bin/gwsumm-plot-triggers
@@ -1,4 +1,4 @@
-#!/home/detchar/opt/gwpysoft-2.7/bin/python
+#!/usr/bin/env python
 
 """Plot the triggers for a given ETG and a given channel
 """

--- a/gwsumm/config.py
+++ b/gwsumm/config.py
@@ -25,7 +25,7 @@ import configparser
 from io import StringIO
 from collections import OrderedDict
 from importlib import import_module
-from http import client as http_client
+from http import client
 
 # import these for evaluating lambda expressions in the configuration file
 import math  # noqa: F401
@@ -276,7 +276,7 @@ class GWSummConfigParser(configparser.ConfigParser):
         for group in [raw, trend]:
             try:
                 newchannels = get_channels(group)
-            except httplib.HTTPException:
+            except client.HTTPException:
                 newchannels = []
 
             # read custom channel definitions

--- a/gwsumm/config.py
+++ b/gwsumm/config.py
@@ -19,17 +19,13 @@
 """Thin wrapper around configparser
 """
 
-import configparser
-import os.path
 import re
+import os.path
+import configparser
+from io import StringIO
 from collections import OrderedDict
 from importlib import import_module
-
-from six import string_types
-from six.moves import (
-    StringIO,
-    http_client as httplib,
-)
+from http import client as http_client
 
 # import these for evaluating lambda expressions in the configuration file
 import math  # noqa: F401
@@ -82,7 +78,7 @@ class GWSummConfigParser(configparser.ConfigParser):
 
     def read(self, filenames):
         readok = configparser.ConfigParser.read(self, filenames)
-        if isinstance(filenames, string_types):
+        if isinstance(filenames, str):
             filenames = filenames.split(',')
         for fp in filenames:
             if fp not in readok:

--- a/gwsumm/config.py
+++ b/gwsumm/config.py
@@ -25,7 +25,7 @@ import configparser
 from io import StringIO
 from collections import OrderedDict
 from importlib import import_module
-from http import client
+from http.client import HTTPException
 
 # import these for evaluating lambda expressions in the configuration file
 import math  # noqa: F401
@@ -276,7 +276,7 @@ class GWSummConfigParser(configparser.ConfigParser):
         for group in [raw, trend]:
             try:
                 newchannels = get_channels(group)
-            except client.HTTPException:
+            except HTTPException:
                 newchannels = []
 
             # read custom channel definitions

--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -21,6 +21,7 @@
 
 import operator
 import warnings
+from functools import reduce
 from itertools import zip_longest
 from collections import OrderedDict
 

--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -19,14 +19,10 @@
 """Utilities for data handling and display
 """
 
-from __future__ import division
-
 import operator
 import warnings
+from itertools import zip_longest
 from collections import OrderedDict
-
-from six import string_types
-from six.moves import (reduce, zip_longest)
 
 import numpy
 
@@ -152,7 +148,7 @@ def _get_coherence_spectrogram(channel_pair, segments, config=None,
             except AttributeError:
                 filter_ = None
             else:
-                if isinstance(filter_, string_types):
+                if isinstance(filter_, str):
                     filter_ = safe_eval(filter_, strict=True)
 
             # check how much of this component still needs to be calculated

--- a/gwsumm/data/mathutils.py
+++ b/gwsumm/data/mathutils.py
@@ -19,9 +19,10 @@
 """Handle arbitrary mathematical operations applied to data series
 """
 
+import re
 import numbers
 import operator
-import re
+from functools import reduce
 from collections import OrderedDict
 
 import numpy

--- a/gwsumm/data/mathutils.py
+++ b/gwsumm/data/mathutils.py
@@ -24,8 +24,6 @@ import operator
 import re
 from collections import OrderedDict
 
-from six.moves import reduce
-
 import numpy
 
 from gwpy.segments import SegmentList

--- a/gwsumm/data/spectral.py
+++ b/gwsumm/data/spectral.py
@@ -19,15 +19,10 @@
 """Get spectrograms and spectra
 """
 
-from __future__ import division
-
 import os.path
 import operator
 import warnings
 from collections import OrderedDict
-
-from six import string_types
-from six.moves import reduce
 
 # imports for filter
 from math import pi  # noqa: F401
@@ -148,9 +143,9 @@ def _get_spectrogram(channel, segments, config=None, cache=None,
         except AttributeError:
             filter_ = None
         else:
-            if isinstance(filter_, string_types) and os.path.isfile(filter_):
+            if isinstance(filter_, str) and os.path.isfile(filter_):
                 filter_ = io.read_frequencyseries(filter_)
-            elif isinstance(filter_, string_types):
+            elif isinstance(filter_, str):
                 filter_ = safe_eval(filter_, strict=True)
 
         # get time-series data

--- a/gwsumm/data/spectral.py
+++ b/gwsumm/data/spectral.py
@@ -22,6 +22,7 @@
 import os.path
 import operator
 import warnings
+from functools import reduce
 from collections import OrderedDict
 
 # imports for filter

--- a/gwsumm/data/timeseries.py
+++ b/gwsumm/data/timeseries.py
@@ -19,19 +19,15 @@
 """Utilities for data handling and display
 """
 
-from __future__ import division
-
-import operator
-import re
 import os
+import re
+import operator
 import warnings
-from math import (floor, ceil)
 from time import sleep
+from math import (floor, ceil)
+from urllib.parse import urlparse
 from collections import OrderedDict
 from configparser import (NoSectionError, NoOptionError)
-
-from six.moves import reduce
-from six.moves.urllib.parse import urlparse
 
 from astropy import units
 

--- a/gwsumm/data/timeseries.py
+++ b/gwsumm/data/timeseries.py
@@ -24,6 +24,7 @@ import re
 import operator
 import warnings
 from time import sleep
+from functools import reduce
 from math import (floor, ceil)
 from urllib.parse import urlparse
 from collections import OrderedDict

--- a/gwsumm/html/bootstrap.py
+++ b/gwsumm/html/bootstrap.py
@@ -24,8 +24,6 @@ import getpass
 import datetime
 import os.path
 
-from six import string_types
-
 from MarkupPy import markup
 
 from gwdetchar.io import html as gwhtml

--- a/gwsumm/html/html5.py
+++ b/gwsumm/html/html5.py
@@ -21,8 +21,7 @@
 
 import os.path
 
-from six import string_types
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 from MarkupPy import markup
 
@@ -67,7 +66,7 @@ def load(url, id_='main', error=False, success=None):
         error = ('alert("Cannot load content from %r, use browser console '
                  'to inspect failure.");' % url)
     else:
-        if not isinstance(error, (string_types, markup.page)):
+        if not isinstance(error, (str, markup.page)):
             error = 'Failed to load content from %r' % url
         error = ('$("#%s").html("<div class=\'alert alert-warning\'>'
                  '<p>%s</p></div>");' % (id_, error))

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -19,13 +19,9 @@
 """Definitions for the standard plots
 """
 
-from __future__ import division
-
 import os.path
 import warnings
 from itertools import cycle
-
-from six import string_types
 
 import numpy
 
@@ -276,7 +272,7 @@ class SpectrogramDataPlot(TimeSeriesDataPlot):
             return self._pid
         except AttributeError:
             super(SpectrogramDataPlot, self).pid
-            if (isinstance(self.ratio, string_types) and
+            if (isinstance(self.ratio, str) and
                     os.path.isfile(self.ratio)):
                 self._pid += '_REFERENCE_RATIO'
             elif self.ratio:
@@ -311,7 +307,7 @@ class SpectrogramDataPlot(TimeSeriesDataPlot):
                 return allspec.percentile(ratio)
             else:
                 return getattr(allspec, ratio)(axis=0)
-        elif isinstance(ratio, string_types) and os.path.isfile(ratio):
+        elif isinstance(ratio, str) and os.path.isfile(ratio):
             try:
                 return io.read_frequencyseries(ratio)
             except IOError as e:  # skip if file can't be read

--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -24,12 +24,10 @@ for GWSumm
 import os.path
 import re
 import warnings
+from urllib.parse import urlparse
 from collections import OrderedDict
 from math import (floor, ceil)
 from numbers import Number
-
-from six import string_types
-from six.moves.urllib.parse import urlparse
 
 from matplotlib import (rcParams, rc_context)
 
@@ -220,7 +218,7 @@ class DataPlot(SummaryPlot):
                  tag=None, pid=None, href=None, new=True, all_data=False,
                  read=True, fileformat='png', caption=None, **pargs):
         super(DataPlot, self).__init__(href=href, new=new, caption=caption)
-        if isinstance(channels, string_types):
+        if isinstance(channels, str):
             channels = split_channels(channels)
         self.channels = channels
         self.span = (start, end)
@@ -269,7 +267,7 @@ class DataPlot(SummaryPlot):
 
     @state.setter
     def state(self, state_):
-        if isinstance(state_, string_types):
+        if isinstance(state_, str):
             self._state = get_state(state_)
         else:
             self._state = state_
@@ -459,7 +457,7 @@ class DataPlot(SummaryPlot):
         # get channels
         if channels is None:
             channels = params.pop('channels', [])
-        if isinstance(channels, string_types):
+        if isinstance(channels, str):
             channels = split_channels(channels)
         # parse specific parameters
         if 'all-data' in params:
@@ -534,7 +532,7 @@ class DataPlot(SummaryPlot):
                 raise e
 
         # evaluate (safely) allowing references to self as 'plot'
-        if isinstance(val, string_types):
+        if isinstance(val, str):
             try:
                 val = safe_eval(val, locals_={'plot': self, 'self': self})
             except ZeroDivisionError:  # e.g. zero livetime
@@ -747,7 +745,7 @@ class DataPlot(SummaryPlot):
         # save figure and close (build both png and pdf for pdf choice)
         if outputfile is None:
             outputfile = self.outputfile
-        if not isinstance(outputfile, string_types):
+        if not isinstance(outputfile, str):
             extensions = [None]
         elif outputfile.endswith('.pdf'):
             extensions = ['.pdf', '.png']
@@ -765,7 +763,7 @@ class DataPlot(SummaryPlot):
                 warnings.warn("Caught %s: %s [retrying...]"
                               % (type(e).__name__, str(e)))
                 self.plot.save(fp, **savekwargs)
-            if isinstance(fp, string_types):
+            if isinstance(fp, str):
                 vprint("        %s written\n" % fp)
         if close:
             self.plot.close()
@@ -779,7 +777,7 @@ class DataPlot(SummaryPlot):
                 if key.startswith('no-'):  # skip no-xxx keys
                     continue
                 val = pargs[key]
-                if key in ['xlim', 'ylim'] and isinstance(val, string_types):
+                if key in ['xlim', 'ylim'] and isinstance(val, str):
                     val = eval(val)
                 elif key == 'grid':
                     self._apply_grid_params(ax, val)

--- a/gwsumm/plot/guardian.py
+++ b/gwsumm/plot/guardian.py
@@ -21,8 +21,6 @@
 
 from collections import OrderedDict
 
-from six import string_types
-
 from gwpy.segments import (Segment, SegmentList)
 from gwpy.plot.colors import tint
 from gwpy.plot.segments import SegmentRectangle
@@ -74,7 +72,7 @@ class GuardianStatePlot(get_plot('segments')):
         flags = [str(f).replace('_', r'\_') for f in self.flags]
         labels = self.pargs.pop('labels', self.pargs.pop('label', flags))
         ax.set_insetlabels(self.pargs.pop('insetlabels', True))
-        if isinstance(labels, string_types):
+        if isinstance(labels, str):
             labels = labels.split(',')
         labels = [re_quote.sub('', str(s).strip('\n ')) for s in labels]
 

--- a/gwsumm/plot/mixins.py
+++ b/gwsumm/plot/mixins.py
@@ -19,11 +19,10 @@
 """
 """
 
+import re
 import abc
 import os.path
-import re
-
-from six.moves import StringIO
+from io import StringIO
 
 from lxml import etree
 

--- a/gwsumm/plot/noisebudget.py
+++ b/gwsumm/plot/noisebudget.py
@@ -19,8 +19,6 @@
 """Extensions to the spectrum plot for noise budgets
 """
 
-from __future__ import division
-
 import re
 
 import numpy

--- a/gwsumm/plot/range.py
+++ b/gwsumm/plot/range.py
@@ -19,14 +19,10 @@
 """Definitions for range plots
 """
 
-from __future__ import division
-
 import re
 from math import pi
 from heapq import nlargest
 from itertools import combinations
-
-from six import string_types
 
 import numpy
 
@@ -133,7 +129,7 @@ class SimpleTimeVolumeDataPlot(get_plot('segments')):
     parse_plot_kwargs = get_plot('timeseries').parse_plot_kwargs
 
     def __init__(self, sources, *args, **kwargs):
-        if isinstance(sources, string_types):
+        if isinstance(sources, str):
             sources = split_channels(sources)
         channels = sources[::2]
         flags = sources[1::2]

--- a/gwsumm/plot/registry.py
+++ b/gwsumm/plot/registry.py
@@ -23,7 +23,6 @@ configuration INI files
 """
 
 import re
-from six import string_types
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -61,7 +60,7 @@ def get_plot(name):
     """Query the registry for the plot class registered to the given
     name
     """
-    if isinstance(name, string_types):
+    if isinstance(name, str):
         name = re.sub(r'[\'\"]', '', name)
     try:
         return _PLOTS[name]

--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -19,15 +19,11 @@
 """Definitions for the standard plots
 """
 
-from __future__ import division
-
 import bisect
 from itertools import (cycle, combinations)
 from numbers import Number
 from collections import OrderedDict
 from configparser import NoOptionError
-
-from six import string_types
 
 import numpy
 
@@ -138,7 +134,7 @@ class SegmentDataPlot(SegmentLabelSvgMixin, TimeSeriesDataPlot):
 
     @flags.setter
     def flags(self, flist):
-        if isinstance(flist, string_types):
+        if isinstance(flist, str):
             flist = [f.strip('\n ') for f in flist.split(',')]
         self._flags = []
         for f in flist:
@@ -210,7 +206,7 @@ class SegmentDataPlot(SegmentLabelSvgMixin, TimeSeriesDataPlot):
         # get flags
         if flags is None:
             flags = dict(config.items(section)).pop('flags', [])
-        if isinstance(flags, string_types):
+        if isinstance(flags, str):
             flags = [f.strip('\n ') for f in flags.split(',')]
         new.flags = flags
         return new
@@ -237,7 +233,7 @@ class SegmentDataPlot(SegmentLabelSvgMixin, TimeSeriesDataPlot):
                 active = active.get('facecolor')
             else:
                 self.pargs['facecolor'] = active
-            if (isinstance(active, string_types) and
+            if (isinstance(active, str) and
                     active.lower() in ('red', '#ff0000')):
                 self.pargs['known'] = 'dodgerblue'
             else:
@@ -259,7 +255,7 @@ class SegmentDataPlot(SegmentLabelSvgMixin, TimeSeriesDataPlot):
 
         # format defaults
         self.pargs.setdefault('height', .8)
-        if isinstance(self.pargs['known'], string_types):
+        if isinstance(self.pargs['known'], str):
             self.pargs['known'] = {'facecolor': self.pargs['known']}
 
         for dtup in (self.pargs, self.pargs['known']):
@@ -412,7 +408,7 @@ class StateVectorDataPlot(TimeSeriesDataPlot):
         """
         chans = list(zip(*self.get_channel_groups()))[0]
         labels = list(self.pargs.pop('labels', defaults))
-        if isinstance(labels, string_types):
+        if isinstance(labels, str):
             labels = labels.split(',')
         for i, l in enumerate(labels):
             if isinstance(l, (list, tuple)):

--- a/gwsumm/plot/triggers.py
+++ b/gwsumm/plot/triggers.py
@@ -19,13 +19,9 @@
 """Definitions for event trigger plots
 """
 
-from __future__ import division
-
 import re
 from collections import OrderedDict
 from itertools import cycle
-
-from six import string_types
 
 from numpy import isinf
 
@@ -147,7 +143,7 @@ class TriggerDataPlot(TriggerPlotMixin, TimeSeriesDataPlot):
 
         # work out labels
         labels = self.pargs.pop('labels', self.channels)
-        if isinstance(labels, string_types):
+        if isinstance(labels, str):
             labels = labels.split(',')
         labels = [str(s).strip('\n ') for s in labels]
 
@@ -345,7 +341,7 @@ class TriggerTimeSeriesDataPlot(TimeSeriesDataPlot):
 
         # work out labels
         labels = self.pargs.pop('labels', self.channels)
-        if isinstance(labels, string_types):
+        if isinstance(labels, str):
             labels = labels.split(',')
         labels = [str(s).strip('\n ') for s in labels]
 
@@ -563,7 +559,7 @@ class TriggerRateDataPlot(TriggerPlotMixin, TimeSeriesDataPlot):
 
         # work out labels
         labels = self.pargs.pop('labels', None)
-        if isinstance(labels, string_types):
+        if isinstance(labels, str):
             labels = labels.split(',')
         elif labels is None and self.column and len(self.channels) > 1:
             labels = []

--- a/gwsumm/segments.py
+++ b/gwsumm/segments.py
@@ -19,7 +19,6 @@
 """Utilities for segment handling and display
 """
 
-from __future__ import (division, print_function)
 import operator
 import sys
 import warnings
@@ -30,9 +29,6 @@ from configparser import (
     NoSectionError,
     NoOptionError,
 )
-
-from six import string_types
-from six.moves import reduce
 
 from astropy.io.registry import IORegistryError
 
@@ -128,7 +124,7 @@ def get_segments(flag, validity=None, config=ConfigParser(), cache=None,
     None
        if ``return_=False``
     """
-    if isinstance(flag, string_types):
+    if isinstance(flag, str):
         flags = flag.split(',')
     else:
         flags = flag
@@ -273,7 +269,7 @@ def get_segments(flag, validity=None, config=ConfigParser(), cache=None,
             out[compound].active &= validity
             if coalesce:
                 out[compound].coalesce()
-        if isinstance(flag, string_types):
+        if isinstance(flag, str):
             return out[flag]
         else:
             return out
@@ -321,7 +317,7 @@ def format_padding(flags, padding):
     """Format an arbitrary collection of paddings into a `dict`
     """
     # parse string to start with
-    if isinstance(padding, string_types):
+    if isinstance(padding, str):
         padding = list(eval(str))
     # zip list into dict
     if (isinstance(padding, (list)) or

--- a/gwsumm/segments.py
+++ b/gwsumm/segments.py
@@ -22,6 +22,7 @@
 import operator
 import sys
 import warnings
+from functools import reduce
 from collections import OrderedDict
 from configparser import (
     DEFAULTSECT,

--- a/gwsumm/tabs/builtin.py
+++ b/gwsumm/tabs/builtin.py
@@ -31,8 +31,6 @@ import os.path
 import warnings
 from configparser import NoOptionError
 
-from six import string_types
-
 from MarkupPy import markup
 
 from .registry import (get_tab, register_tab)
@@ -285,20 +283,20 @@ class PlotTab(Tab):
             return
         # parse a single int
         if isinstance(layout, int) or (
-                isinstance(layout, string_types) and
+                isinstance(layout, str) and
                 layout.isdigit()
         ):
             self._layout = [int(layout)]
             return
         # otherwise parse as a list of ints or pairs of ints
-        if isinstance(layout, string_types):
+        if isinstance(layout, str):
             layout = layout.split(',')
         self._layout = []
         for item in layout:
             if isinstance(item, int):
                 self._layout.append(item)
                 continue
-            if isinstance(item, string_types):
+            if isinstance(item, str):
                 item = item.strip('([').rstrip(')]').split(',')
             if not isinstance(item, (list, tuple)) or not len(item) == 2:
                 raise ValueError("Cannot parse layout element %r (%s)"
@@ -421,7 +419,7 @@ class PlotTab(Tab):
             either the URL of a plot to embed, or a formatted `SummaryPlot`
             object.
         """
-        if isinstance(plot, string_types):
+        if isinstance(plot, str):
             plot = SummaryPlot(href=plot)
             plot.new = False
         if not isinstance(plot, SummaryPlot):
@@ -637,7 +635,7 @@ class StateTab(PlotTab):
             # allow default indication by trailing asterisk
             if state == default:
                 default_ = True
-            elif (default is None and isinstance(state, string_types) and
+            elif (default is None and isinstance(state, str) and
                     state.endswith('*')):
                 state = state[:-1]
                 default_ = True

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -35,7 +35,7 @@ keyword arguments.
 
 import os
 import re
-from urllib,parse import urlparse
+from urllib.parse import urlparse
 from collections import OrderedDict
 from configparser import NoOptionError
 from shutil import copyfile

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -35,12 +35,10 @@ keyword arguments.
 
 import os
 import re
+from urllib,parse import urlparse
 from collections import OrderedDict
 from configparser import NoOptionError
 from shutil import copyfile
-
-from six import (string_types, add_metaclass)
-from six.moves.urllib.parse import urlparse
 
 from MarkupPy import markup
 
@@ -948,7 +946,6 @@ class _MetaTab(type):
 # this is the first actual Tab object, all of the functionality is defined
 # in the `BaseTab` object
 
-@add_metaclass(_MetaTab)
 class Tab(BaseTab):
     """A Simple HTML tab.
 
@@ -1002,6 +999,7 @@ class Tab(BaseTab):
     to collect child tabs in a given place, assign them all the same
     `~Tab.group`.
     """
+    __metaclass__ = _MetaTab
     type = 'basic'
 
 
@@ -1083,7 +1081,7 @@ class TabList(list):
     @classmethod
     def from_ini(cls, config, tag='tab[_-]', match=[],
                  path=os.curdir, plotdir='plots'):
-        if isinstance(tag, string_types):
+        if isinstance(tag, str):
             tag = re.compile(tag)
         tabs = cls()
         parents = {}

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -946,7 +946,7 @@ class _MetaTab(type):
 # this is the first actual Tab object, all of the functionality is defined
 # in the `BaseTab` object
 
-class Tab(BaseTab):
+class Tab(BaseTab, metaclass=_MetaTab):
     """A Simple HTML tab.
 
     This `class` provides a mechanism to generate a full-formatted
@@ -999,7 +999,6 @@ class Tab(BaseTab):
     to collect child tabs in a given place, assign them all the same
     `~Tab.group`.
     """
-    __metaclass__ = _MetaTab
     type = 'basic'
 
 

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -23,20 +23,17 @@ to declare that a tab has a `process()` method that should be executed
 as part of a workflow, see the ``gw_summary`` executable as an example.
 """
 
-from __future__ import print_function
-
+import re
 import os.path
 import getpass
-import re
 from configparser import (
     ConfigParser,
     NoOptionError,
     NoSectionError,
 )
 from copy import copy
+from io import StringIO
 from datetime import timedelta
-
-from six.moves import StringIO
 
 from MarkupPy import markup
 

--- a/gwsumm/tabs/etg.py
+++ b/gwsumm/tabs/etg.py
@@ -23,8 +23,6 @@ import os
 from configparser import NoOptionError
 from warnings import warn
 
-from six import string_types
-
 from MarkupPy import markup
 
 from glue.lal import Cache
@@ -234,7 +232,7 @@ class EventTriggerTab(get_tab('default')):
     def process(self, *args, **kwargs):
         error = None
         # read the cache files
-        if isinstance(self.cache, string_types) and os.path.isfile(self.cache):
+        if isinstance(self.cache, str) and os.path.isfile(self.cache):
             with open(self.cache, 'r') as fobj:
                 try:
                     self.cache = Cache.fromfile(fobj).sieve(
@@ -244,7 +242,7 @@ class EventTriggerTab(get_tab('default')):
                         error = 'could not parse event cache file'
                     else:
                         raise
-        elif isinstance(self.cache, string_types):
+        elif isinstance(self.cache, str):
             error = 'could not locate event cache file'
             warn("Cache file %s not found." % self.cache)
         elif self.cache is not None and not isinstance(self.cache, Cache):

--- a/gwsumm/tabs/fscan.py
+++ b/gwsumm/tabs/fscan.py
@@ -21,9 +21,6 @@
 
 import os
 import glob
-
-from six import string_types
-
 from dateutil import parser
 
 from MarkupPy import markup
@@ -88,7 +85,7 @@ class FscanTab(base):
     def process(self, config=GWSummConfigParser(), **kwargs):
         # find all plots
         self.plots = []
-        if isinstance(self.directory, string_types):
+        if isinstance(self.directory, str):
             plots = sorted(
                 glob.glob(os.path.join(self.directory, 'spec_*.png')),
                 key=lambda p: float(os.path.basename(p).split('_')[1]))

--- a/gwsumm/tabs/sei.py
+++ b/gwsumm/tabs/sei.py
@@ -19,8 +19,6 @@
 """`SummaryTab` for seismic watchdog monitoring
 """
 
-from __future__ import print_function
-
 import os
 import re
 from collections import OrderedDict

--- a/gwsumm/tabs/stamp.py
+++ b/gwsumm/tabs/stamp.py
@@ -23,8 +23,6 @@ import os
 import re
 import glob
 
-from six import string_types
-
 from .registry import (get_tab, register_tab)
 
 from .. import html
@@ -74,7 +72,7 @@ class StampPEMTab(base):
     def process(self, config=GWSummConfigParser(), **kwargs):
         # find all plots
         self.plots = []
-        if isinstance(self.directory, string_types):
+        if isinstance(self.directory, str):
             plots = sorted(
                 glob.glob(os.path.join(self.directory, 'DAY_*.png')),
                 key=lambda p: float(re.split(r'[-_]', os.path.basename(p))[1]))

--- a/gwsumm/tests/test_config.py
+++ b/gwsumm/tests/test_config.py
@@ -21,10 +21,9 @@
 
 import os.path
 import tempfile
+from io import StringIO
 from collections import OrderedDict
 from configparser import (DEFAULTSECT, ConfigParser)
-
-from six.moves import StringIO
 
 import pytest
 

--- a/gwsumm/tests/test_data.py
+++ b/gwsumm/tests/test_data.py
@@ -25,8 +25,7 @@ import operator
 import tempfile
 import shutil
 from collections import OrderedDict
-
-from six.moves.urllib.request import urlopen
+from urllib.request import urlopen
 
 import pytest
 

--- a/gwsumm/tests/test_utils.py
+++ b/gwsumm/tests/test_utils.py
@@ -27,8 +27,6 @@ import sys
 import shutil
 from math import pi
 
-from six import string_types
-
 import pytest
 
 try:
@@ -120,7 +118,7 @@ def test_safe_eval(value, out):
     evalue = utils.safe_eval(value)
     assert type(evalue) is type(out)
 
-    if not isinstance(value, string_types):
+    if not isinstance(value, str):
         assert evalue is out
     elif callable(out):
         assert evalue(4) == out(4)

--- a/gwsumm/triggers.py
+++ b/gwsumm/triggers.py
@@ -20,8 +20,7 @@
 """
 
 import warnings
-
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 from astropy.table import vstack as vstack_tables
 

--- a/gwsumm/utils.py
+++ b/gwsumm/utils.py
@@ -24,8 +24,6 @@ import sys
 import re
 from socket import getfqdn
 
-from six import string_types
-
 # import filter evals
 from math import pi  # noqa: F401
 import numpy  # noqa: F401
@@ -185,7 +183,7 @@ def safe_eval(val, strict=False, globals_=None, locals_=None):
         for more documentation on the underlying evaluation method
     """
     # don't evaluate non-strings
-    if not isinstance(val, string_types):
+    if not isinstance(val, str):
         return val
     # check that we aren't evaluating something dangerous
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ libsass
 jsmin
 
 # core requirements
-enum34 ; python_version < '3.4'
 python-dateutil
 lxml
 numpy>=1.10
@@ -31,4 +30,3 @@ ligo-gracedb>=2.0.0
 # testing extras
 pytest>=2.8,<3.7
 pytest-cov
-mock ; python_version < '3'

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,6 @@
 """Setup the GWSumm package
 """
 
-from __future__ import print_function
-
 import sys
 import glob
 import os
@@ -33,8 +31,9 @@ from setuptools.command.build_py import build_py
 
 import versioneer
 
-if sys.version < '2.6':
-    raise ImportError("Python versions older than 2.6 are not supported.")
+# enforce python version
+if sys.version < '3.5':
+    raise ImportError("Python versions older than 3.5 are not supported.")
 
 # set basic metadata
 PACKAGENAME = 'gwsumm'
@@ -86,7 +85,6 @@ install_requires = [
     'MarkupPy',
     'gwdetchar>=0.5.1',
     'configparser ; python_version < \'3.6\'',
-    'enum34 ; python_version < \'3.4\''
 ]
 
 # testing requirements
@@ -253,7 +251,7 @@ setup(name=DISTNAME,
           'Programming Language :: Python',
           'Development Status :: 3 - Alpha',
           'Programming Language :: Python',
-          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3.5',
           'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',
           'Intended Audience :: Science/Research',

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,6 @@ from setuptools.command.build_py import build_py
 
 import versioneer
 
-# enforce python version
-if sys.version < '3.5':
-    raise ImportError("Python versions older than 3.5 are not supported.")
-
 # set basic metadata
 PACKAGENAME = 'gwsumm'
 DISTNAME = 'gwsumm'

--- a/versioneer.py
+++ b/versioneer.py
@@ -10,7 +10,7 @@ The Versioneer
 * https://github.com/warner/python-versioneer
 * Brian Warner
 * License: Public Domain
-* Compatible With: python2.6, 2.7, 3.3, 3.4, 3.5, and pypy
+* Compatible With: python3.5+, conda, and pypy
 * [![Latest Version]
 (https://pypip.in/version/versioneer/badge.svg?style=flat)
 ](https://pypi.python.org/pypi/versioneer/)

--- a/versioneer.py
+++ b/versioneer.py
@@ -10,7 +10,7 @@ The Versioneer
 * https://github.com/warner/python-versioneer
 * Brian Warner
 * License: Public Domain
-* Compatible With: python3.5+, conda, and pypy
+* Compatible With: python2.6, 2.7, 3.3, 3.4, 3.5, and pypy
 * [![Latest Version]
 (https://pypip.in/version/versioneer/badge.svg?style=flat)
 ](https://pypi.python.org/pypi/versioneer/)


### PR DESCRIPTION
This PR drops all support for python-2.7, now that we've been running stably in python-3.7:

* Remove imports from `__future__`
* Replace imports from `six` with their python3 equivalents
* Enforce system python versions >= 3.5

This is part of an extensive purge of python2 across our detchar software stack, see gwdetchar/gwdetchar#324 and gwdetchar/hveto#126.

cc @duncanmmacleod