### PR TITLE
Support Python >= 3.6 with build-and-test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,54 @@
-language: python
+language: minimal
 
-dist: xenial
-
-python:
-  - '3.5'
-  - '3.6'
-  - '3.7'
+os: linux
 
 env:
-  - PIP_FLAGS=""
-  - PIP_FLAGS="--upgrade --pre"
+  global:
+    - COVERAGE_STORAGE="json"
+    - CONDA_PKGS_DIRS="${HOME}/.cache/conda/pkgs"
+
+matrix:
+  fast_finish: true
+
+  include:
+    # conda builds
+    - name: "conda:3.6"
+      env: PYTHON_VERSION="3.6"
+    - name: "conda:3.7"
+      env: PYTHON_VERSION="3.7"
+    - name: "conda:3.8"
+      env: PYTHON_VERSION="3.8"
+    - name: "conda:3.9"
+      env: PYTHON_VERSION="3.9"
 
 before_install:
-  - python -m pip install --upgrade pip
-  - python -m pip install ${PIP_FLAGS} -r requirements.txt
+  - curl -LO https://raw.githubusercontent.com/gwpy/gwpy/master/ci/parse-conda-requirements.py
+  - curl -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+  - bash miniconda.sh -b -p ${HOME}/miniconda
+  - source "${HOME}/miniconda/etc/profile.d/conda.sh"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda config --add channels conda-forge
+  - travis_retry conda update --quiet --yes conda
+  # Useful for debugging any issues with conda
+  - conda info --all
 
 install:
-  # note: need --editable for executable coverage with `which ...` to work
+  # create a conda environment
+  - travis_retry conda create --quiet --yes --name gwsummci python=${PYTHON_VERSION} pip setuptools
+  - travis_retry conda activate gwsummci
+  - travis_retry python ./parse-conda-requirements.py requirements.txt -o conda-reqs.txt
+  - travis_retry conda install --quiet --yes --update-all --name gwsummci --file conda-reqs.txt
+  # clean up
+  - rm -f conda-reqs.txt parse-conda-requirements.py
+  # install this version
+  # note: need --editable for coverage with `which ...` to work
   - python -m pip install --editable .
 
 script:
   # run flake8
