### PR TITLE
Display release notes and help content in a dialog box

### DIFF
--- a/gwsumm/html/html5.py
+++ b/gwsumm/html/html5.py
@@ -134,11 +134,11 @@ def ldvw_qscan(channel, time, fmin=10, fmax='inf', qmin=4, qmax=100):
         class_='btn btn-default btn-xs', title=title)
 
 
-def dialog_box(content, title):
+def dialog_box(content, title, id_):
     """Generate a dialog box to be loaded modal atop the main page
     """
     page = markup.page()
-    page.add('<dialog>')  # MarkupPy does not support dialog elements
+    page.add('<dialog id="%s">' % id_)  # MarkupPy does not support dialog
     page.div(class_='row')
     page.div(class_='col-sm-11')
     page.h1(title)

--- a/gwsumm/html/html5.py
+++ b/gwsumm/html/html5.py
@@ -24,6 +24,7 @@ import os.path
 from urllib.parse import urlparse
 
 from MarkupPy import markup
+from markdown import markdown
 
 DOCTYPE = '<!DOCTYPE html>'
 
@@ -134,18 +135,30 @@ def ldvw_qscan(channel, time, fmin=10, fmax='inf', qmin=4, qmax=100):
         class_='btn btn-default btn-xs', title=title)
 
 
-def dialog_box(content, title, id_):
+def dialog_box(content, id_):
     """Generate a dialog box to be loaded modal atop the main page
+
+    Parameters
+    ----------
+    content : `str`
+        either raw markdown text or the path to a file containing markdown,
+        this will be rendered in HTML as the contents of the dialog box
+
+    id_ : `str`
+        unique identifier for the dialog box
+
+    Returns
+    -------
+    page : `~MarkupPy.markup.page`
+        fully rendered HTML containing the dialog box
     """
     page = markup.page()
     page.add('<dialog id="%s">' % id_)  # MarkupPy does not support dialog
     page.a('&#x2715;', title='Close', onclick="closeDialog('%s')" % id_,
            class_='btn btn-default pull-right', **{'aria-label': 'Close'})
-    page.h1(title)
-    page.add('<hr class="row-divider">')
-    if isinstance(content, str):
-        content = markup.oneliner.p(content) if (
-            not content.startswith('<')) else content
-    page.add(str(content))
+    if os.path.isfile(content):
+        with open(content, 'r') as source:
+            content = source.read()
+    page.add(markdown(content))
     page.add('</dialog>')
     return page

--- a/gwsumm/html/html5.py
+++ b/gwsumm/html/html5.py
@@ -139,15 +139,10 @@ def dialog_box(content, title, id_):
     """
     page = markup.page()
     page.add('<dialog id="%s">' % id_)  # MarkupPy does not support dialog
-    page.div(class_='row')
-    page.div(class_='col-sm-11')
+    page.a('&#x2715;', title='Close', onclick='closeDialog()',
+           class_='btn btn-default pull-right', **{'aria-label': 'Close'})
     page.h1(title)
-    page.div.close()  # col-sm-11
-    page.div(class_='col-sm-1')
-    page.a('&times;', title='Close', onclick='closeDialog()',
-           **{'aria-label': 'Close'})
-    page.div.close()  # col-sm-1
-    page.div.close()  # row
+    page.add('<hr class="row-divider">')
     if isinstance(content, str):
         content = markup.oneliner.p(content) if (
             not content.startswith('<')) else content

--- a/gwsumm/html/html5.py
+++ b/gwsumm/html/html5.py
@@ -159,6 +159,6 @@ def dialog_box(content, id_):
     if os.path.isfile(content):
         with open(content, 'r') as source:
             content = source.read()
-    page.add(markdown(content))
+    page.add(markdown(str(content)))
     page.add('</dialog>')
     return page

--- a/gwsumm/html/html5.py
+++ b/gwsumm/html/html5.py
@@ -139,7 +139,7 @@ def dialog_box(content, title, id_):
     """
     page = markup.page()
     page.add('<dialog id="%s">' % id_)  # MarkupPy does not support dialog
