### PR TITLE
Upgrade to jQuery-3.4.1

### DIFF
--- a/gwsumm/html/static.py
+++ b/gwsumm/html/static.py
@@ -43,7 +43,7 @@ CSS = OrderedDict((
 
 # build collection of javascript resources
 JS = OrderedDict((
-    ('jquery', 'https://code.jquery.com/jquery-2.2.4.min.js'),
+    ('jquery', 'https://code.jquery.com/jquery-3.4.1.min.js'),
     ('jquery-ui', 'https://code.jquery.com/ui/1.12.1/jquery-ui.min.js'),
     ('moment', 'https://cdnjs.cloudflare.com/ajax/libs/'
                'moment.js/2.24.0/moment.min.js'),

--- a/gwsumm/html/tests/test_static.py
+++ b/gwsumm/html/tests/test_static.py
@@ -62,7 +62,7 @@ def test_get_js():
     # test list of files
     js_files = list(x.split('/')[-1] for x in js.values())
     assert js_files == [
-        'jquery-2.2.4.min.js',
+        'jquery-3.4.1.min.js',
         'jquery-ui.min.js',
         'moment.min.js',
         'bootstrap.min.js',


### PR DESCRIPTION
This PR upgrades the jQuery dependence to 3.4.1, as the jQuery 3.x series patches some (minor) security vulnerabilities.