### PR TITLE
Resolve symbolic links when pointing to external pages

### DIFF
--- a/gwsumm/html/html5.py
+++ b/gwsumm/html/html5.py
@@ -24,7 +24,7 @@ import os.path
 try:
     from pathlib2 import Path
 except ImportError:  # python >= 3.6
-    # NOTE: we do it this was around because pathlib exists for py35,
+    # NOTE: we do it this way around because pathlib exists for py35,
     #       but doesn't work very well
     from pathlib import Path
 

--- a/gwsumm/html/html5.py
+++ b/gwsumm/html/html5.py
@@ -19,7 +19,14 @@
 """HTML5 specific extensions
 """
 
+import re
 import os.path
+try:
+    from pathlib2 import Path
+except ImportError:  # python >= 3.6
+    # NOTE: we do it this was around because pathlib exists for py35,
+    #       but doesn't work very well
+    from pathlib import Path
 
 from urllib.parse import urlparse
 
@@ -27,6 +34,15 @@ from MarkupPy import markup
 from markdown import markdown
 
 DOCTYPE = '<!DOCTYPE html>'
+
+
+def _expand_path(path):
+    """Expand a server path that may contain symbolic links
+    """
+    subbed = Path(re.sub(r'^/\~(.*?)/', r'/home/\1/public_html/', path))
+    resolved = subbed.resolve() if subbed.exists() else subbed
+    return re.sub(r'^/home/(.*?)/public_html/', r'/~\1/',
+                  str(resolved) if resolved.exists() else path)
 
 
 def load_state(url):
@@ -73,6 +89,7 @@ def load(url, id_='main', error=False, success=None):
                  '<p>%s</p></div>");' % (id_, error))
     if success is None:
         success = '$("#%s").html(data);' % id_
+    url = _expand_path(url)
     return markup.given_oneliner.script("""
     $.ajax({
         url : '%s',

--- a/gwsumm/html/tests/test_html5.py
+++ b/gwsumm/html/tests/test_html5.py
@@ -79,7 +79,7 @@ DIALOG = ('<dialog id="id">\n<a title="Close" '
 
 # test utilities
 
-def test_expand_path(tmpdir):
+def test_expand_path():
     assert html5._expand_path(URL) == URL
 
 

--- a/gwsumm/html/tests/test_html5.py
+++ b/gwsumm/html/tests/test_html5.py
@@ -79,6 +79,10 @@ DIALOG = ('<dialog id="id">\n<a title="Close" '
 
 # test utilities
 
+def test_expand_path(tmpdir):
+    assert html5._expand_path(URL) == URL
+
+
 def test_load_state():
     state = html5.load_state('test')
     assert parse_html(str(state)) == parse_html(


### PR DESCRIPTION
This PR adds functionality to resolve symbolic links when pointing to external pages. Specifically, it is designed to support production hveto runs, which are processed three times a day with a symbolic link pointing to the latest analysis.

cc @duncanmmacleod, @areeda 