### PR TITLE
Remove treename kwarg if not using root format

### DIFF
--- a/gwsumm/triggers.py
+++ b/gwsumm/triggers.py
@@ -202,6 +202,8 @@ def get_triggers(channel, etg, segments, config=GWSummConfigParser(),
             read_kw['ifo'] = get_channel(channel).ifo
         if etg.lower() in ['kw', 'kleinewelle']:
             read_kw['selection'].append('channel == "%s"' % channel)
+        if etg.lower() in ['cwb'] and 'root' not in read_kw['format']:
+            read_kw.pop('treename')
 
         # filter on segments
         if 'timecolumn' in read_kw:


### PR DESCRIPTION
This PR removes the `treename` kwarg from the etg trigger reading arguments when the file format is not root. If this isn't removed, `EventTable.read()` tries to include `treename` when invoking other formats that don't use tree structures (like `ascii`). This kwarg is only set when `etg = 'cwb'`, so the logic I've included should be comprehensive for avoiding formatting errors.