### PR TITLE
Adjust normalization of segment livetime pie charts

### DIFF
--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -1018,6 +1018,7 @@ class SegmentPiePlot(PiePlot, SegmentDataPlot):
 
         # get segments
         data = []
+        alltime = float(abs(self.span))
         for flag in self.flags:
             if self.state and not self.all_data:
                 valid = self.state.active
@@ -1026,10 +1027,11 @@ class SegmentPiePlot(PiePlot, SegmentDataPlot):
             segs = get_segments(flag, validity=valid, query=False,
                                 padding=self.padding).coalesce()
             data.append(float(abs(segs.active)))
-        if future:
-            total = sum(data)
-            alltime = abs(self.span)
-            data.append(alltime-total)
+
+        # handle missing or future data
+        total = sum(data)
+        if future or (total < alltime):
+            data.append(alltime - total)
             if 'labels' in plotargs:
                 plotargs['labels'] = list(plotargs['labels']) + [' ']
             if 'colors' in plotargs:
@@ -1050,14 +1052,13 @@ class SegmentPiePlot(PiePlot, SegmentDataPlot):
         ax.set_title('')
         legth = legendargs.pop('threshold', 0)
         legsort = legendargs.pop('sorted', False)
-        tot = float(sum(data))
         pclabels = []
         for d, label in zip(data, labels):
             if not label or label == ' ':
                 pclabels.append(label)
             else:
                 try:
-                    pc = d/tot * 100
+                    pc = d / alltime * 100
                 except ZeroDivisionError:
                     pc = 0.0
                 pclabels.append(texify(

--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -1029,7 +1029,7 @@ class SegmentPiePlot(PiePlot, SegmentDataPlot):
             data.append(float(abs(segs.active)))
 
         # handle missing or future data
-        total = sum(data)
+        total = float(sum(data))
         if future or (total < alltime):
             data.append(alltime - total)
             if 'labels' in plotargs:
@@ -1058,7 +1058,7 @@ class SegmentPiePlot(PiePlot, SegmentDataPlot):
                 pclabels.append(label)
             else:
                 try:
-                    pc = d / alltime * 100
+                    pc = d / (total if future else alltime) * 100
                 except ZeroDivisionError:
                     pc = 0.0
                 pclabels.append(texify(


### PR DESCRIPTION
This PR fixes a bug in segment livetime pie charts, by normalizing the fractional duty cycle to the total analyzed wall-clock time rather than the sum of all segments. See [**this page**](https://ldas-jobs.ligo.caltech.edu/~detchar/summary/1256655618-1269363618/segments/) (cf. bottom row of plots and "Segment information" table) for an example run in production.

cc @tjma12, @duncanmmacleod 