-    page.a('&#x2715;', title='Close', onclick='closeDialog()',
+    page.a('&#x2715;', title='Close', onclick="closeDialog('%s')" % id_,
            class_='btn btn-default pull-right', **{'aria-label': 'Close'})
     page.h1(title)
     page.add('<hr class="row-divider">')

--- a/gwsumm/html/html5.py
+++ b/gwsumm/html/html5.py
@@ -132,3 +132,25 @@ def ldvw_qscan(channel, time, fmin=10, fmax='inf', qmin=4, qmax=100):
     return markup.oneliner.a(
         label, href=uri, target='_blank', rel='external',
         class_='btn btn-default btn-xs', title=title)
+
+
+def dialog_box(content, title):
+    """Generate a dialog box to be loaded modal atop the main page
+    """
+    page = markup.page()
+    page.add('<dialog>')  # MarkupPy does not support dialog elements
+    page.div(class_='row')
+    page.div(class_='col-sm-11')
+    page.h1(title)
+    page.div.close()  # col-sm-11
+    page.div(class_='col-sm-1')
+    page.a('&times;', title='Close', onclick='closeDialog()',
+           **{'aria-label': 'Close'})
+    page.div.close()  # col-sm-1
+    page.div.close()  # row
+    if isinstance(content, str):
+        content = markup.oneliner.p(content) if (
+            not content.startswith('<')) else content
+    page.add(str(content))
+    page.add('</dialog>')
+    return page

--- a/gwsumm/html/static.py
+++ b/gwsumm/html/static.py
@@ -40,6 +40,9 @@ JS = OrderedDict((
     ('datepicker', (
         '//cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/'
         '1.6.0/js/bootstrap-datepicker.min.js')),
+    ('dialog-polyfill', (
+        'https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/'
+        '0.5.0/dialog-polyfill.min.js')),
     ('bootstrap-ligo', JS_FILES[4]),
     ('gwdetchar', JS_FILES[5]),
     ('gwsumm', os.path.join(STATICDIR, 'gwsumm.min.js')),
@@ -52,6 +55,9 @@ CSS = OrderedDict((
     ('datepicker', (
         '//cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/'
         '1.6.0/css/bootstrap-datepicker.min.css')),
+    ('dialog-polyfill', (
+        'https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/'
+        '0.5.0/dialog-polyfill.min.css')),
     ('bootstrap-ligo', CSS_FILES[2]),
     ('gwdetchar', CSS_FILES[3]),
     ('gwsumm', os.path.join(STATICDIR, 'gwsumm.min.css')),

--- a/gwsumm/html/tests/test_html5.py
+++ b/gwsumm/html/tests/test_html5.py
@@ -130,7 +130,9 @@ def test_ldvw_qscan_batch():
 
 def test_dialog_box():
     box = html5.dialog_box('test', 'title', 'testid')
+    print(box)
     assert parse_html(str(box)) == parse_html(
-        '<dialog id="testid">\n<a title="Close" onclick="closeDialog()" '
+        '<dialog id="testid">\n<a title="Close" '
+        'onclick="closeDialog(&quot;testid&quot;)" '
         'class="btn btn-default pull-right" aria-label="Close">&#x2715;</a>\n'
         '<h1>title</h1>\n<hr class="row-divider">\n<p>test</p>\n</dialog>')

--- a/gwsumm/html/tests/test_html5.py
+++ b/gwsumm/html/tests/test_html5.py
@@ -21,6 +21,11 @@
 
 __author__ = 'Alex Urban <alexander.urban@ligo.org>'
 
+import os
+import shutil
+
+from markdown import markdown
+
 from gwdetchar.utils import parse_html
 
 from .. import html5
@@ -56,6 +61,20 @@ BOX = """<div id="disqus_thread">
 <noscript>Please enable JavaScript to view the</noscript>
 <a href="https://disqus.com/?ref_noscript">comments powered by Disqus</a>
 </div>"""
+
+CONTENTS = """Heading
+=======
+
+This is a test.
+
+* Bullet 1
+* Bullet 2"""
+
+DIALOG = ('<dialog id="id">\n<a title="Close" '
+          'onclick="closeDialog(&quot;id&quot;)" '
+          'class="btn btn-default pull-right" '
+          'aria-label="Close">&#x2715;</a>\n%s\n'
+          '</dialog>') % markdown(CONTENTS)
 
 
 # test utilities
@@ -128,11 +147,10 @@ def test_ldvw_qscan_batch():
         'triggers via LDVW">Launch omega scans</a>')
 
 
-def test_dialog_box():
-    box = html5.dialog_box('test', 'title', 'testid')
-    print(box)
-    assert parse_html(str(box)) == parse_html(
-        '<dialog id="testid">\n<a title="Close" '
-        'onclick="closeDialog(&quot;testid&quot;)" '
-        'class="btn btn-default pull-right" aria-label="Close">&#x2715;</a>\n'
-        '<h1>title</h1>\n<hr class="row-divider">\n<p>test</p>\n</dialog>')
+def test_dialog_box(tmpdir):
+    mdfile = os.path.join(str(tmpdir), 'test.md')
+    with open(mdfile, 'w') as f:
+        f.write(CONTENTS)
+    box = html5.dialog_box(mdfile, 'id')
+    assert parse_html(str(box)) == parse_html(DIALOG)
+    shutil.rmtree(str(tmpdir), ignore_errors=True)

--- a/gwsumm/html/tests/test_html5.py
+++ b/gwsumm/html/tests/test_html5.py
@@ -131,7 +131,6 @@ def test_ldvw_qscan_batch():
 def test_dialog_box():
     box = html5.dialog_box('test', 'title', 'testid')
     assert parse_html(str(box)) == parse_html(
-        '<dialog id="testid">\n<div class="row">\n<div class="col-sm-11">\n'
-        '<h1>title</h1>\n</div>\n<div class="col-sm-1">\n<a title="Close" '
-        'onclick="closeDialog()" aria-label="Close">&times;</a>\n</div>\n'
-        '</div>\n<p>test</p>\n</dialog>')
+        '<dialog id="testid">\n<a title="Close" onclick="closeDialog()" '
+        'class="btn btn-default pull-right" aria-label="Close">&#x2715;</a>\n'
+        '<h1>title</h1>\n<hr class="row-divider">\n<p>test</p>\n</dialog>')

--- a/gwsumm/html/tests/test_html5.py
+++ b/gwsumm/html/tests/test_html5.py
@@ -129,9 +129,9 @@ def test_ldvw_qscan_batch():
 
 
 def test_dialog_box():
-    box = html5.dialog_box('test', 'title')
+    box = html5.dialog_box('test', 'title', 'testid')
     assert parse_html(str(box)) == parse_html(
-        '<dialog>\n<div class="row">\n<div class="col-sm-11">\n<h1>title</h1>'
-        '\n</div>\n<div class="col-sm-1">\n<a title="Close" '
+        '<dialog id="testid">\n<div class="row">\n<div class="col-sm-11">\n'
+        '<h1>title</h1>\n</div>\n<div class="col-sm-1">\n<a title="Close" '
         'onclick="closeDialog()" aria-label="Close">&times;</a>\n</div>\n'
         '</div>\n<p>test</p>\n</dialog>')

--- a/gwsumm/html/tests/test_html5.py
+++ b/gwsumm/html/tests/test_html5.py
@@ -126,3 +126,12 @@ def test_ldvw_qscan_batch():
         'amp;goBtn=goBtn" target="_blank" rel="external" class="btn '
         'btn-default btn-xs" title="Batch-process omega scans of the loudest '
         'triggers via LDVW">Launch omega scans</a>')
+
+
+def test_dialog_box():
+    box = html5.dialog_box('test', 'title')
+    assert parse_html(str(box)) == parse_html(
+        '<dialog>\n<div class="row">\n<div class="col-sm-11">\n<h1>title</h1>'
+        '\n</div>\n<div class="col-sm-1">\n<a title="Close" '
+        'onclick="closeDialog()" aria-label="Close">&times;</a>\n</div>\n'
+        '</div>\n<p>test</p>\n</dialog>')

--- a/gwsumm/html/tests/test_static.py
+++ b/gwsumm/html/tests/test_static.py
@@ -42,16 +42,18 @@ def test_get_css():
         'bootstrap',
         'fancybox',
         'datepicker',
+        'dialog-polyfill',
         'bootstrap-ligo',
         'gwdetchar',
         'gwsumm',
     ]
     # test list of files
     css_files = list(css.values())
-    assert len(css_files) == len(GWDETCHAR_CSS_FILES) + 2
+    assert len(css_files) == len(GWDETCHAR_CSS_FILES) + 3
     assert set(GWDETCHAR_CSS_FILES) < set(css_files)
     assert os.path.basename(css_files[2]) == 'bootstrap-datepicker.min.css'
-    assert os.path.basename(css_files[5]) == 'gwsumm.min.css'
+    assert os.path.basename(css_files[3]) == 'dialog-polyfill.min.css'
+    assert os.path.basename(css_files[6]) == 'gwsumm.min.css'
 
 
 def test_get_js():
@@ -65,13 +67,15 @@ def test_get_js():
         'bootstrap',
         'fancybox',
         'datepicker',
+        'dialog-polyfill',
         'bootstrap-ligo',
         'gwdetchar',
         'gwsumm',
     ]
     # test list of files
     js_files = list(js.values())
