### PR TITLE
Properly test for cache types

### DIFF
--- a/gwsumm/segments.py
+++ b/gwsumm/segments.py
@@ -184,7 +184,7 @@ def get_segments(flag, validity=None, config=ConfigParser(), cache=None,
         query &= len(cache) != 0
     if query:
         if cache is not None:
-            if os.path.isfile(cache) and cache.endswith(
+            if os.path.isfile(str(cache)) and str(cache).endswith(
                 (".h5", ".hdf", ".hdf5")) and (
                     'path' not in read_kw):
                 read_kw['path'] = config.get(

--- a/gwsumm/segments.py
+++ b/gwsumm/segments.py
@@ -19,8 +19,9 @@
 """Utilities for segment handling and display
 """
 
-import operator
+import os
 import sys
+import operator
 import warnings
 from functools import reduce
 from collections import OrderedDict
@@ -183,11 +184,11 @@ def get_segments(flag, validity=None, config=ConfigParser(), cache=None,
         query &= len(cache) != 0
     if query:
         if cache is not None:
-            if isinstance(cache, str) and cache.endswith(
+            if os.path.isfile(cache) and cache.endswith(
                 (".h5", ".hdf", ".hdf5")) and (
                     'path' not in read_kw):
-                read_kw['path'] = config.get('DEFAULT', 'segments-hdf5-path',
-                                             fallback='')
+                read_kw['path'] = config.get(
+                    'DEFAULT', 'segments-hdf5-path', fallback='segments')
             try:
                 new = DataQualityDict.read(cache, list(allflags), **read_kw)
             except IORegistryError as e:

--- a/gwsumm/segments.py
+++ b/gwsumm/segments.py
@@ -183,7 +183,8 @@ def get_segments(flag, validity=None, config=ConfigParser(), cache=None,
         query &= len(cache) != 0
     if query:
         if cache is not None:
-            if cache.endswith((".h5", ".hdf", ".hdf5")) and (
+            if isinstance(cache, str) and cache.endswith(
+                (".h5", ".hdf", ".hdf5")) and (
                     'path' not in read_kw):
                 read_kw['path'] = config.get('DEFAULT', 'segments-hdf5-path',
                                              fallback='')

--- a/gwsumm/segments.py
+++ b/gwsumm/segments.py
@@ -19,7 +19,6 @@
 """Utilities for segment handling and display
 """
 
-import os
 import sys
 import operator
 import warnings
@@ -184,7 +183,7 @@ def get_segments(flag, validity=None, config=ConfigParser(), cache=None,
         query &= len(cache) != 0
     if query:
         if cache is not None:
-            if os.path.isfile(str(cache)) and str(cache).endswith(
+            if isinstance(cache, str) and cache.endswith(
                 (".h5", ".hdf", ".hdf5")) and (
                     'path' not in read_kw):
                 read_kw['path'] = config.get(


### PR DESCRIPTION
This PR fixes a bug in reading segment caches by properly testing that `cache` is a file path object before attempting to determine its file extension.

cc @Madeline-wade