### PR TITLE
Copy over minified files, rather than building them

### DIFF
--- a/gwsumm/tabs/builtin.py
+++ b/gwsumm/tabs/builtin.py
@@ -455,6 +455,7 @@ class PlotTab(Tab):
         k = i = 0
         fbkw.setdefault('rel', 'fancybox')
         fbkw.setdefault('target', '_blank')
+        fbkw.setdefault('data-fancybox', 'gallery')
         fbkw.setdefault('data-fancybox-group', 'images')
 
         for j, plot in enumerate(plots):

--- a/setup.py
+++ b/setup.py
@@ -138,12 +138,12 @@ class BuildHtmlFiles(Command):
         return self.staticdir.replace(os.path.sep, '.')
 
     def build_utils(self):
-         log.info('copying minified elements')
-         for file_ in SOURCE_FILES:
-             filename = os.path.basename(file_)
-             target = os.path.join(self.staticdir, filename)
-             copyfile(file_, target)
-             log.info('minified CSS and JS written to %s' % target)
+        log.info('copying minified elements')
+        for file_ in SOURCE_FILES:
+            filename = os.path.basename(file_)
+            target = os.path.join(self.staticdir, filename)
+            copyfile(file_, target)
+            log.info('minified CSS and JS written to %s' % target)
 
     def run(self):
         self.build_utils()


### PR DESCRIPTION
This PR tweaks `setup.py` to copy over minified files from gwbootstrap, rather than building them directly. It also adds an extra identifier to figures rendered with fancybox:

```html
<a class="fancybox" data-fancybox="gallery" ...>
```

This ensures such figures will have a thumbnail view with flickable album of photos per page.