-    assert len(js_files) == len(GWDETCHAR_JS_FILES) + 2
+    assert len(js_files) == len(GWDETCHAR_JS_FILES) + 3
     assert set(GWDETCHAR_JS_FILES) < set(js_files)
     assert os.path.basename(js_files[4]) == 'bootstrap-datepicker.min.js'
-    assert os.path.basename(js_files[7]) == 'gwsumm.min.js'
+    assert os.path.basename(js_files[5]) == 'dialog-polyfill.min.js'
+    assert os.path.basename(js_files[8]) == 'gwsumm.min.js'

--- a/gwsumm/tabs/builtin.py
+++ b/gwsumm/tabs/builtin.py
@@ -32,6 +32,7 @@ import warnings
 from configparser import NoOptionError
 
 from MarkupPy import markup
+from markdown import markdown
 
 from .registry import (get_tab, register_tab)
 from ..plot import get_plot
@@ -315,10 +316,7 @@ class PlotTab(Tab):
             self._pre = content
         else:
             self._pre = markup.page()
-            if not str(content).startswith('<'):
-                self._pre.p(str(content))
-            else:
-                self._pre.add(str(content))
+            self._pre.add(markdown(str(content)))
 
     @property
     def afterword(self):
@@ -332,10 +330,7 @@ class PlotTab(Tab):
             self._post = content
         else:
             self._post = markup.page()
