### PR TITLE
Optimize KAGRA ADC frametypes

### DIFF
--- a/gwsumm/data/timeseries.py
+++ b/gwsumm/data/timeseries.py
@@ -87,7 +87,7 @@ FRAMETYPE_REGEX = {
 }
 
 # list of GWF frametypes that contain only ADC channels
-#     allows big memory/time savings when reading with frameCPP
+# (allows big memory/time savings when reading with frameCPP)
 try:
     GWF_API = get_default_gwf_api()
 except ImportError:
@@ -99,6 +99,7 @@ ADC_TYPES = {
     'T', 'M',  # old LIGO trend types
     'H1_R', 'H1_C', 'L1_R', 'L1_C',  # new LIGO raw and commissioning types
     'H1_T', 'H1_M', 'L1_T', 'L1_M',  # new LIGO trend types
+    'K1_R', 'K1_C', 'K1_T', 'K1_M',  # KAGRA commissioning and trend types
     'raw',  # Virgo raw type
 }
 

--- a/gwsumm/tabs/guardian.py
+++ b/gwsumm/tabs/guardian.py
@@ -308,6 +308,8 @@ class GuardianTab(DataTab):
                 localzone = tz.gettz('America/Los_Angeles')
             elif self.ifo in ['L1']:
                 localzone = tz.gettz('America/Chicago')
+            elif self.ifo in ['K1']:
+                localzone = tz.gettz('Asia/Tokyo')
             else:
                 localzone = tz.gettz('Europe/Berlin')
             for t, from_, to_ in self.transitions[bit]:

--- a/gwsumm/tabs/sei.py
+++ b/gwsumm/tabs/sei.py
@@ -346,6 +346,8 @@ class SEIWatchDogTab(base):
             localzone = tz.gettz('America/Los_Angeles')
         elif self.ifo in ['L1']:
             localzone = tz.gettz('America/Chicago')
+        elif self.ifo in ['K1']:
+            localzone = tz.gettz('Asia/Tokyo')
         else:
             localzone = tz.gettz('Europe/Berlin')
         headers = ['GPS time', 'UTC time', 'Local time', 'Chamber', 'Trigger',


### PR DESCRIPTION
This PR explicitly optimizes over KAGRA ADC frametypes (commissioning, raw, and trends), similar to those for H1 and L1. It also includes support for KAGRA's local timezone when displaying Guardian state transition tables and SEI watchdog trips.

cc @duncanmmacleod 