### PR TITLE
Discover frametype dynamically if passed a cache file

### DIFF
--- a/gwsumm/data/timeseries.py
+++ b/gwsumm/data/timeseries.py
@@ -476,7 +476,7 @@ def get_timeseries_dict(channels, segments, config=GWSummConfigParser(),
                 channel = get_channel(channel)
                 ifo = channel.ifo
                 ftype = (None if cache and not channel.frametype
-                        else find_frame_type(channel))
+                         else find_frame_type(channel))
                 id_ = (ifo, ftype)
                 if id_ in frametypes:
                     frametypes[id_].append(channel)

--- a/gwsumm/data/timeseries.py
+++ b/gwsumm/data/timeseries.py
@@ -465,7 +465,7 @@ def get_timeseries_dict(channels, segments, config=GWSummConfigParser(),
     """
     # separate channels by type
     if query:
-        if frametype is not None or cache is not None:
+        if frametype is not None:
             frametypes = {(None, frametype): channels}
         else:
             frametypes = dict()

--- a/gwsumm/data/timeseries.py
+++ b/gwsumm/data/timeseries.py
@@ -475,7 +475,8 @@ def get_timeseries_dict(channels, segments, config=GWSummConfigParser(),
             for channel in allchannels:
                 channel = get_channel(channel)
                 ifo = channel.ifo
-                ftype = find_frame_type(channel)
+                ftype = (None if cache and not channel.frametype
+                        else find_frame_type(channel))
                 id_ = (ifo, ftype)
                 if id_ in frametypes:
                     frametypes[id_].append(channel)


### PR DESCRIPTION
In the current code, when a cache file is passed to `get_timeseries_dict`, it assigns the frametype of the first channel to all channels listed in the config (in the `frametypes` dict on `L469`) and attempts to read all channels from this frametype. This causes failures when a cache file contains frames of more than one type. After this change, users can define frametypes for several channels in a config file and they will all be read from frames correctly. If frametypes are not provided in the config, the standard process for guessing a frametype will commence.

Tested this with a cache file that contains several frametypes: https://ldas-jobs.ligo.caltech.edu/~thomas.massinger/detchar/nonsens-review/summary/C01/day/20190418/compare_strain/

And tested on a config that reads directly from frames without a cache file: https://ldas-jobs.ligo.caltech.edu/~thomas.massinger/summary/h1-lomon-frame-test/1253577618-1253580618/isc/asc_local_oscillators/