### PR TITLE
Use backwards-compatible cache file reading

### DIFF
--- a/bin/gw_scan_loudest
+++ b/bin/gw_scan_loudest
@@ -296,7 +296,7 @@ print('Generating frame file cache...')
 cache = Cache()
 
 frametypes = set()
-with open(args.config_file, 'rb') as f:
+with open(args.config_file, 'r') as f:
     while True:
         try:
             line = f.next()

--- a/bin/gw_summary
+++ b/bin/gw_summary
@@ -504,7 +504,7 @@ for key, var in zip(['datacache', 'trigcache', 'segmentcache'],
         vprint("Reading %s from %d files... " % (key, len(var)))
         cache[key] = Cache()
         for fp in var:
-            with open(fp, 'rb') as f:
+            with open(fp, 'r') as f:
                 cache[key].extend(Cache.fromfile(f))
         cache[key] = cache[key].sieve(segment=span)
         vprint("done [%d entries]\n" % len(cache[key]))

--- a/bin/gwsumm-plot-triggers
+++ b/bin/gwsumm-plot-triggers
@@ -123,7 +123,7 @@ if args.state:
 
 # read cache
 if args.cache_file:
-    with open(args.cache_file, 'rb') as f:
+    with open(args.cache_file, 'r') as f:
         cache = Cache.fromfile(f).sieve(segment=span)
     print("Read cache of {0} files".format(len(cache)))
 else:


### PR DESCRIPTION
This PR stops reading cache files as `bytes` objects, for backwards-compatibility with cache files written in python2.