### PR TITLE
Support nicely-formatted log-scaled VT plots

### DIFF
--- a/gwsumm/plot/range.py
+++ b/gwsumm/plot/range.py
@@ -25,7 +25,7 @@ from itertools import combinations
 
 import numpy
 
-from matplotlib.ticker import MaxNLocator
+from matplotlib.ticker import (LogLocator, MaxNLocator)
 
 from gwpy.segments import (Segment, SegmentList)
 from gwpy.timeseries import TimeSeries
@@ -349,7 +349,10 @@ class SimpleTimeVolumeDataPlot(get_plot('segments')):
         # add extra axes and finalise
         self.add_state_segments(ax)
         self.add_future_shade()
-        ax.yaxis.set_major_locator(MaxNLocator(8))
+        if ax.get_yscale() == 'log':
+            ax.yaxis.set_major_locator(LogLocator())
+        else:
+            ax.yaxis.set_major_locator(MaxNLocator(8))
         ticks = ax.get_yticks()
         ax.yaxis.set_ticklabels(ticks)
         return self.finalize(outputfile=outputfile)


### PR DESCRIPTION
This PR supports nicely-formatted log-scale VT and cumulative VT plots by explicitly using `matplotlib.ticker.LogLocator` to set major tick locations.

cc @duncanmmacleod 