### PR TITLE
Restore the correct staticpath

### DIFF
--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -690,7 +690,8 @@ class BaseTab(object):
 
         # initialize page
         self.page = gwhtml.new_bootstrap_page(
-            title=title, base=base, css=css, script=js, navbar=navbar)
+            title=title, base=base, path=self.path,
+            css=css, script=js, navbar=navbar)
 
         # add banner
         self.page.add(str(self.html_banner(


### PR DESCRIPTION
This PR takes advantage of new functionality in `gwdetchar.io.html.new_bootstrap_page` to restore the correct `staticpath` for CSS and JS files. See also gwdetchar/gwdetchar#337.

cc @duncanmmacleod 