### PR TITLE
Take advantage of event listeners in gwbootstrap

### DIFF
--- a/gwsumm/html/bootstrap.py
+++ b/gwsumm/html/bootstrap.py
@@ -101,8 +101,7 @@ def calendar(date, tag='a', class_='navbar-brand dropdown-toggle',
     datestring = date.strftime(dateformat).replace(' 0', ' ')
     data_date = date.strftime('%d-%m-%Y')
     page = markup.page()
-    page.a('&laquo;', class_='navbar-brand step-back', title='Step back',
-           onclick='stepDate(-1)')
+    page.a('&laquo;', class_='navbar-brand step-back', title='Step back')
     page.a(id_=id_, class_=class_, title='Show/hide calendar',
            **{'data-date': data_date, 'data-date-format': 'dd-mm-yyyy',
               'data-viewmode': '%ss' % mode.name})
@@ -110,7 +109,7 @@ def calendar(date, tag='a', class_='navbar-brand dropdown-toggle',
     page.b('', class_='caret')
     page.a.close()
     page.a('&raquo;', class_='navbar-brand step-forward',
-           title='Step forwards', onclick='stepDate(1)')
+           title='Step forwards')
     return page
 
 

--- a/gwsumm/html/tests/test_bootstrap.py
+++ b/gwsumm/html/tests/test_bootstrap.py
@@ -30,12 +30,12 @@ from .. import bootstrap
 
 # global variables
 DATE = datetime.strptime('20140410', '%Y%m%d')
-CALENDAR = """<a class="navbar-brand step-back" title="Step back" onclick="stepDate(-1)">&laquo;</a>
+CALENDAR = """<a class="navbar-brand step-back" title="Step back">&laquo;</a>
 <a id="calendar" class="navbar-brand dropdown-toggle" title="Show/hide calendar" data-date="10-04-2014" data-date-format="dd-mm-yyyy" data-viewmode="{}">
 {}
 <b class="caret"></b>
 </a>
-<a class="navbar-brand step-forward" title="Step forwards" onclick="stepDate(1)">&raquo;</a>"""  # noqa: E501
+<a class="navbar-brand step-forward" title="Step forwards">&raquo;</a>"""  # noqa: E501
 
 
 # test utilities

--- a/gwsumm/tabs/gracedb.py
+++ b/gwsumm/tabs/gracedb.py
@@ -233,8 +233,7 @@ class GraceDbTab(get_tab('default')):
         else:
             page.button(
                 'Export to CSV', class_='btn btn-default btn-table',
-                onclick="exportTableToCSV('{name}.csv', '{name}')".format(
-                    name='gracedb'))
+                **{'data-table-id': 'gracedb', 'data-filename': 'gracedb.csv'})
         page.div.close()  # scaffold well
 
         # query doc

--- a/gwsumm/tabs/guardian.py
+++ b/gwsumm/tabs/guardian.py
@@ -275,8 +275,7 @@ class GuardianTab(DataTab):
         page.table.close()
         page.button(
             'Export to CSV', class_='btn btn-default btn-table',
-            onclick="exportTableToCSV('{name}.csv', '{name}')".format(
-                name=id_))
+            **{'data-table-id': id_, 'data-filename': '%s.csv' % id_})
         page.div.close()
         page.div.close()
 

--- a/gwsumm/tabs/sei.py
+++ b/gwsumm/tabs/sei.py
@@ -315,8 +315,7 @@ class SEIWatchDogTab(base):
         page.table.close()
         page.button(
             'Export to CSV', class_='btn btn-default btn-table',
-            onclick="exportTableToCSV('{name}.csv', '{name}')".format(
-                name=id_))
+            **{'data-table-id': id_, 'data-filename': '%s.csv' % id_})
         page.div.close()
 
         # build trip groups


### PR DESCRIPTION
This PR takes advantage of a couple new event listeners added to `gwbootstrap` for button click actions, including for table-to-CSV conversion and the return-to-top button.

See also gwdetchar/gwbootstrap#9.

cc @duncanmmacleod