-            if not str(content).startswith('<'):
-                self._post.p(str(content))
-            else:
-                self._post.add(str(content))
+            self._post.add(markdown(str(content)))
 
     @classmethod
     def from_ini(cls, cp, section, *args, **kwargs):

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -718,7 +718,8 @@ class BaseTab(object):
 
         # add help button
         if self.notes is not None:
-            self.page.add(html.dialog_box(self.notes, "What's new?"))
+            self.page.add(str(html.dialog_box(
+                self.notes, "What's new?", id_='whats-new')))
             self.page.button(markup.oneliner.span('&#63;'),
                              title="What's new?", onclick='showDialog()',
                              class_='btn-float', id_='help-btn')

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -63,7 +63,7 @@ class BaseTab(object):
     """
     def __init__(self, name, index=None,
                  shortname=None, parent=None, children=list(), group=None,
-                 path=os.curdir, mode=None, hidden=False):
+                 notes=None, path=os.curdir, mode=None, hidden=False):
         # mode
         self.mode = mode
         # names
@@ -74,6 +74,7 @@ class BaseTab(object):
         self.parent = parent
         self.children = children
         self.group = group
+        self.notes = notes
         # HTML format
         self.path = path
         self.index = index
@@ -255,6 +256,19 @@ class BaseTab(object):
             self._group = str(gp)
 
     @property
+    def notes(self):
+        """Release notes for this `Tab`
+        """
+        return self._notes
+
+    @notes.setter
+    def notes(self, n):
+        if n is None:
+            self._notes = None
+        else:
+            self._notes = n
+
+    @property
     def mode(self):
         """The date-time mode of this tab.
 
