### PR TITLE
Bump gwbootstrap to version 1.2.1

### DIFF
--- a/gwsumm/html/static.py
+++ b/gwsumm/html/static.py
@@ -35,7 +35,7 @@ CSS = OrderedDict((
                      'font-awesome/5.11.2/css/fontawesome.min.css'),
     ('font-awesome-solid', 'https://cdnjs.cloudflare.com/ajax/libs/'
                            'font-awesome/5.11.2/css/solid.min.css'),
-    ('gwbootstrap', 'https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.0/'
+    ('gwbootstrap', 'https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.1/'
                     'lib/gwbootstrap.min.css'),
 ))
 
@@ -52,7 +52,7 @@ JS = OrderedDict((
     ('datepicker', 'https://cdnjs.cloudflare.com/ajax/libs/'
                    'bootstrap-datepicker/1.9.0/js/'
                    'bootstrap-datepicker.min.js'),
-    ('gwbootstrap', 'https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.0/'
+    ('gwbootstrap', 'https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.1/'
                     'lib/gwbootstrap-extra.min.js'),
 ))
 


### PR DESCRIPTION
This PR bumps the gwbootstrap version to 1.2.1.

cc @duncanmmacleod