### PR TITLE
Allow users to select and overlay plots

### DIFF
--- a/gwsumm/html/html5.py
+++ b/gwsumm/html/html5.py
@@ -67,7 +67,7 @@ can be compared at once.\
 # -- utilities ----------------------------------------------------------------
 
 def _expand_path(path):
-    """
+    """Expand a server path that may contain symbolic links
     """
     subbed = Path(re.sub(r'^/\~(.*?)/', r'/home/\1/public_html/', path))
     resolved = subbed.resolve() if subbed.exists() else subbed

--- a/gwsumm/html/tests/test_html5.py
+++ b/gwsumm/html/tests/test_html5.py
@@ -74,6 +74,22 @@ DIALOG = ('<button title="Test" id="id-btn" class="btn-float btn-open" '
           'data-id="#id">T</button>\n<div class="dialog" title="Test" '
           'id="id">\n%s\n</div>') % markdown(CONTENTS)
 
+OVERLAY = (
+    '<button title="Overlay figures" id="overlay-btn" class="btn-float '
+    'btn-open" data-id="#overlay"><i class="fas fa-layer-group"></i></button>'
+    '\n<div class="dialog" title="Overlay figures" id="overlay">\n'
+    '<h1>Overlay figures for easy comparison</h1>\n\n<p><hr '
+    'class="row-divider" />\n<div class="row" id="overlay-outer">\n'
+    '<div class="col-md-4">\n<div class="scaffold well" id="overlay-info">\n'
+    '<h4>Instructions</h4>\n%s\n</div>\n</div>\n<div class="col-md-8">\n'
+    '<div class="center-text">\n<a title="Overlay all selected figures" '
+    'class="btn btn-default" id="overlay-figures">Overlay</a>\n'
+    '<a title="Download overlay figure" class="btn btn-default" '
+    'id="download-overlay">Download</a>\n<a title="Clear all figure '
+    'selections" class="btn btn-default" id="clear-figures">Clear</a>\n'
+    '</div>\n<br />\n<canvas id="overlay-canvas" />\n</div>\n</div></p>\n'
+    '</div>') % markdown(html5.OVERLAY_INSTRUCTIONS)
+
 
 # test utilities
 
@@ -156,3 +172,8 @@ def test_dialog_box(tmpdir):
     box = html5.dialog_box(mdfile, 'Test', 'id', 'T')
     assert parse_html(str(box)) == parse_html(DIALOG)
     shutil.rmtree(str(tmpdir), ignore_errors=True)
+
+
+def test_overlay_canvas():
+    box = html5.overlay_canvas()
+    assert parse_html(str(box)) == parse_html(OVERLAY)

--- a/gwsumm/tabs/builtin.py
+++ b/gwsumm/tabs/builtin.py
@@ -158,11 +158,7 @@ class ExternalTab(Tab):
         """
         if not kwargs.pop('writehtml', True):
             return
-        link = markup.given_oneliner.a('click here to view the original',
-                                       class_='reference',
-                                       href=self.url.split()[0])
-        kwargs.setdefault('footer', 'This page contains data from an external '
-                                    'source, %s.' % link)
+        kwargs.setdefault('footer', self.url.split()[0])
         return super(ExternalTab, self).write_html('', **kwargs)
 
 
@@ -486,9 +482,11 @@ class PlotTab(Tab):
             else:
                 fbkw['title'] = plot.caption
                 page.a(href=plot.href, class_=aclass, **fbkw)
-            src = plot.src.replace('.pdf', '.png') if (
-                plot.src.endswith('.pdf')) else plot.src
-            page.img(class_='img-responsive', src=src)
+            page.img(
+                class_='img-responsive',
+                src=plot.src.replace('.pdf', '.png') if (
+                    plot.src.endswith('.pdf')) else plot.src,
+            )
             page.a.close()
             page.div.close()
             # detect end of row

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ ligo-segments
 pygments
 MarkupPy
 markdown
-gwdetchar>=1.0.0
+gwdetchar>=0.5.1
 gwpy>=0.14.2
 configparser ; python_version < '3.6'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ ligo-segments
 pygments
 MarkupPy
 markdown
-gwdetchar>=0.5.1
+gwdetchar>=1.0.0
 gwpy>=0.14.2
 configparser ; python_version < '3.6'
 


### PR DESCRIPTION
This PR implements a feature allowing users to select and overlay plots from across the summary pages, a feature request based on feedback from LIGO data-quality shifts during O3, see [**here**](https://git.ligo.org/detchar/ligo-summary-pages/issues/121) for the original issue ticket. Also included are a few minor icon replacements and other edits related to consistency with pre-release gwdetchar.

See [**here**](https://ldas-jobs.ligo.caltech.edu/~alexander.urban/summary/testing/1242518418-1242522018/) for example output showing the plot overlay feature in action (requires `LIGO.ORG` credentials). Note, image selections are saved in session storage, so they will be remembered across a change of tabs up to and until the user navigates away from a GWSumm output page. For the upstream implementation of this in JavaScript see [`gwbootstrap`](https://github.com/gwdetchar/gwbootstrap).

This PR is related to #289.

cc @duncanmmacleod 