### PR TITLE
Prefer content delivery over local submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "gwbootstrap"]
-	path = gwbootstrap
-	url = https://github.com/gwdetchar/gwbootstrap

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,4 @@
 include LICENSE README.rst MANIFEST.in
-include ez_setup.py
-include versioneer.py
+include versioneer.py setup.py
 include gwsumm/_version.py
-recursive-include gwsumm/html/static *.min.css *.min.js
 recursive-include share *.ini

--- a/gwsumm/html/static.py
+++ b/gwsumm/html/static.py
@@ -37,8 +37,8 @@ CSS = OrderedDict((
                      'font-awesome/5.10.2/css/fontawesome.min.css'),
     ('font-awesome-solid', 'https://cdnjs.cloudflare.com/ajax/libs/'
                            'font-awesome/5.10.2/css/solid.min.css'),
-    ('gwbootstrap', resource_filename(
-        'gwsumm', os.path.join(STATICDIR, 'gwbootstrap.min.css'))),
+    ('gwbootstrap', 'https://cdn.jsdelivr.net/npm/gwbootstrap@1.1.1/'
+                    'lib/gwbootstrap.min.css'),
 ))
 
 # build collection of javascript resources
@@ -54,8 +54,8 @@ JS = OrderedDict((
     ('datepicker', 'https://cdnjs.cloudflare.com/ajax/libs/'
                    'bootstrap-datepicker/1.9.0/js/'
                    'bootstrap-datepicker.min.js'),
-    ('gwbootstrap', resource_filename(
-        'gwsumm', os.path.join(STATICDIR, 'gwbootstrap-extra.min.js')))
+    ('gwbootstrap', 'https://cdn.jsdelivr.net/npm/gwbootstrap@1.1.1/'
+                    'lib/gwbootstrap-extra.min.js'),
 ))
 
 

