### PR TITLE
Gracefully handle coherence gaps

### DIFF
--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -122,7 +122,11 @@ def _get_coherence_spectrogram(channel_pair, segments, config=None,
                               config=config, cache=cache, frametype=frametype,
                               nproc=nproc, query=query,
                               datafind_error=datafind_error, nds=nds)
-        sampling = min(dts1[0].sample_rate.value, dts2[0].sample_rate.value)
+        try:
+            sampling = min(dts1[0].sample_rate.value,
+                           dts2[0].sample_rate.value)
+        except IndexError:
+            sampling = None
     else:
         sampling = None
 


### PR DESCRIPTION
This PR gracefully handles the use case where coherence analysis segments are non-empty, but no data are found in the frame archive, by wrapping the sample rate in a try-except block.

Note, this change has been successfully tested in production at LIGO-Livingston.

cc @duncanmmacleod 