### PR TITLE
Use text-justify class on bootstrap alert boxes

### DIFF
--- a/gwsumm/html/html5.py
+++ b/gwsumm/html/html5.py
@@ -116,7 +116,7 @@ def load(url, id_='main', error=False, success=None):
         if not isinstance(error, (str, markup.page)):
             error = 'Failed to load content from %r' % url
         error = ('jQuery("#%s").html("<div class=\'alert alert-warning '
-                 'shadow-sm\'><p>%s</p></div>");' % (id_, error))
+                 'text-justify shadow-sm\'><p>%s</p></div>");' % (id_, error))
     if success is None:
         success = 'jQuery("#%s").html(data);' % id_
     url = _expand_path(url)

--- a/gwsumm/html/tests/test_html5.py
+++ b/gwsumm/html/tests/test_html5.py
@@ -120,7 +120,7 @@ def test_load():
     success = 'jQuery(\"#main\").html(data);'
     error = 'Failed to load content from %r' % URL
     errormsg = ('jQuery(\"#main\").html(\"<div class=\'alert alert-warning '
-                'shadow-sm\'><p>%s</p></div>\");' % error)
+                'text-justify shadow-sm\'><p>%s</p></div>\");' % error)
     content = html5.load(URL, error=1)
     assert parse_html(content) == parse_html(LOAD % (URL, success, errormsg))
 
@@ -129,7 +129,7 @@ def test_load_custom():
     error = 'Error'
     success = 'document.write(\"Success\")'
     errormsg = ('jQuery(\"#main\").html(\"<div class=\'alert alert-warning '
-                'shadow-sm\'><p>%s</p></div>\");' % error)
+                'text-justify shadow-sm\'><p>%s</p></div>\");' % error)
     # test local url
     content = html5.load('test', success=success, error=error)
     assert parse_html(content) == parse_html(

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -642,16 +642,23 @@ class DataTab(ProcessedTab, ParentTab):
     def write_state_placeholder(self, state):
         """Write a placeholder '#main' content for this tab
         """
-        email = markup.oneliner.a('the DetChar group',
-                                  class_='alert-link',
-                                  href='mailto:detchar+code@ligo.org')
+        def bootstrap_context(sname):
+            ifos = re.findall('[A-Z]1', sname, flags=re.IGNORECASE)
+            return (ifos[0].lower() if len(ifos) == 1 else 'network')
+
+        email = markup.oneliner.a(
+            'the DetChar group', class_='alert-link',
+            href='mailto:detchar+code@ligo.org')
         page = markup.page()
         page.div(class_='row')
         page.div(class_='col-md-12')
         page.add(gwhtml.alert((
-            "These data have not been generated yet, please check back later.",
-            "If this state persists for more than three or four hours, "
-            "please contact %s." % email), dismiss=False))
+            ('Data have not been generated yet, please check back later.',
+             'If this state persists for more than three or four hours, '
+             'please contact %s.' % email),
+            context=bootstrap_context(state.name),
+            dismiss=False,
+        ))
         page.div.close()
         page.div.close()
 

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -652,7 +652,7 @@ class DataTab(ProcessedTab, ParentTab):
         page = markup.page()
         page.div(class_='row')
         page.div(class_='col-md-12')