@@ -345,6 +359,7 @@ class BaseTab(object):
            ~Tab.shortname
            ~Tab.parent
            ~Tab.group
+           ~Tab.notes
            ~Tab.index
 
         Sub-classes should parse their own configuration values and then pass
@@ -404,6 +419,12 @@ class BaseTab(object):
             else:
                 hidden = bool(hidden.title())
         kwargs.setdefault('hidden', hidden)
+
+        # get release notes
+        try:
+            kwargs.setdefault('notes', cp.get(section, 'notes'))
+        except NoOptionError:
+            pass
 
         # get mode and times if required
         try:
@@ -610,7 +631,7 @@ class BaseTab(object):
     def write_html(self, maincontent, title=None, subtitle=None, tabs=list(),
                    ifo=None, ifomap=dict(), brand=None, base=None,
                    css=None, js=None, about=None, footer=None, issues=True,
-                   notes=None, **inargs):
+                   **inargs):
         """Write the HTML page for this `Tab`.
 
         Parameters
@@ -655,10 +676,6 @@ class BaseTab(object):
         issues : `bool` or `str`, default: `True`
             print link to github.com issue tracker for this package
 
-        notes : `str`, `~MarkupPy.markup.page`, optional
-            simple string or structured `page` of content describing new
-            features available on the website, default: none
-
         **inargs
             other keyword arguments to pass to the
             :meth:`~Tab.build_inner_html` method
@@ -700,8 +717,8 @@ class BaseTab(object):
             title=title.replace('|', ':'), subtitle=subtitle)))
 
         # add help button
-        if notes is not None:
-            self.page.add(html.dialog_box(notes, "What's new?"))
+        if self.notes is not None:
+            self.page.add(html.dialog_box(self.notes, "What's new?"))
             self.page.button(markup.oneliner.span('&#63;'),
                              title="What's new?", onclick='showDialog()',
                              class_='btn-float', id_='help-btn')

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -720,9 +720,10 @@ class BaseTab(object):
         if self.notes is not None:
             self.page.add(str(html.dialog_box(
                 self.notes, "What's new?", id_='whats-new')))
-            self.page.button(markup.oneliner.span('&#63;'),
-                             title="What's new?", onclick='showDialog()',
-                             class_='btn-float', id_='help-btn')
+            self.page.button(
+                markup.oneliner.span('&#63;'), title="What's new?",
+                onclick="showDialog('whats-new')", class_='btn-float',
+                id_='help-btn')
 
         # add #main content
         self.page.add(str(self.html_content(maincontent)))

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -610,7 +610,7 @@ class BaseTab(object):
     def write_html(self, maincontent, title=None, subtitle=None, tabs=list(),
                    ifo=None, ifomap=dict(), brand=None, base=None,
                    css=None, js=None, about=None, footer=None, issues=True,
-                   **inargs):
+                   notes=None, **inargs):
         """Write the HTML page for this `Tab`.
 
         Parameters
@@ -655,6 +655,10 @@ class BaseTab(object):
         issues : `bool` or `str`, default: `True`
             print link to github.com issue tracker for this package
 
+        notes : `str`, `~MarkupPy.markup.page`, optional
+            simple string or structured `page` of content describing new
+            features available on the website, default: none
+
         **inargs
             other keyword arguments to pass to the
             :meth:`~Tab.build_inner_html` method
