### PR TITLE
Require numpy 1.16 for consistency with astropy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ setuptools
 # core requirements
 python-dateutil
 lxml
-numpy>=1.10
+numpy>=1.16
 scipy>=1.2.0
 matplotlib>=2.0
 astropy>=1.2.1

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ else:
 install_requires = [
     'python-dateutil',
     'lxml',
-    'numpy>=1.10',
+    'numpy>=1.16',
     'scipy>=1.2.0',
     'matplotlib>=2.2.0',
     'astropy>=1.2.1',


### PR DESCRIPTION
This PR simply bumps the minimum supported numpy version to 1.16 in order to be consistent with astropy.

cc @duncanmmacleod 