--- a/gwsumm/html/static.py
+++ b/gwsumm/html/static.py
@@ -21,9 +21,7 @@
 This module mainly declares the resources used by standard on HTML pages
 """
 
-import os.path
 from collections import OrderedDict
-from pkg_resources import resource_filename
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Alex Urban <alexander.urban@ligo.org>'

--- a/gwsumm/html/tests/test_bootstrap.py
+++ b/gwsumm/html/tests/test_bootstrap.py
@@ -101,7 +101,7 @@ def test_base_map_dropdown():
     menu_wbases = bootstrap.base_map_dropdown('test', bases={'key': 'value'})
     assert parse_html(str(menu_wbases)) == parse_html(
         '<div class="dropdown base-map">\n<a href="#" class="navbar-brand '
-        'nav-link border border-white rounded dropdown-toggle" data-toggle='
-        '"dropdown">\ntest\n<b class="caret"></b>\n</a>\n<ul class="dropdown-'
-        'menu">\n<li>\n<a title="key" class="dropdown-item" data-new-base='
-        '"value">key</a>\n</li>\n</ul>\n</div>')
+        'nav-link border border-white rounded dropdown-toggle" role="button" '
+        'data-toggle="dropdown">test</a>\n<div class="dropdown-menu '
+        'dropdown-1-col shadow">\n<a title="key" class="dropdown-item" '
+        'data-new-base="value">key</a>\n</div>\n</div>')

--- a/gwsumm/tests/test_archive.py
+++ b/gwsumm/tests/test_archive.py
@@ -117,7 +117,7 @@ def test_archive_load_table():
     empty = EventTable(names=['a', 'b'])
     try:
         fname = tempfile.mktemp(suffix='.h5', prefix='gwsumm-tests-')
-        h5file = h5py.File(fname, mode='r')
+        h5file = h5py.File(fname, mode='a')
         # check table gets archived and read transparently
         archive.archive_table(t, 'test-table', h5file)
         t2 = archive.load_table(h5file['test-table'])

--- a/gwsumm/tests/test_archive.py
+++ b/gwsumm/tests/test_archive.py
@@ -117,7 +117,7 @@ def test_archive_load_table():
     empty = EventTable(names=['a', 'b'])
     try:
         fname = tempfile.mktemp(suffix='.h5', prefix='gwsumm-tests-')
-        h5file = h5py.File(fname)
+        h5file = h5py.File(fname, mode='r')
         # check table gets archived and read transparently
         archive.archive_table(t, 'test-table', h5file)
         t2 = archive.load_table(h5file['test-table'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 # build requirements
 setuptools
-libsass
-jsmin
 
 # core requirements
 python-dateutil
@@ -18,7 +16,7 @@ ligo-segments
 pygments
 MarkupPy
 markdown
-gwdetchar>=0.5.1
+gwdetchar>=1.0.0
 gwpy>=1.0.0
 configparser ; python_version < '3.6'
 
@@ -31,4 +29,5 @@ ligo-gracedb>=2.0.0
 # testing extras
 pytest>=2.8,<3.7
 pytest-cov
+coverage
 flake8

--- a/setup.py
+++ b/setup.py
@@ -23,12 +23,8 @@
 import sys
 import glob
 import os
-from distutils import log
-from shutil import copyfile
 
-from setuptools import (Command, setup, find_packages)
-from setuptools.command.egg_info import egg_info
-from setuptools.command.build_py import build_py
+from setuptools import (setup, find_packages)
 
 # set basic metadata
 PACKAGENAME = 'gwsumm'
@@ -74,7 +70,7 @@ install_requires = [
     'pygments',
     'MarkupPy',
     'markdown',
-    'gwdetchar>=0.5.1',
+    'gwdetchar>=1.0.0',
     'configparser ; python_version < \'3.6\'',
 ]
 
@@ -84,6 +80,7 @@ setup_requires = ['pytest_runner'] if {
 tests_require = [
     'pytest>=2.8,<3.7',
     'pytest-cov',
+    'coverage',
     'flake8',
 ]
 if sys.version < '3':
@@ -101,85 +98,6 @@ extras_require = {
 
 # -- data files ---------------------------------------------------------------
 
-SOURCE_FILES = [
-     os.path.join('gwbootstrap', 'lib', 'gwbootstrap.min.css'),
-     os.path.join('gwbootstrap', 'lib', 'gwbootstrap-extra.min.js'),
-]
-
-if not SOURCE_FILES:  # make sure submodule is not empty
-    raise ValueError('gwbootstrap submodule is empty, please populate it '
-                     'with `git submodule update --init`')
-
-
-class BuildHtmlFiles(Command):
-    """Grab compiled CSS and minified JavaScript
-    """
-    description = 'Grab compiled CSS and minified JS'
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    @property
-    def staticdir(self):
-        try:
-            return self._static
-        except AttributeError:
-            self._static = os.path.join(PACKAGENAME, 'html', 'static')
-            if not os.path.isdir(self._static):
-                os.makedirs(self._static)
-                log.info('created static dir in %s' % self._static)
-        return self._static
-
-    @property
-    def staticpackage(self):
-        return self.staticdir.replace(os.path.sep, '.')
-
-    def build_utils(self):
-        log.info('copying minified elements')
-        for file_ in SOURCE_FILES:
-            filename = os.path.basename(file_)
-            target = os.path.join(self.staticdir, filename)
-            copyfile(file_, target)
-            log.info('minified CSS and JS written to %s' % target)
-
-    def run(self):
-        self.build_utils()
-        if self.staticpackage not in self.distribution.packages:
-            self.distribution.packages.append(self.staticpackage)
-            log.info("added %s to package list" % self.staticpackage)
-
-
-cmdclass['build_html_files'] = BuildHtmlFiles
-
-old_build_py = cmdclass.pop('build_py', build_py)
-
-
-class BuildPyWithHtmlFiles(old_build_py):
-    """Custom build_py that grabs compiled CSS+JS sources as well
-    """
-    def run(self):
-        self.run_command('build_html_files')
-        old_build_py.run(self)
-
-
-cmdclass['build_py'] = BuildPyWithHtmlFiles
-
-old_egg_info = cmdclass.pop('egg_info', egg_info)
-
-
-class EggInfoWithHtmlFiles(old_egg_info):
-    """Custom egg_info that grabs compiled CSS+JS sources as well
-    """
-    def run(self):
-        self.run_command('build_html_files')
-        old_egg_info.run(self)
-
-
-cmdclass['egg_info'] = EggInfoWithHtmlFiles
-
 # configuration files
 data_files = [
     (os.path.join('etc', PACKAGENAME, 'configuration'),
@@ -195,43 +113,44 @@ scripts = glob.glob(os.path.join('bin', '*'))
 with open('README.rst', 'rb') as f:
     longdesc = f.read().decode().strip()
 
-setup(name=DISTNAME,
-      provides=[PACKAGENAME],
-      version=__version__,
-      description=("A python toolbox used by the LIGO Scientific "
-                   "Collaboration for detector characterisation"),
-      long_description=longdesc,
-      author=AUTHOR,
-      author_email=AUTHOR_EMAIL,
-      license=LICENSE,
-      url='https://github.com/gwpy/gwsumm',
-      packages=packagenames,
-      include_package_data=True,
-      cmdclass=cmdclass,
-      scripts=scripts,
-      setup_requires=setup_requires,
-      install_requires=install_requires,
-      tests_require=tests_require,
-      extras_require=extras_require,
-      data_files=data_files,
-      use_2to3=False,
-      classifiers=[
-          'Programming Language :: Python',
-          'Development Status :: 3 - Alpha',
-          'Programming Language :: Python',
-          'Programming Language :: Python :: 3.5',
-          'Programming Language :: Python :: 3.6',
-          'Programming Language :: Python :: 3.7',
-          'Intended Audience :: Science/Research',
-          'Intended Audience :: End Users/Desktop',
-          'Intended Audience :: Developers',
-          'Natural Language :: English',
-          'Topic :: Scientific/Engineering',
-          'Topic :: Scientific/Engineering :: Astronomy',
-          'Topic :: Scientific/Engineering :: Physics',
-          'Operating System :: POSIX',
-          'Operating System :: Unix',
-          'Operating System :: MacOS',
-          'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-      ],
-      )
+setup(
+    name=DISTNAME,
+    provides=[PACKAGENAME],
+    version=__version__,
+    description=("A python toolbox used by the LIGO Scientific "
+                 "Collaboration for detector characterisation"),
+    long_description=longdesc,
+    author=AUTHOR,
+    author_email=AUTHOR_EMAIL,
+    license=LICENSE,
+    url='https://github.com/gwpy/gwsumm',
+    packages=packagenames,
+    include_package_data=True,
+    cmdclass=cmdclass,
+    scripts=scripts,
+    setup_requires=setup_requires,
+    install_requires=install_requires,
+    tests_require=tests_require,
+    extras_require=extras_require,
+    data_files=data_files,
+    use_2to3=False,
+    classifiers=[
+        'Programming Language :: Python',
+        'Development Status :: 3 - Alpha',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Intended Audience :: Science/Research',
+        'Intended Audience :: End Users/Desktop',
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'Topic :: Scientific/Engineering',
+        'Topic :: Scientific/Engineering :: Astronomy',
+        'Topic :: Scientific/Engineering :: Physics',
+        'Operating System :: POSIX',
+        'Operating System :: Unix',
+        'Operating System :: MacOS',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+    ],
+)


### PR DESCRIPTION
This PR removes `gwbootstrap` as a submodule, drops custom setup modules for compiling CSS and JS, and grabs `gwbootstrap` over the content delivery network [`jsDelivr`](https://www.jsdelivr.com/package/npm/gwbootstrap?path=lib). It also bumps the `gwdetchar` version requirement to 1.0.0.

cc @duncanmmacleod 