@@ -694,6 +698,13 @@ class BaseTab(object):
         # add banner
         self.page.add(str(self.html_banner(
             title=title.replace('|', ':'), subtitle=subtitle)))
+
+        # add help button
+        if notes is not None:
+            self.page.add(html.dialog_box(notes, "What's new?"))
+            self.page.button(markup.oneliner.span('&#63;'),
+                             title="What's new?", onclick='showDialog()',
+                             class_='btn-float', id_='help-btn')
 
         # add #main content
         self.page.add(str(self.html_content(maincontent)))

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -718,11 +718,10 @@ class BaseTab(object):
 
         # add help button
         if self.notes is not None:
-            self.page.add(str(html.dialog_box(
-                self.notes, "What's new?", id_='whats-new')))
+            self.page.add(str(html.dialog_box(self.notes, id_='help')))
             self.page.button(
-                markup.oneliner.span('&#63;'), title="What's new?",
-                onclick="showDialog('whats-new')", class_='btn-float',
+                markup.oneliner.span('&#63;'), title='Help',
+                onclick="showDialog('help')", class_='btn-float',
                 id_='help-btn')
 
         # add #main content

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ lscsoft-glue>=1.60.0
 ligo-segments
 pygments
 MarkupPy
+markdown
 gwdetchar>=0.5.1
 gwpy>=0.14.2
 configparser ; python_version < '3.6'

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ install_requires = [
     'gwdatafind',
     'pygments',
     'MarkupPy',
+    'markdown',
     'gwdetchar>=0.5.1',
     'configparser ; python_version < \'3.6\'',
 ]

