### PR TITLE
Force timezone to UTC for javascript utilities

### DIFF
--- a/share/js/gwsumm.js
+++ b/share/js/gwsumm.js
@@ -187,18 +187,16 @@ $(window).load(function() {
   });
 
   // set 'today' location
-  Site.Calendar = function() {
-    $.datepicker._gotoToday = function(id) {
-      var dateformat = findDateFormat();
-      var tday = moment().utc();
-      if (dateformat == 'day') {
-        move_to_date({type: 'changeDate', date: tday});
-      } else if (dateformat == 'month') {
-        move_to_date({type: 'changeMonth', date: tday});
-      } else if (dateformat == 'year') {
-        move_to_date({type: 'changeYear', date: tday});
-      }
-    };
+  $.datepicker._gotoToday = function(id) {
+    var dateformat = findDateFormat();
+    var tday = moment().utc();
+    if (dateformat == 'day') {
+      move_to_date({type: 'changeDate', date: tday});
+    } else if (dateformat == 'month') {
+      move_to_date({type: 'changeMonth', date: tday});
+    } else if (dateformat == 'year') {
+      move_to_date({type: 'changeYear', date: tday});
+    }
   };
 
   // define the calendar

--- a/share/js/gwsumm.js
+++ b/share/js/gwsumm.js
@@ -176,6 +176,9 @@ function shortenDate() {
 // When document is ready, run this stuff:
 $(window).load(function() {
 
+  // set default timezone
+  moment.tz.setDefault('Etc/UTC');
+
   // shorten the date
   if ($('#calendar').length){ shortenDate();}
 
@@ -188,7 +191,7 @@ $(window).load(function() {
 
   // define the calendar
   $('#calendar').datepicker({
-    weekStart: 1,
+    weekStart: 0,
     endDate: moment().utc().format('DD/MM/YYYY'),
     todayHighlight: true,
     todayBtn: "linked"

--- a/share/js/gwsumm.js
+++ b/share/js/gwsumm.js
@@ -176,11 +176,8 @@ function shortenDate() {
 // When document is ready, run this stuff:
 $(window).load(function() {
 
-  // set default timezone
-  moment.tz.setDefault('Etc/UTC');
-
   // shorten the date
-  if ($('#calendar').length){ shortenDate();}
+  if ($('#calendar').length){shortenDate();}
 
   // define inter-IFO links
   var thisbase = document.getElementsByTagName('base')[0].href;
@@ -189,9 +186,23 @@ $(window).load(function() {
     $(this).attr('href', window.location.href.replace(thisbase, newbase));
   });
 
+  // set 'today' location
+  Site.Calendar = function() {
+    $.datepicker._gotoToday = function(id) {
+      var dateformat = findDateFormat();
+      var tday = moment().utc();
+      if (dateformat == 'day') {
+        move_to_date({type: 'changeDate', date: tday});
+      } else if (dateformat == 'month') {
+        move_to_date({type: 'changeMonth', date: tday});
+      } else if (dateformat == 'year') {
+        move_to_date({type: 'changeYear', date: tday});
+      }
+    };
+  };
+
   // define the calendar
   $('#calendar').datepicker({
-    weekStart: 0,
     endDate: moment().utc().format('DD/MM/YYYY'),
     todayHighlight: true,
     todayBtn: "linked"


### PR DESCRIPTION
This PR attempts to set links constructed with bootstrap-datepicker, particularly the `Today` link at the bottom of the calendar, to use UTC rather than the local timezone of the browser. This is to avoid browser-side issues for users in timezones east of London, who currently see links to a nonexistent page for at least one hour each day.

This PR also sets the calendar to begin on Sunday rather than Monday.

Example output is available [**here**](https://ldas-jobs.ligo.caltech.edu/~alexander.urban/summary/testing/day/20190902/).

cc @duncanmmacleod 