### PR TITLE
Refactor ldvw_qscan to support batch qscans

### DIFF
--- a/gwsumm/html/html5.py
+++ b/gwsumm/html/html5.py
@@ -114,15 +114,20 @@ def comments_box(name, identifier=None, title=None, url=None):
 def ldvw_qscan(channel, time, fmin=10, fmax='inf', qmin=4, qmax=100):
     """Generate a Q-scan through LIGO DataViewer Web (LDVW)
     """
-    uri = ('https://ldvw.ligo.caltech.edu/ldvw/view?act=doplot&chanName='
-           '{0}&doQxfrm=yes&strtTime={1}&qxfrm_pltfrq={2} {3}&qxfrm_srchqrng='
-           '{4} {5}&qxfrm_plttimes=0.5 2 8').format(
-               channel, time, fmin, fmax, qmin, qmax)
+    if isinstance(time, (tuple, str)):
+        label = 'Launch omega scans (LDVW)'
+        title = 'Batch-process omega scans of the loudest triggers via LDVW'
+        times = '&'.join('wdq_gps=' + str(t) for t in time)
+        query = ('Wdq?submitAct=go&wdq_ifo=%s&wdq_cmap=viridis&%s&'
+                 'wdq_prog=py-Omega&goBtn=goBtn') % (channel[:2], times)
+    else:
+        label = 'Q-scan'
+        title = 'Q-scan {0} at {1} via LDVW'.format(channel, time)
+        query = ('view?act=doplot&chanName={0}&doQxfrm=yes&strtTime={1}&'
+                 '&qxfrm_pltfrq={2} {3}&qxfrm_srchqrng={4} {5}&'
+                 'qxfrm_plttimes=0.5 2 8').format(
+                     channel, time, fmin, fmax, qmin, qmax)
+    uri = 'https://ldvw.ligo.caltech.edu/ldvw/{0}'.format(query)
     return markup.oneliner.a(
-        'Q-scan',
-        href=uri,
-        target='_blank',
-        rel='external',
-        class_='btn btn-default btn-xs',
-        title='Q-scan of {0} at {1} in LDVW'.format(channel, time),
-    )
+        label, href=uri, target='_blank', rel='external',
+        class_='btn btn-default btn-xs', title=title)

--- a/gwsumm/html/html5.py
+++ b/gwsumm/html/html5.py
@@ -114,7 +114,8 @@ def comments_box(name, identifier=None, title=None, url=None):
 def ldvw_qscan(channel, time, fmin=10, fmax='inf', qmin=4, qmax=100):
     """Generate a Q-scan through LIGO DataViewer Web (LDVW)
     """
-    if isinstance(time, (tuple, str)):
+    channel = str(channel)
+    if isinstance(time, (tuple, list)):
         label = 'Launch omega scans (LDVW)'
         title = 'Batch-process omega scans of the loudest triggers via LDVW'
         times = '&'.join('wdq_gps=' + str(t) for t in time)

