### PR TITLE
Implement acorn checks for GWSumm JavaScript

### DIFF
--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -1,0 +1,18 @@
+extends:
+  - stylelint-config-sass-guidelines
+
+rules:
+  indentation:
+    - tab
+  max-nesting-depth:
+    - 4
+  number-leading-zero:
+    - null
+  number-no-trailing-zeros:
+    - null
+  property-no-vendor-prefix:
+    - null
+  selector-max-compound-selectors:
+    - 5
+  selector-max-id:
+    - 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
   - python -m coverage run --append $(which gwsumm-plot-triggers) --help
   - python -m coverage run --append $(which gwsumm-plot-guardian) --help
   # test minified javascript
-  - acorn --silent gwsumm/_static/gwsumm.min.js
+  - acorn --silent share/js/gwsumm.js
 
 after_success:
   - python -m pip install ${PIP_FLAGS} codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
 before_install:
   - python -m pip install --upgrade pip
   - python -m pip install ${PIP_FLAGS} -r requirements.txt
+  - npm -g install acorn
 
 install:
   # note: need --editable for executable coverage with `which ...` to work
@@ -34,6 +35,8 @@ script:
   - python -m coverage run --append $(which gw_summary_pipe) --help
   - python -m coverage run --append $(which gwsumm-plot-triggers) --help
   - python -m coverage run --append $(which gwsumm-plot-guardian) --help
+  # test minified javascript
+  - acorn --silent gwsumm/_static/gwsumm.min.js
 
 after_success:
   - python -m pip install ${PIP_FLAGS} codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 before_install:
   - python -m pip install --upgrade pip
   - python -m pip install ${PIP_FLAGS} -r requirements.txt
-  - npm -g install acorn csslint
+  - npm -g install acorn stylelint stylelint-config-sass-guidelines
 
 install:
   # note: need --editable for executable coverage with `which ...` to work
@@ -36,7 +36,7 @@ script:
   - python -m coverage run --append $(which gwsumm-plot-triggers) --help
   - python -m coverage run --append $(which gwsumm-plot-guardian) --help
   # test CSS and JavaScript
-  - csslint share/sass/gwsumm.scss
+  - stylelint share/sass/gwsumm.scss
   - acorn --silent share/js/gwsumm.js
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 before_install:
   - python -m pip install --upgrade pip
   - python -m pip install ${PIP_FLAGS} -r requirements.txt
-  - npm -g install acorn
+  - npm -g install acorn csslint
 
 install:
   # note: need --editable for executable coverage with `which ...` to work
@@ -35,7 +35,8 @@ script:
   - python -m coverage run --append $(which gw_summary_pipe) --help
   - python -m coverage run --append $(which gwsumm-plot-triggers) --help
   - python -m coverage run --append $(which gwsumm-plot-guardian) --help