--- a/share/js/gwsumm.js
+++ b/share/js/gwsumm.js
@@ -249,15 +249,20 @@ $(window).resize(function() {
 
 /* ------------------------------------------------------------------------- */
 /* html5 dialog elements                                                     */ 
-var dialog = document.querySelector('dialog');
 
-// register element
-dialogPolyfill.registerDialog(dialog);
+function getDialog(id) {
+  var dialog = document.getElementById(id);
+  // register polyfill for new dialog element
+  dialogPolyfill.registerDialog(dialog);
+  return dialog;
+}
 
-function showDialog() {
+function showDialog(id) {
+  var dialog = getDialog(id);
   dialog.showModal();
-};
+}
 
-function closeDialog() {
-  dialog.closeModal();
-};
+function closeDialog(id) {
+  var dialog = getDialog(id);
+  dialog.close();
+}

--- a/share/js/gwsumm.js
+++ b/share/js/gwsumm.js
@@ -254,12 +254,10 @@ var dialog = document.querySelector('dialog');
 // register element
 dialogPolyfill.registerDialog(dialog);
 
-document.querySelector('#show').onclick = function() {
-  // show dialog
-  dialog.show();
+function showDialog() {
+  dialog.showModal();
 };
 
-document.querySelector('#close').onclick = function() {
-  // close dialog
-  dialog.close();
+function closeDialog() {
+  dialog.closeModal();
 };

--- a/share/js/gwsumm.js
+++ b/share/js/gwsumm.js
@@ -245,3 +245,21 @@ $(window).resize(function() {
   // set short month date
   if ($('#calendar').length){ shortenDate();}
 });
+
+
+/* ------------------------------------------------------------------------- */
+/* html5 dialog elements                                                     */ 
+var dialog = document.querySelector('dialog');
+
+// register element
+dialogPolyfill.registerDialog(dialog);
+
+document.querySelector('#show').onclick = function() {
+  // show dialog
+  dialog.show();
+};
+
+document.querySelector('#close').onclick = function() {
+  // close dialog
+  dialog.close();
+};

--- a/share/sass/gwsumm.scss
+++ b/share/sass/gwsumm.scss
@@ -11,6 +11,8 @@ dialog {
 		-ms-transform: translateY(-50%);
 		transform: translateY(-50%);
 		min-width: 60%;
+		max-height: 80%;
+		overflow-y: scroll;
 		position: fixed;
 		border-radius: 6px;
 		background-color: white;

--- a/share/sass/gwsumm.scss
+++ b/share/sass/gwsumm.scss
@@ -11,6 +11,7 @@ dialog {
 		-ms-transform: translateY(-50%);
 		transform: translateY(-50%);
 		min-width: 60%;
+		max-width: 80%;
 		max-height: 80%;
 		overflow-y: scroll;
 		position: fixed;

--- a/share/sass/gwsumm.scss
+++ b/share/sass/gwsumm.scss
@@ -8,21 +8,34 @@ body {
 
 dialog {
 		top: 50%;
-		left: 50%;
+		-ms-transform: translateY(-50%);
+		transform: translateY(-50%);
+		min-width: 60%;
 		position: fixed;
 		border-radius: 6px;
 		background-color: white;
 		border: 1px solid rgba(0, 0, 0, 0.3);
-		box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
+		box-shadow:0 3px 7px rgba(0, 0, 0, 0.8);
 }
 
+// native dialog
 dialog::backdrop {
 		position: fixed;
 		top: 0;
 		left: 0;
 		right: 0;
 		bottom: 0;
-		background-color: rgba(0, 0, 0, 0.8);
+		background-color: rgba(0, 0, 0, 0.6);
+}
+
+// polyfill dialog
+dialog+.backdrop {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		background-color: rgba(0, 0, 0, 0.6);
 }
 
 .footer {
@@ -108,5 +121,7 @@ dialog::backdrop {
 #help-btn {
 		@media(min-width:992px) {
 				bottom: 80px;
+				padding-left: 16px;
+				padding-right: 16px;
 		}
 }

--- a/share/sass/gwsumm.scss
+++ b/share/sass/gwsumm.scss
@@ -6,6 +6,29 @@ body {
 		background-color: #eee;
 }
 
+dialog {
+		top: 50%;
+		left: 50%;
+		position: fixed;
+		border-radius: 6px;
+		background-color: white;
+		border: 1px solid rgba(0, 0, 0, 0.3);
+		box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
+}
+
+dialog::backdrop {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		background-color: rgba(0, 0, 0, 0.8);
+}
+
+.footer {
+		height: 148px;
+}
+
 .navbar {
 		.btn-group {
 				margin-bottom: 0px;
@@ -53,11 +76,6 @@ body {
 		}
 }
 
-// footer height
-.footer {
-		height: 148px;
-}
-
 // detchar stuff
 #idq img,
 #upv img {
@@ -84,4 +102,11 @@ body {
 		-o-transform-origin: 0 0;
 		-webkit-transform: scale(0.55);
 		-webkit-transform-origin: 0 0;
+}
+
+// help button
+#help-btn {
+		@media(min-width:992px) {
+				bottom: 80px;
+		}
 }


### PR DESCRIPTION
This PR allows us to publish user-side release notes and help content for the summary pages. The notes themselves will be taken from configuration files, then wrapped in HTML and displayed in a `dialog` element. The user-facing way to activate this feature is a floating, sticky button showing a question mark.

Two dependencies are introduced:
* Because many modern browsers do not natively support the `dialog` element (see [**this reference**](https://caniuse.com/#feat=dialog)), I'm importing a [**polyfill**](https://github.com/GoogleChrome/dialog-polyfill) that is widely compatible.
* As a trade-off between ability to customize and ease of use, the [**python-markdown**](https://python-markdown.github.io/reference/) library is used to render release notes. This allows users to write notes to a `README.md`-style document, then configure GWSumm to point to it. Note, this library is available through Conda.

python-markdown will also now be used to render `foreword` and `afterword` elements.

Test output showing the full suite of Network summary pages is available [**here**](https://ldas-jobs.ligo.caltech.edu/~alexander.urban/summary/testing/1242518418-1242522018/).

cc @duncanmmacleod, @areeda