### PR TITLE
Pass segment cache to finalize_states, if available

### DIFF
--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -348,6 +348,7 @@ class DataTab(ProcessedTab, ParentTab):
         # load state segments
         self.finalize_states(
             config=config, datacache=stateargs.get('datacache', None),
+            segmentcache=stateargs.get('segmentcache', None),
             segdb_error=stateargs.get('segdb_error', 'raise'),
             datafind_error=stateargs.get('datafind_error', 'raise'),
             nproc=nproc, nds=stateargs.get('nds', None))


### PR DESCRIPTION
This PR fixes a(n evidently) longstanding bug where segment caches fail to get passed properly to the `finalize_states` method when constructing data tabs.

cc @duncanmmacleod, @madeline-wade 