### PR TITLE
Address warnings discovered in production

### DIFF
--- a/bin/gw_summary
+++ b/bin/gw_summary
@@ -60,7 +60,7 @@ use('Agg')  # noqa
 from glue.lal import Cache
 
 from gwpy.segments import (Segment, SegmentList)
-from gwpy.signal.fft import lal as fft_lal
+from gwpy.signal.spectral import _lal as fft_lal
 from gwpy.time import (tconvert, to_gps, Time)
 
 from gwsumm import (

--- a/gwsumm/plot/range.py
+++ b/gwsumm/plot/range.py
@@ -287,10 +287,15 @@ class SimpleTimeVolumeDataPlot(get_plot('segments')):
 
         # set ylabel
         if cumulative:
-            self.pargs.setdefault('ylabel',
-                                  'Cumulative time-volume [Mpc$^3$ kyr]')
+            self.pargs.setdefault(
+                'ylabel',
+                'Cumulative time-volume [Mpc$^3$ kyr]',
+            )
         else:
-            self.pargs.setdefault('ylabel', 'Time-volume [Mpc$^3$ kyr]')
+            self.pargs.setdefault(
+                'ylabel',
+                'Time-volume [Mpc$^3$ kyr]',
+            )
 
         # get data
         allsegs, allranges = ([], [])
@@ -299,7 +304,7 @@ class SimpleTimeVolumeDataPlot(get_plot('segments')):
             if self.state and not self.all_data:
                 valid = self.state.active
                 pad = numpy.nan
-            elif channel.sample_rate:
+            elif channel.sample_rate.value:
                 valid = SegmentList([self.span.protract(
                     1/channel.sample_rate.value)])
             else:

--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -31,7 +31,6 @@ from dateutil.relativedelta import relativedelta
 
 from matplotlib import rcParams
 from matplotlib.artist import setp
-from matplotlib.cbook import iterable
 from matplotlib.colors import (rgb2hex, is_color_like)
 from matplotlib.patches import Rectangle
 
@@ -85,7 +84,7 @@ def common_limits(datasets, default_min=0, default_max=0):
     (min, max) : `float`
         2-tuple of common minimum and maximum over all datasets.
     """
-    if isinstance(datasets, numpy.ndarray) or not iterable(datasets[0]):
+    if isinstance(datasets, numpy.ndarray) or not numpy.iterable(datasets[0]):
         datasets = [datasets]
     max_stat = max(list(iterutils.flatten(datasets)) + [-numpy.inf])
     min_stat = min(list(iterutils.flatten(datasets)) + [numpy.inf])


### PR DESCRIPTION
This PR addresses a collection of warnings discovered in the production LIGO summary pages:

* `gwpy.signal.fft` has been deprecated in favor of `gwpy.signal.spectral`
* `astropy.units.Quantity` objects have an ambiguous truth value, so use their raw numerical value
* `matplotlib.cbook.iterable` has been deprecated, use `numpy.iterable` instead
* Minor reshuffling for a different PEP-8 aesthetic

cc @duncanmmacleod 