-        page.add(gwhtml.alert((
+        page.add(gwhtml.alert(
             ('Data have not been generated yet, please check back later.',
              'If this state persists for more than three or four hours, '
              'please contact %s.' % email),

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -642,10 +642,6 @@ class DataTab(ProcessedTab, ParentTab):
     def write_state_placeholder(self, state):
         """Write a placeholder '#main' content for this tab
         """
-        def bootstrap_context(sname):
-            ifos = re.findall('[A-Z]1', sname, flags=re.IGNORECASE)
-            return (ifos[0].lower() if len(ifos) == 1 else 'network')
-
         email = markup.oneliner.a(
             'the DetChar group', class_='alert-link',
             href='mailto:detchar+code@ligo.org')
@@ -656,7 +652,6 @@ class DataTab(ProcessedTab, ParentTab):
             ('Data have not been generated yet, please check back later.',
              'If this state persists for more than three or four hours, '
              'please contact %s.' % email),
-            context=bootstrap_context(state.name),
             dismiss=False,
         ))
         page.div.close()

--- a/gwsumm/tabs/guardian.py
+++ b/gwsumm/tabs/guardian.py
@@ -228,25 +228,28 @@ class GuardianTab(DataTab):
         """Write the HTML for the given state of this `GuardianTab`
         """
         page = self.scaffold_plots(state=state)
+
+        page.div(class_='row')
+        page.div(class_='col-md-12')
+        page.h2('%s state transitions' % self.node, class_='mt-4 mb-4')
         page.add(html.alert(  # add dismissable alert
             'For all of the following data, "Unknown" simply labels any '
             'state in this node that was not chosen for display, and does '
             'not mean that the state was unrecognised by the Guardian '
             'system. Transitions from an "Unkown" state are not listed in '
-            'the below table, but are included in the totals.'))
-
-        page.div(class_='row')
-        page.div(class_='col-md-12')
+            'the table below, but are included in the totals.'),
+            context=self.ifo.lower())
 
         # draw table
-        page.h2('%s state transitions' % self.node, class_='mt-4 mb-4')
         id_ = '{}-state-transitions'.format(self.ifo.lower())
-        page.table(class_='table table-sm table-hover transitions', id_=id_)
-        page.caption("Transitions into each state (row) from each other "
-                     "state (column). Only those states named in the "
-                     "configuration are shown, but the 'Total' includes "
-                     "transitions from any and all states. '-' indicates no "
-                     "transitions from that state.")
+        page.table(class_='table table-sm table-hover transitions mt-2',
+                   id_=id_)
+        page.caption('Transitions into each state (row) from each other '
+                     'state (column). Only those states named in the '
+                     'configuration are shown, but the \'Total\' includes '
+                     'transitions from any and all states. A dash '
+                     '(\'&mdash;\') indicates no transitions from '
+                     'the given state.')
         page.thead()
         page.tr()
         for th in ['State'] + list(self.grdstates.values()) + ['Total']:
@@ -260,14 +263,14 @@ class GuardianTab(DataTab):
             page.th(name)
             for j, bit2 in enumerate(self.grdstates):
                 if i == j:
-                    page.td('-', class_='ignore')
+                    page.td('&mdash;', class_='ignore')
                     continue
                 count = len([t for t in self.transitions[bit] if
                              t[1] == bit2])
                 if count:
                     page.td(str(count))
                 else:
-                    page.td('-')
+                    page.td('&mdash;')
             page.th(str(len(self.transitions[bit])))
             page.tr.close()
         page.tbody.close()
@@ -275,8 +278,8 @@ class GuardianTab(DataTab):
         page.button(
             'Export to CSV', class_='btn btn-outline-secondary btn-table mt-2',
             **{'data-table-id': id_, 'data-filename': '%s.csv' % id_})
-        page.div.close()
-        page.div.close()
+        page.div.close()  # col-md-12
+        page.div.close()  # row
 
         # summarise each state
         page.div(class_='row')

--- a/gwsumm/tabs/guardian.py
+++ b/gwsumm/tabs/guardian.py
@@ -237,8 +237,8 @@ class GuardianTab(DataTab):
             'state in this node that was not chosen for display, and does '
             'not mean that the state was unrecognised by the Guardian '
             'system. Transitions from an "Unkown" state are not listed in '
-            'the table below, but are included in the totals.'),
-            context=self.ifo.lower())
+            'the table below, but are included in the totals.',
+            context=self.ifo.lower()))
 
         # draw table
         id_ = '{}-state-transitions'.format(self.ifo.lower())

--- a/gwsumm/tabs/misc.py
+++ b/gwsumm/tabs/misc.py
@@ -65,15 +65,15 @@ class Error404Tab(Tab):
             top = kwargs.get('base', self.path)
         kwargs.setdefault('title', '404: Page not found')
         page = markup.page()
-        page.div(class_='alert alert-danger shadow-sm')
+        page.div(class_='alert alert-danger text-justify shadow-sm')
         page.p()
-        page.strong("The page you are looking for doesn't exist")
+        page.strong("The page you are looking for does not exist.")
         page.p.close()
         page.p("This could be because the times for which you are looking "
-               "were never processed (or haven't even happened yet), or "
-               "because no page exists for the specific data products you "
-               "want. Either way, if you think this is in error, please "
-               "contact <a class=\"alert-link\" "
+               "were never processed (or have not happened yet), or because "
+               "no page exists for the specific data products you want. "
+               "Either way, if you think this is in error, please contact "
+               "<a class=\"alert-link\" "
                "href=\"mailto:detchar+code@ligo.org\">the DetChar group</a>.")
         page.p("Otherwise, you might be interested in one of the following:")
         page.div(style="padding-top: 10px;")
@@ -85,7 +85,7 @@ class Error404Tab(Tab):
         page.a("Take me to the top level", role="button",
                class_="btn btn-lg btn-success", title="Top", href=top)
         page.div.close()
-        page.div.close()
+        page.div.close()  # alert alert-danger
         page.script("""
   function linkUp() {
     var url = window.location.href;


### PR DESCRIPTION
This PR takes advantage of bootstrap-4's `text-justify` class to justify text inside of alert boxes, and of gwbootstrap's new IFO-specific alert boxes.

cc @duncanmmacleod 