-  - python -m flake8 .
-  - python -m flake8 bin/*
+  - python -m flake8 . bin/*
   # run test suite
-  - python -m pytest --pyargs gwsumm --cov gwsumm
+  - python -m pytest --verbose --cov --pyargs gwsumm
   # test executables
   - python -m coverage run --append $(which gw_summary) --help
   - python -m coverage run --append $(which gw_summary) day --help
@@ -36,10 +60,14 @@ script:
   - python -m coverage run --append $(which gwsumm-plot-guardian) --help
 
 after_success:
-  - python -m pip install ${PIP_FLAGS} codecov
-  - python -m codecov --flags $(uname) python${TRAVIS_PYTHON_VERSION/./}
+  - travis_retry conda install --quiet --yes --name gwsummci codecov
+  - python -m coverage report
+  - python -m codecov --flags $(uname) python${PYTHON_VERSION/./}
 
+before_cache:
+  - travis_retry conda clean --quiet --yes --all
+  - rm -f $HOME/.cache/pip/log/debug.log
 cache:
   pip: true
-before_cache:
-  - rm -f $HOME/.cache/pip/log/debug.log
+  directories:
+    - ${HOME}/.cache/conda/pkgs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ And that's it.
 
  ### Python compatibility
 
- **GWSumm code must be compatible with Python versions >=3.5.**
+ **GWSumm code must be compatible with Python versions >=3.6.**
 
  ### Style
 

--- a/bin/gw_summary
+++ b/bin/gw_summary
@@ -29,14 +29,6 @@ Run 'gw_summary <mode> --help' for details of the specific arguments and
 options acceptable for each mode.
 """
 
-# XXX HACK XXX
-# plots don't work with multiprocessing with lal.LIGOTimeGPS
-from gwpy import time
-from gwpy.time import _tconvert
-from glue.lal import LIGOTimeGPS
-time.LIGOTimeGPS = LIGOTimeGPS  # noqa
-_tconvert.LIGOTimeGPS = LIGOTimeGPS  # noqa
-
 import argparse
 import calendar
 import datetime
@@ -44,24 +36,18 @@ import getpass
 import os
 import re
 import warnings
+
 from collections import OrderedDict
 from configparser import (DEFAULTSECT, NoOptionError, NoSectionError)
-try:
-    from urllib.parse import urlparse
-except ImportError:  # python < 3
-    from urlparse import urlparse
-
 from dateutil.relativedelta import relativedelta
+from urllib.parse import urlparse
 
-# set matplotlib backend
-from matplotlib import use
-use('Agg')  # noqa
+from glue.lal import (Cache, LIGOTimeGPS)
 
-from glue.lal import Cache
-
+from gwpy import time
 from gwpy.segments import (Segment, SegmentList)
 from gwpy.signal.spectral import _lal as fft_lal
-from gwpy.time import (tconvert, to_gps, Time)
+from gwpy.time import (Time, _tconvert, tconvert, to_gps)
 
 from gwsumm import (
     __version__,
@@ -87,6 +73,15 @@ from gwsumm.utils import (
     vprint,
 )
 from gwsumm.data import get_timeseries_dict
+
+# set matplotlib backend
+from matplotlib import use
+use('Agg')
+
+# XXX HACK XXX
+# plots don't work with multiprocessing with lal.LIGOTimeGPS
+time.LIGOTimeGPS = LIGOTimeGPS  # noqa
+_tconvert.LIGOTimeGPS = LIGOTimeGPS  # noqa
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -123,6 +118,7 @@ class GWHelpFormatter(argparse.ArgumentDefaultsHelpFormatter):
 # define actions for formatting dates
 class DateAction(argparse.Action):
     TIMESCALE = {'days': 1}
+
     @staticmethod
     def set_gps_times(namespace, startdate, enddate):
         setattr(namespace, 'gpsstart', to_gps(startdate))

--- a/bin/gw_summary
+++ b/bin/gw_summary
@@ -80,8 +80,8 @@ use('Agg')
 
 # XXX HACK XXX
 # plots don't work with multiprocessing with lal.LIGOTimeGPS
-time.LIGOTimeGPS = LIGOTimeGPS  # noqa
-_tconvert.LIGOTimeGPS = LIGOTimeGPS  # noqa
+time.LIGOTimeGPS = LIGOTimeGPS
+_tconvert.LIGOTimeGPS = LIGOTimeGPS
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 

--- a/bin/gwsumm-plot-guardian
+++ b/bin/gwsumm-plot-guardian
@@ -8,11 +8,9 @@ __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 import argparse
 import os
 import re
+
 from collections import OrderedDict
 from configparser import DEFAULTSECT
-
-from matplotlib import use
-use('Agg')  # noqa
 
 from gwpy.time import to_gps
 
@@ -22,6 +20,10 @@ from gwsumm.config import GWSummConfigParser
 from gwsumm.data import get_timeseries
 from gwsumm.state import generate_all_state
 from gwsumm.tabs import GuardianTab
+
+# set matplotlib backend
+from matplotlib import use
+use('Agg')
 
 GWSummConfigParser.OPTCRE = re.compile(
     r'(?P<option>[^=\s][^=]*)\s*(?P<vi>[=])\s*(?P<value>.*)$')

--- a/bin/gwsumm-plot-triggers
+++ b/bin/gwsumm-plot-triggers
@@ -8,21 +8,23 @@ from collections import OrderedDict
 
 from numpy import ndarray
 
-from matplotlib import use
-use('Agg')  # noqa
-
-from matplotlib.artist import setp
-from matplotlib.colors import LogNorm
-
 from glue.lal import Cache
 
 from gwpy.segments import Segment
 from gwpy.time import to_gps
 
-from gwsumm.plot import get_plot
 from gwsumm.segments import get_segments
 from gwsumm.triggers import (get_triggers, keep_in_segments)
 from gwsumm.utils import safe_eval
+
+# set matplotlib backend
+from matplotlib import use
+use('Agg')
+
+# backend-dependent imports
+from matplotlib.artist import setp  # noqa: E402
+from matplotlib.colors import LogNorm  # noqa: E402
+from gwsumm.plot import get_plot  # noqa: E402
 
 # default columns for plot
 DEFAULT_COLUMNS = ['time', 'frequency', 'snr']

--- a/gwsumm/_version.py
+++ b/gwsumm/_version.py
@@ -90,9 +90,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False):
         if verbose:
             print("unable to find command, tried %s" % (commands,))
         return None
-    stdout = p.communicate()[0].strip()
-    if sys.version_info[0] >= 3:
-        stdout = stdout.decode()
+    stdout = p.communicate()[0].strip().decode()
     if p.returncode != 0:
         if verbose:
             print("unable to run %s (error)" % dispcmd)

--- a/gwsumm/config.py
+++ b/gwsumm/config.py
@@ -39,7 +39,7 @@ from astropy import units
 from gwpy.detector import (Channel, ChannelList)
 from gwpy.time import tconvert
 
-from .utils import (nat_sorted, re_cchar, re_quote, safe_eval, OBSERVATORY_MAP)
+from .channels import (get_channels, split as split_channels,
                        update_channel_params)
 from .html import (get_css, get_js)
 from .utils import (nat_sorted, re_cchar, re_quote, safe_eval, OBSERVATORY_MAP)

--- a/gwsumm/config.py
+++ b/gwsumm/config.py
@@ -19,17 +19,18 @@
 """Thin wrapper around configparser
 """
 
+import configparser
 import re
 import os.path
-import configparser
-from io import StringIO
-from collections import OrderedDict
-from importlib import import_module
-from http.client import HTTPException
 
 # import these for evaluating lambda expressions in the configuration file
 import math  # noqa: F401
 import numpy  # noqa: F401
+
+from collections import OrderedDict
+from importlib import import_module
+from io import StringIO
+from http.client import HTTPException
 
 from matplotlib import rcParams
 
@@ -38,10 +39,10 @@ from astropy import units
 from gwpy.detector import (Channel, ChannelList)
 from gwpy.time import tconvert
 
+from .utils import (nat_sorted, re_cchar, re_quote, safe_eval, OBSERVATORY_MAP)
+                       update_channel_params)
 from .html import (get_css, get_js)
 from .utils import (nat_sorted, re_cchar, re_quote, safe_eval, OBSERVATORY_MAP)
-from .channels import (get_channels, split as split_channels,
-                       update_channel_params)
 
 __all__ = [
     'GWSummConfigParser',
@@ -61,12 +62,6 @@ class GWSummConfigParser(configparser.ConfigParser):
         kwargs.setdefault('dict_type', OrderedDict)
         configparser.ConfigParser.__init__(self, *args, **kwargs)
     __init__.__doc__ = configparser.ConfigParser.__init__.__doc__
-
-    def read_file(self, *args, **kwargs):
-        try:
-            return configparser.ConfigParser.read_file(self, *args, **kwargs)
-        except AttributeError:  # python < 3
-            return self.readfp(*args, **kwargs)
 
     def ndoptions(self, section, **kwargs):
         options = configparser.ConfigParser.options(self, section, **kwargs)

--- a/gwsumm/html/html5.py
+++ b/gwsumm/html/html5.py
@@ -21,13 +21,8 @@
 
 import re
 import os.path
-try:
-    from pathlib2 import Path
-except ImportError:  # python >= 3.6
-    # NOTE: we do it this way around because pathlib exists for py35,
-    #       but doesn't work very well
-    from pathlib import Path
 
+from pathlib import Path
 from urllib.parse import urlparse
 
 from MarkupPy import markup

--- a/gwsumm/html/tests/test_html5.py
+++ b/gwsumm/html/tests/test_html5.py
@@ -78,17 +78,17 @@ OVERLAY = (
     '<button title="Overlay figures" id="overlay-btn" class="btn-float '
     'btn-open shadow" data-id="#overlay"><i class="fas fa-layer-group"></i>'
     '</button>\n<div class="dialog" title="Overlay figures" id="overlay">\n'
-    '<h1>Overlay figures for easy comparison</h1>\n\n<p><hr '
-    'class="row-divider" />\n<div class="row" id="overlay-outer">\n'
-    '<div class="col-md-4">\n<div class="card card-body shadow-sm" '
-    'id="overlay-info">\n<h4>Instructions</h4>\n%s\n</div>\n</div>\n<div '
-    'class="col-md-8">\n<div class="text-center">\n<a title="Overlay all '
-    'selected figures" class="btn btn-light shadow-sm" id="overlay-figures">'
-    'Overlay</a>\n<a title="Download overlay figure" class="btn btn-light '
-    'shadow-sm" id="download-overlay">Download</a>\n<a title="Clear all figure'
-    ' selections" class="btn btn-light shadow-sm" id="clear-figures">Clear'
-    '</a>\n</div>\n<br />\n<canvas id="overlay-canvas" />\n</div>\n</div></p>'
-    '\n</div>') % markdown(html5.OVERLAY_INSTRUCTIONS)
+    '<h1>Overlay figures for easy comparison</h1>\n<hr class="row-divider" />'
+    '\n<div class="row" id="overlay-outer">\n<div class="col-md-4">\n'
+    '<div class="card card-body shadow-sm" id="overlay-info">\n'
+    '<h4>Instructions</h4>\n%s\n</div>\n</div>\n<div class="col-md-8">\n'
+    '<div class="text-center">\n<a title="Overlay all selected figures" '
+    'class="btn btn-light shadow-sm" id="overlay-figures">Overlay</a>\n'
+    '<a title="Download overlay figure" class="btn btn-light shadow-sm" '
+    'id="download-overlay">Download</a>\n<a title="Clear all figure '
+    'selections" class="btn btn-light shadow-sm" id="clear-figures">Clear</a>'
+    '\n</div>\n<br />\n<canvas id="overlay-canvas" />\n</div>\n</div>\n'
+    '</div>') % markdown(html5.OVERLAY_INSTRUCTIONS)
 
 
 # test utilities

--- a/gwsumm/tabs/gracedb.py
+++ b/gwsumm/tabs/gracedb.py
@@ -221,7 +221,8 @@ class GraceDbTab(get_tab('default')):
                     page.td('%.3g' % v)
                 elif col == 'labels':
                     page.td(', '.join(
-                        ['<samp>%s</samp>' % l for l in sorted(labs)]))
+                        ['<samp>%s</samp>' % iterable
+                         for iterable in sorted(labs)]))
                 else:
                     page.td(str(v))
             page.tr.close()
@@ -257,7 +258,8 @@ class GraceDbTab(get_tab('default')):
                'its labels as follows:')
         for c, labels in LABELS.items():
             c = (c if c == 'warning' else '%s text-white' % c)
-            labstr = ', '.join(['<samp>%s</samp>' % l for l in sorted(labels)])
+            labstr = ', '.join(['<samp>%s</samp>' % item
+                                for item in sorted(labels)])
             page.p(labstr, class_='bg-%s pl-2' % c, style='width: auto;')
 
         # write to file

--- a/gwsumm/tests/test_plot.py
+++ b/gwsumm/tests/test_plot.py
@@ -21,15 +21,9 @@
 """
 
 import os
+import pytest
 
 from configparser import ConfigParser
-
-from matplotlib import use
-use('Agg')  # noqa
-
-from matplotlib import (rcParams, rc_context)
-
-import pytest
 
 from gwpy.detector import ChannelList
 from gwpy.plot import Plot
@@ -38,6 +32,12 @@ from gwpy.segments import Segment
 
 from gwsumm import plot as gwsumm_plot
 from gwsumm.channels import get_channel
+
+from matplotlib import use
+use('Agg')
+
+# backend-dependent imports
+from matplotlib import (rcParams, rc_context)  # noqa: E402
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 

--- a/gwsumm/utils.py
+++ b/gwsumm/utils.py
@@ -86,12 +86,12 @@ def mkdir(*paths):
             os.makedirs(path)
 
 
-def nat_sorted(l, key=None):
+def nat_sorted(iterable, key=None):
     """Sorted a list in the way that humans expect.
 
     Parameters
     ----------
-    l : `iterable`
+    iterable : `iterable`
         iterable to sort
     key : `callable`
         sorting key
@@ -101,7 +101,7 @@ def nat_sorted(l, key=None):
     lsorted : `list`
         sorted() version of input ``l``
     """
-    k = key and list(map(key, l)) or l
+    k = key and list(map(key, iterable)) or iterable
 
     def convert(text):
         if text.isdigit():
@@ -110,9 +110,10 @@ def nat_sorted(l, key=None):
             return text
 
     def alphanum_key(key):
-        return [convert(c) for c in re.split('([0-9]+)', k[l.index(key)])]
+        return [convert(c) for c in re.split(
+            '([0-9]+)', k[iterable.index(key)])]
 
-    return sorted(l, key=alphanum_key)
+    return sorted(iterable, key=alphanum_key)
 
 
 def which(program):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,32 +2,29 @@
 setuptools
 
 # core requirements
-python-dateutil
-lxml
-numpy>=1.16
-scipy>=1.2.0
-matplotlib>=2.0
-astropy>=1.2.1
-lalsuite
-gwtrigfind
+astropy>=3.0.0
 gwdatafind
-lscsoft-glue>=1.60.0
+gwdetchar>=1.1.0
+gwpy>=2.0.0
+gwtrigfind
+lalsuite
 ligo-segments
-pygments
-MarkupPy
+lscsoft-glue>=1.60.0
+lxml
 markdown
-gwdetchar>=1.0.0
-gwpy>=1.0.0
-configparser ; python_version < '3.6'
+MarkupPy
+matplotlib>=3.1
+numpy>=1.16
+pygments>=2.7.0
+python-dateutil
+scipy>=1.2.0
 
 # optional extras (not module-level imports)
 pykerberos
 h5py
-dqsegdb>=1.4.2
 ligo-gracedb>=2.0.0
 
 # testing extras
-pytest>=2.8,<3.7
-pytest-cov
-coverage
+pytest>=3.3.0
+pytest-cov>2.4.0
 flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,11 +66,10 @@ tests_require =
 	pytest >=3.3.0
 	pytest-cov >=2.4.0
 scripts =
-	bin/gwdetchar-lasso-correlation
-	bin/gwdetchar-mct
-	bin/gwdetchar-overflow
-	bin/gwdetchar-slow-correlation
-	bin/gwdetchar-software-saturations
+	bin/gw_summary
+	bin/gw_summary_pipe
+	bin/gwsumm-plot-guardian
+	bin/gwsumm-plot-triggers
 
 [options.extras_require]
 doc =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,4 @@
-[aliases]
-test = pytest
-
-[tool:pytest]
-addopts = --verbose -r s
+; -- metadata ---------------
 
 [versioneer]
 VCS = git
@@ -11,6 +7,83 @@ versionfile_source = gwsumm/_version.py
 versionfile_build = gwsumm/_version.py
 tag_prefix =
 parentdir_prefix =
+
+[bdist_wheel]
+universal = 1
+
+[metadata]
+name = gwsumm
+author = Alex Urban, Duncan Macleod
+author_email = alexander.urban@ligo.org
+license = GPL-3.0-or-later
+license_file = LICENSE
+keywords = physics, astronomy, gravitational-waves, ligo
+url = https://gwsumm.readthedocs.io
+description = A python toolbox used by the LIGO Scientific Collaboration for detector characterisation
+long_description = file: README.rst
+classifiers =
+	Development Status :: 5 - Production/Stable
+	Intended Audience :: Developers
+	Intended Audience :: Science/Research
+	License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
+	Natural Language :: English
+	Operating System :: OS Independent
+	Programming Language :: Python
+	Programming Language :: Python :: 3
+	Programming Language :: Python :: 3.6
+	Programming Language :: Python :: 3.7
+	Programming Language :: Python :: 3.8
+	Programming Language :: Python :: 3.9
+	Topic :: Scientific/Engineering
+	Topic :: Scientific/Engineering :: Astronomy
+	Topic :: Scientific/Engineering :: Physics
+
+[options]
+zip_safe = False
+packages = find:
+python_requires = >=3.6
+setup_requires =
+	setuptools >=30.3.0
+install_requires =
+	astropy >=3.0.0
+	gwdatafind
+	gwdetchar >=1.1.0
+	gwpy >=2.0.0
+	gwtrigfind
+	lalsuite
+	ligo-segments
+	lscsoft-glue >=1.60.0
+	lxml
+	markdown
+	MarkupPy
+	matplotlib >=3.1
+	numpy >=1.16
+	pygments >=2.7.0
+	python-dateutil
+	scipy >=1.2.0
+tests_require =
+	flake8
+	pytest >=3.3.0
+	pytest-cov >=2.4.0
+scripts =
+	bin/gwdetchar-lasso-correlation
+	bin/gwdetchar-mct
+	bin/gwdetchar-overflow
+	bin/gwdetchar-slow-correlation
+	bin/gwdetchar-software-saturations
+
+[options.extras_require]
+doc =
+	sphinx
+	numpydoc
+	sphinx_bootstrap_theme
+    astropy_helpers
+
+[tool:pytest]
+; print skip reasons
+addopts = --verbose -r s
+
+; -- tools ------------------
 
 [coverage:run]
 source = gwsumm

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@
 """
 
 import glob
+import os
 import versioneer
 
 from setuptools import setup
@@ -37,7 +38,7 @@ else:
 
 # configuration files
 data_files = [
-    (os.path.join('etc', PACKAGENAME, 'configuration'),
+    (os.path.join('etc', 'gwsumm', 'configuration'),
      glob.glob(os.path.join('share', '*.ini'))),
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -20,30 +20,14 @@
 """Setup the GWSumm package
 """
 
-import sys
 import glob
-import os
+import versioneer
 
-from setuptools import (setup, find_packages)
+from setuptools import setup
 
-# set basic metadata
-PACKAGENAME = 'gwsumm'
-DISTNAME = 'gwsumm'
-AUTHOR = 'Alex Urban, Duncan Macleod'
-AUTHOR_EMAIL = 'alexander.urban@ligo.org'
-LICENSE = 'GPL-3.0-or-later'
+version = versioneer.get_version()
+cmdclass = versioneer.get_cmdclass()
 
-cmdclass = {}
-
-# -- versioning ---------------------------------------------------------------
-
-import versioneer  # noqa: E402
-__version__ = versioneer.get_version()
-cmdclass.update(versioneer.get_cmdclass())
-
-# -- documentation ------------------------------------------------------------
-
-# import sphinx commands
 try:
     from sphinx.setup_command import BuildDoc
 except ImportError:
@@ -51,108 +35,22 @@ except ImportError:
 else:
     cmdclass['build_sphinx'] = BuildDoc
 
-# -- dependencies -------------------------------------------------------------
-
-# install requirements (module-level imported packages)
-install_requires = [
-    'python-dateutil',
-    'lxml',
-    'numpy>=1.16',
-    'scipy>=1.2.0',
-    'matplotlib>=2.2.0',
-    'astropy>=1.2.1',
-    'lalsuite',
-    'lscsoft-glue>=1.60.0',
-    'ligo-segments',
-    'gwpy>=1.0.0',
-    'gwtrigfind',
-    'gwdatafind',
-    'pygments',
-    'MarkupPy',
-    'markdown',
-    'gwdetchar>=1.0.0',
-    'configparser ; python_version < \'3.6\'',
-]
-
-# build and test requirements
-setup_requires = ['pytest_runner'] if {
-    'pytest', 'test'}.intersection(sys.argv) else []
-tests_require = [
-    'pytest>=2.8,<3.7',
-    'pytest-cov',
-    'coverage',
-    'flake8',
-]
-if sys.version < '3':
-    tests_require.append('mock')
-
-# extras
-extras_require = {
-    'docs': [
-        'sphinx',
-        'numpydoc',
-        'sphinx-bootstrap-theme',
-        'astropy_helpers',
-    ],
-}
-
-# -- data files ---------------------------------------------------------------
-
 # configuration files
 data_files = [
     (os.path.join('etc', PACKAGENAME, 'configuration'),
      glob.glob(os.path.join('share', '*.ini'))),
 ]
 
-# -- run setup ----------------------------------------------------------------
-
-packagenames = find_packages()
-scripts = glob.glob(os.path.join('bin', '*'))
-
-# read description
-with open('README.rst', 'rb') as f:
-    longdesc = f.read().decode().strip()
-
+# run setup
+# NOTE: all other metadata and options come from setup.cfg
 setup(
-    name=DISTNAME,
-    provides=[PACKAGENAME],
-    version=__version__,
-    description=("A python toolbox used by the LIGO Scientific "
-                 "Collaboration for detector characterisation"),
-    long_description=longdesc,
-    author=AUTHOR,
-    author_email=AUTHOR_EMAIL,
-    license=LICENSE,
-    url='https://gwsumm.readthedocs.io',
+    version=version,
     project_urls={
          "Bug Tracker": "https://github.com/gwpy/gwsumm/issues",
          "Discussion Forum": "https://gwdetchar.slack.com",
          "Documentation": "https://gwsumm.readthedocs.io",
          "Source Code": "https://github.com/gwpy/gwsumm",
      },
-    packages=packagenames,
-    include_package_data=True,
     cmdclass=cmdclass,
-    scripts=scripts,
-    setup_requires=setup_requires,
-    install_requires=install_requires,
-    tests_require=tests_require,
-    extras_require=extras_require,
     data_files=data_files,
-    use_2to3=False,
-    classifiers=[
-        'Programming Language :: Python',
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Science/Research',
-        ('License :: OSI Approved :: '
-         'GNU General Public License v3 or later (GPLv3+)'),
-        'Natural Language :: English',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Topic :: Scientific/Engineering :: Astronomy',
-        'Topic :: Scientific/Engineering :: Physics',
-    ],
 )


### PR DESCRIPTION
This PR drops all support for python < 3.6 and adds explicit support for 3.8 and 3.9 through build tests. This includes the following:
* Overhaul the Travis CI configuration to enable Conda builds
* Refactor `setup.py` into the configuration file `setup.cfg`
* Update dependency version pins
* Resolve various flake8 linter complaints

cc @duncanmmacleod 