### PR TITLE
WIP: Support Roboto as the font for HTML rendering

### DIFF
--- a/gwsumm/html/static.py
+++ b/gwsumm/html/static.py
@@ -63,7 +63,6 @@ CSS = OrderedDict((
     ('gwdetchar', CSS_FILES[4]),
     ('gwsumm', os.path.join(STATICDIR, 'gwsumm.min.css')),
 ))
-print(CSS_FILES.keys())
 
 
 # -- utilities ----------------------------------------------------------------

--- a/gwsumm/html/static.py
+++ b/gwsumm/html/static.py
@@ -52,16 +52,18 @@ JS = OrderedDict((
 CSS = OrderedDict((
     ('bootstrap', CSS_FILES[0]),
     ('fancybox', CSS_FILES[1]),
+    ('google-fonts', CSS_FILES[2]),
     ('datepicker', (
         '//cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/'
         '1.6.0/css/bootstrap-datepicker.min.css')),
     ('dialog-polyfill', (
         'https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/'
         '0.5.0/dialog-polyfill.min.css')),
-    ('bootstrap-ligo', CSS_FILES[2]),
-    ('gwdetchar', CSS_FILES[3]),
+    ('bootstrap-ligo', CSS_FILES[3]),
+    ('gwdetchar', CSS_FILES[4]),
     ('gwsumm', os.path.join(STATICDIR, 'gwsumm.min.css')),
 ))
+print(CSS_FILES.keys())
 
 
 # -- utilities ----------------------------------------------------------------

--- a/gwsumm/html/tests/test_static.py
+++ b/gwsumm/html/tests/test_static.py
@@ -41,6 +41,7 @@ def test_get_css():
     assert keys == [
         'bootstrap',
         'fancybox',
+        'google-fonts',
         'datepicker',
         'dialog-polyfill',
         'bootstrap-ligo',
@@ -51,9 +52,9 @@ def test_get_css():
     css_files = list(css.values())
     assert len(css_files) == len(GWDETCHAR_CSS_FILES) + 3
     assert set(GWDETCHAR_CSS_FILES) < set(css_files)
-    assert os.path.basename(css_files[2]) == 'bootstrap-datepicker.min.css'
-    assert os.path.basename(css_files[3]) == 'dialog-polyfill.min.css'
-    assert os.path.basename(css_files[6]) == 'gwsumm.min.css'
+    assert os.path.basename(css_files[3]) == 'bootstrap-datepicker.min.css'
+    assert os.path.basename(css_files[4]) == 'dialog-polyfill.min.css'
+    assert os.path.basename(css_files[7]) == 'gwsumm.min.css'
 
 
 def test_get_js():

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ ligo-segments
 pygments
 MarkupPy
 markdown
-gwdetchar>=0.5.1
+gwdetchar>=1.0.0
 gwpy>=0.14.2
 configparser ; python_version < '3.6'
 


### PR DESCRIPTION
This PR implements changes needed to support Roboto as the primary font for HTML rendering, and requires gwdetchar >= 1.0.0. As this is not yet released, I'm marking this a work-in-progress for now.

cc @duncanmmacleod 