--- a/gwsumm/html/html5.py
+++ b/gwsumm/html/html5.py
@@ -116,7 +116,7 @@ def ldvw_qscan(channel, time, fmin=10, fmax='inf', qmin=4, qmax=100):
     """
     channel = str(channel)
     if isinstance(time, (tuple, list)):
-        label = 'Launch omega scans (LDVW)'
+        label = 'Launch omega scans'
         title = 'Batch-process omega scans of the loudest triggers via LDVW'
         times = '&'.join('wdq_gps=' + str(t) for t in time)
         query = ('Wdq?submitAct=go&wdq_ifo=%s&wdq_cmap=viridis&%s&'

--- a/gwsumm/html/tests/test_html5.py
+++ b/gwsumm/html/tests/test_html5.py
@@ -107,12 +107,22 @@ def test_comments_box():
     assert parse_html(str(box)) == parse_html(BOX % URL)
 
 
-def test_ldvw_qscan():
+def test_ldvw_qscan_single():
     button = html5.ldvw_qscan('X1:TEST', 0)
     assert parse_html(str(button)) == parse_html(
-        '<a href="https://ldvw.ligo.caltech.edu/ldvw/view?'
-        'act=doplot&amp;chanName=X1:TEST&amp;doQxfrm=yes&amp;'
-        'strtTime=0&amp;qxfrm_pltfrq=10 inf&amp;qxfrm_srchqrng=4 100&'
-        'amp;qxfrm_plttimes=0.5 2 8" target="_blank" rel="external" '
-        'class="btn btn-default btn-xs" title="Q-scan of X1:TEST at 0 '
-        'in LDVW">Q-scan</a>')
+        '<a href="https://ldvw.ligo.caltech.edu/ldvw/view?act=doplot&amp;'
+        'chanName=X1:TEST&amp;doQxfrm=yes&amp;strtTime=0&amp;&amp;'
+        'qxfrm_pltfrq=10 inf&amp;qxfrm_srchqrng=4 100&amp;'
+        'qxfrm_plttimes=0.5 2 8" target="_blank" rel="external" '
+        'class="btn btn-default btn-xs" title="Q-scan X1:TEST at 0 via LDVW">'
+        'Q-scan</a>')
+
+
+def test_ldvw_qscan_batch():
+    button = html5.ldvw_qscan('X1:TEST', (0,))
+    assert parse_html(str(button)) == parse_html(
+        '<a href="https://ldvw.ligo.caltech.edu/ldvw/Wdq?submitAct=go&amp;'
+        'wdq_ifo=X1&amp;wdq_cmap=viridis&amp;wdq_gps=0&amp;wdq_prog=py-Omega&'
+        'amp;goBtn=goBtn" target="_blank" rel="external" class="btn '
+        'btn-default btn-xs" title="Batch-process omega scans of the loudest '
+        'triggers via LDVW">Launch omega scans (LDVW)</a>')

--- a/gwsumm/html/tests/test_html5.py
+++ b/gwsumm/html/tests/test_html5.py
@@ -125,4 +125,4 @@ def test_ldvw_qscan_batch():
         'wdq_ifo=X1&amp;wdq_cmap=viridis&amp;wdq_gps=0&amp;wdq_prog=py-Omega&'
         'amp;goBtn=goBtn" target="_blank" rel="external" class="btn '
         'btn-default btn-xs" title="Batch-process omega scans of the loudest '
-        'triggers via LDVW">Launch omega scans (LDVW)</a>')
+        'triggers via LDVW">Launch omega scans</a>')

--- a/gwsumm/tabs/etg.py
+++ b/gwsumm/tabs/etg.py
@@ -350,7 +350,7 @@ class EventTriggerTab(get_tab('default')):
 
                     # construct table
                     times = (row[0] for row in data)
-                    launch = ldvw_qscan(self.channel.name, times)
+                    launch = ldvw_qscan(self.channel, times)
                     page.add(str(html.table(
                         headers, data, id='%s-loudest-table' % self.etg,
                         caption=("%d loudest <samp>%s</samp> (%s) events "

--- a/gwsumm/tabs/etg.py
+++ b/gwsumm/tabs/etg.py
@@ -349,7 +349,7 @@ class EventTriggerTab(get_tab('default')):
                         data[-1].append(ldvw_qscan(self.channel, data[-1][0]))
 
                     # construct table
-                    times = (row[0] for row in data)
+                    times = tuple(row[0] for row in data)
                     launch = ldvw_qscan(self.channel, times)
                     page.add(str(html.table(
                         headers, data, id='%s-loudest-table' % self.etg,

--- a/gwsumm/tabs/etg.py
+++ b/gwsumm/tabs/etg.py
@@ -349,15 +349,8 @@ class EventTriggerTab(get_tab('default')):
                         data[-1].append(ldvw_qscan(self.channel, data[-1][0]))
 
                     # construct table
-                    times = ' '.join(str(row[0]) for row in data)
-                    launch = markup.oneliner.a(
-                        'Launch full omega scans through LDVW',
-                        target='_blank',
-                        href='https://ldvw.ligo.caltech.edu/ldvw/Wdq?'
-                             'submitAct=go&wdq_ifo=%s&wdq_cmap=viridis&'
-                             'wdq_gps=%s&wdq_prog=py-Omega&'
-                             'goBtn=goBtn' % (self.channel.name[:2], times),
-                    )
+                    times = (row[0] for row in data)
+                    launch = ldvw_qscan(self.channel.name, times)
                     page.add(str(html.table(
                         headers, data, id='%s-loudest-table' % self.etg,
                         caption=("%d loudest <samp>%s</samp> (%s) events "


### PR DESCRIPTION
This PR refactors the `html.html5.ldvw_qscan` utility to support batch omega scans through LDVW. It also adds a new unit test for the refactored functionality.

Example output is available [**here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/summary/day/20190702/detchar/pycbc_live_short/).

cc @areeda, @duncanmmacleod 