-  # test minified javascript
+  # test CSS and JavaScript
+  - csslint share/sass/gwsumm.scss
   - acorn --silent share/js/gwsumm.js
 
 after_success:

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,9 @@ install_requires = [
 if {'pytest', 'test'}.intersection(sys.argv):
     setup_requires.append('pytest_runner')  # python setup.py test
 tests_require = [
-    'pytest>=2.8'
+    'pytest>=2.8,<3.7',
+    'pytest-cov',
+    'flake8',
 ]
 if sys.version < '3':
     tests_require.append('mock')

--- a/share/sass/gwsumm.scss
+++ b/share/sass/gwsumm.scss
@@ -3,128 +3,131 @@
  */
 
 body {
-		background-color: #eee;
+	background-color: #eee;
 }
 
 dialog {
-		top: 50%;
-		-ms-transform: translateY(-50%);
-		transform: translateY(-50%);
-		min-width: 60%;
-		max-width: 80%;
-		max-height: 80%;
-		overflow-y: scroll;
-		position: fixed;
-		border-radius: 6px;
-		background-color: white;
-		border: 1px solid rgba(0, 0, 0, 0.3);
-		box-shadow:0 3px 7px rgba(0, 0, 0, 0.8);
+	background-color: #fff;
+	border: 1px solid rgba(0, 0, 0, 0.3);
+	border-radius: 6px;
+	box-shadow: 0 3px 7px rgba(0, 0, 0, 0.8);
+	max-height: 80%;
+	max-width: 80%;
+	min-width: 60%;
+	overflow-y: scroll;
+	position: fixed;
+	top: 50%;
+	-ms-transform: translateY(-50%);
+	transform: translateY(-50%);
 }
 
 // native dialog
 dialog::backdrop {
-		position: fixed;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		background-color: rgba(0, 0, 0, 0.6);
+	background-color: rgba(0, 0, 0, 0.6);
+	bottom: 0;
+	left: 0;
+	position: fixed;
+	right: 0;
+	top: 0;
 }
 
 // polyfill dialog
 dialog+.backdrop {
-		position: fixed;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		background-color: rgba(0, 0, 0, 0.6);
+	background-color: rgba(0, 0, 0, 0.6);
+	bottom: 0;
+	left: 0;
+	position: fixed;
+	right: 0;
+	top: 0;
 }
 
 .footer {
-		height: 148px;
+	height: 148px;
 }
 
 .navbar {
-		.btn-group {
-				margin-bottom: 0px;
-		}
-		// map page to another IFO
-		.base-map {
-				padding-right: 5px;
-				@media (min-width: 768px) {
-						margin-right: 10px;
-				}
-				.dropdown-menu {
-						min-width: 44px;
-						a {
-								padding-left: 12px;
-								cursor: pointer;
-								&:after {
-										display: block;
-										content: attr(title);
-										font-weight: bold;
-										height: 1px;
-										color: transparent;
-										overflow: hidden;
-										visibility: hidden;
-										margin-bottom: -1px;
-								}
-						}
-						@media (min-width: 768px) {
-								margin-left: -15px;
-								min-width: 52px;
-						}
-				}
+	.btn-group {
+		margin-bottom: 0;
+	}
+	// map page to another IFO
+	.base-map {
+		padding-right: 5px;
+		@media (min-width: 768px) {
+			margin-right: 10px;
 		}
 
-		// state switch
-		.state-switch  {
-				.dropdown-header {
-						padding-left: 20px;
-						padding-right: 20px;
-						white-space: normal;;
+		.dropdown-menu {
+			min-width: 44px;
+
+			a {
+				cursor: pointer;
+				padding-left: 12px;
+
+				&::after {
+					color: transparent;
+					content: attr(title);
+					display: block;
+					font-weight: bold;
+					height: 1px;
+					margin-bottom: -1px;
+					overflow: hidden;
+					visibility: hidden;
 				}
-				@media (min-width: 768px) {
-						position: absolute;
-						right: 0;
-				}
+			}
+			@media (min-width: 768px) {
+				margin-left: -15px;
+				min-width: 52px;
+			}
 		}
+	}
+
+	// state switch
+	.state-switch {
+		.dropdown-header {
+			padding-left: 20px;
+			padding-right: 20px;
+			white-space: normal;;
+		}
+		@media (min-width: 768px) {
+			position: absolute;
+			right: 0;
+		}
+	}
 }
 
 // detchar stuff
 #idq img,
 #upv img {
-		width: auto;
+	width: auto;
 }
 
 #upv font {
-		color: black;
+	color: #000;
 }
 
 #idq > h1:first-of-type,
 #idq > hr:first-of-type,
 #idq > p:first-of-type {
-		display: none;
+	display: none;
 }
 
 #stamp-pem .fancybox-iframe {
-		width: 1800px;
-		height: 1000px;
-		zoom: 1.00;
-		-moz-transform: scale(0.55);
-		-moz-transform-origin: 0 0;
-		-o-transform: scale(0.55);
-		-o-transform-origin: 0 0;
-		-webkit-transform: scale(0.55);
-		-webkit-transform-origin: 0 0;
+	height: 1000px;
+	-moz-transform: scale(0.55);
+	-o-transform: scale(0.55);
+	-webkit-transform: scale(0.55);
+	-moz-transform-origin: 0 0;
+	-o-transform-origin: 0 0;
+	-webkit-transform-origin: 0 0;
+	width: 1800px;
+	zoom: 1.00;
 }
 
 // help button
 #help-btn {
-		@media(min-width:992px) {
-				bottom: 80px;
-				padding-left: 16px;
-				padding-right: 16px;
-		}
+	@media(min-width:992px) {
+		bottom: 80px;
+		padding-left: 16px;
+		padding-right: 16px;
+	}
 }


### PR DESCRIPTION
This PR implements an additional build-and-test phase for JavaScript elements using `acorn`, and for CSS elements using `stylelint` and standard SASS guidelines. The `gwsumm.scss` source file is corrected for a number of linting complaints.

This also explicitly requires `flake8` and `pytest-cov` from the `setup.py` script.

cc @duncanmmacleod 