### PR TITLE
Implement unit tests for gwsumm.plot.{guardian,triggers}

### DIFF
--- a/gwsumm/plot/guardian/__main__.py
+++ b/gwsumm/plot/guardian/__main__.py
@@ -83,28 +83,28 @@ def create_parser():
         '-i',
         '--ifo',
         type=str,
-        default='L1',
+        default="L1",
     )
     parser.add_argument(
         '-s',
         '--section',
         type=str,
-        help='suffix of INI tab section to read, e.g. give '
-             '--section=\'ISC_LOCK\' to read [tab-ISC_LOCK] '
-             'section, defaults to {node}',
+        help="suffix of INI tab section to read, e.g. give "
+             "--section='ISC_LOCK' to read [tab-ISC_LOCK] "
+             "section, defaults to {node}",
     )
     parser.add_argument(
         '-t',
         '--epoch',
         type=to_gps,
-        help='Zero-time for plot, defaults to GPSSTART',
+        help="Zero-time for plot, defaults to GPSSTART",
     )
     parser.add_argument(
         '-p',
         '--plot-params',
         action='append',
         default=[],
-        help='extra plotting keyword argument',
+        help="extra plotting keyword argument",
     )
     parser.add_argument(
         '-m',
@@ -112,37 +112,37 @@ def create_parser():
         type=int,
         default=1,
         dest='nproc',
-        help='number of processes to use, default: %(default)s',
+        help="number of processes to use, default: %(default)s",
     )
     parser.add_argument(
         '-o',
         '--output-file',
-        default='guardian.png',
-        help='output file name, default: %(default)s',
+        default="guardian.png",
+        help="output file name, default: %(default)s",
     )
     parser.add_argument(
         '-v',
         '--verbose',
         action='store_true',
-        help='print verbose output, default: False',
+        help="print verbose output, default: False",
     )
     parser.add_argument(
         '-P',
         '--profile',
         action='store_true',
-        help='print timing output, default: False',
+        help="print timing output, default: False",
     )
 
     # archive options
     archopts.add_argument(
         '-a',
         '--archive',
-        help='full path of HDF archive for data',
+        help="full path of HDF archive for data",
     )
     archopts.add_argument(
         '-r',
         '--read-only-archive',
-        help='full path of HDF archive for data, does not write',
+        help="full path of HDF archive for data, does not write",
     )
 
     # return the argument parser
@@ -157,10 +157,9 @@ def main(args=None):
     parser = create_parser()
     args = parser.parse_args(args=args)
 
-    if args.epoch is None:
-        args.epoch = args.gpsstart
     globalv.VERBOSE = args.verbose
     globalv.PROFILE = args.profile
+    args.epoch = args.epoch or args.gpsstart
     state = generate_all_state(args.gpsstart, args.gpsend)
 
     # format params
@@ -175,7 +174,7 @@ def main(args=None):
     config.set(DEFAULTSECT, 'gps-start-time', str(int(args.gpsstart)))
     config.set(DEFAULTSECT, 'gps-end-time', str(int(args.gpsend)))
     config.set(DEFAULTSECT, 'IFO', args.ifo)
-    sec = 'tab-%s' % (args.section or args.node)
+    sec = 'tab-{}'.format(args.section or args.node)
 
     # read archive
     if args.archive and not args.read_only_archive:
@@ -196,7 +195,7 @@ def main(args=None):
     tab.process(nproc=args.nproc)
     plotfile = tab.plots[0].outputfile
     os.rename(plotfile, args.output_file)
-    LOGGER.info('Plot saved to {0.output_file}'.format(args))
+    LOGGER.info("Plot saved to {0.output_file}".format(args))
 
     # crop and save archive
     if args.archive:

--- a/gwsumm/plot/guardian/core.py
+++ b/gwsumm/plot/guardian/core.py
@@ -64,8 +64,8 @@ class GuardianStatePlot(get_plot('segments')):
         return list(self.ifos)[0]
 
     def draw(self):
-        from ..tabs.guardian import (REQUESTSTUB, NOMINALSTUB,
-                                     re_guardian_index)
+        from ...tabs.guardian import (REQUESTSTUB, NOMINALSTUB,
+                                      re_guardian_index)
 
         plot = self.init_plot()
         ax = plot.gca()

--- a/gwsumm/plot/guardian/tests/__init__.py
+++ b/gwsumm/plot/guardian/tests/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Alex Urban (2020)
+#
+# This file is part of GWSumm.
+#
+# GWSumm is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWSumm is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWSumm.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for gwsumm.plot.guardian
+"""
+
+__author__ = 'Alex Urban <alexander.urban@ligo.org>'

--- a/gwsumm/plot/guardian/tests/test_main.py
+++ b/gwsumm/plot/guardian/tests/test_main.py
@@ -90,6 +90,7 @@ def test_main(tmpdir, caplog):
         'ISC_LOCK',
         '0', '3600',
         ini,
+        '--plot-params', 'title="Test figure"',
         '--output-file', plot,
         '--verbose',
         '--archive', archive,

--- a/gwsumm/plot/guardian/tests/test_main.py
+++ b/gwsumm/plot/guardian/tests/test_main.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Alex Urban (2020)
+#
+# This file is part of GWSumm.
+#
+# GWSumm is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWSumm is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWSumm.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the `gwsumm.plot.guardian` command-line interface
+"""
+
+import os
+import shutil
+
+from gwpy.timeseries import (
+    TimeSeries,
+    TimeSeriesList,
+)
+
+from .... import globalv
+from ....archive import write_data_archive
+from .. import __main__ as guardian_cli
+
+__author__ = 'Alex Urban <alexander.urban@ligo.org>'
+
+# -- test configuration
+
+CONFIG = """
+[tab-ISC_LOCK]
+type = guardian
+node = ISC_LOCK
+name = %(node)s
+; node states
+600 = Low noise
+"""
+
+# -- test data
+
+SUFFICES = [
+    "STATE_N",
+    "REQUEST_N",
+    "NOMINAL_N",
+    "OK",
+    "MODE",
+    "OP",
+]
+DATA = {
+    key: TimeSeriesList(
+        TimeSeries([600] * 3600 * 16, sample_rate=16, name=key, channel=key)
+    ) for key in ["L1:GRD-ISC_LOCK_{}".format(suff) for suff in SUFFICES]
+}
+
+
+# -- utils --------------------------------------------------------------------
+
+def _get_inputs(workdir):
+    """Prepare, and return paths to, input data products
+    """
+    # set global timeseries data
+    globalv.DATA = DATA
+    # get path to data files
+    ini = os.path.join(workdir, "config.ini")
+    archive = os.path.abspath(os.path.join(workdir, "archive.h5"))
+    # write to data files
+    with open(ini, 'w') as f:
+        f.write(CONFIG)
+    write_data_archive(archive)
+    # reset global data and return
+    globalv.DATA = {}
+    return (ini, archive)
+
+
+# -- cli tests ----------------------------------------------------------------
+
+def test_main(tmpdir, caplog):
+    outdir = str(tmpdir)
+    plot = os.path.join(outdir, "guardian.png")
+    (ini, archive) = _get_inputs(outdir)
+    args = [
+        'ISC_LOCK',
+        '0', '3600',
+        ini,
+        '--output-file', plot,
+        '--verbose',
+        '--archive', archive,
+    ]
+    # test output
+    guardian_cli.main(args)
+    assert os.path.exists(plot)
+    assert len(os.listdir(outdir)) == 3  # 2 inputs, 1 output
+    assert 'Read data archive from {}'.format(archive) in caplog.text
+    assert 'Processing:' in caplog.text
+    assert 'Plot saved to {}'.format(plot) in caplog.text
+    assert 'Archive recorded as {}'.format(archive) in caplog.text
+    # clean up
+    shutil.rmtree(outdir, ignore_errors=True)

--- a/gwsumm/plot/guardian/tests/test_main.py
+++ b/gwsumm/plot/guardian/tests/test_main.py
@@ -90,7 +90,7 @@ def test_main(tmpdir, caplog):
         'ISC_LOCK',
         '0', '3600',
         ini,
-        '--plot-params', 'title="Test figure"',
+        '--plot-params', 'title=Test figure',
         '--output-file', plot,
         '--verbose',
         '--archive', archive,

--- a/gwsumm/plot/triggers/__main__.py
+++ b/gwsumm/plot/triggers/__main__.py
@@ -235,13 +235,11 @@ def main(args=None):
         plot = trigs.tile(args.x_column, args.y_column,
                           'duration', 'bandwidth', color=args.color,
                           edgecolor=params.pop('edgecolor', 'face'),
-                          linewidth=params.pop('linewidth', .8),
-                          **plot_kw)
+                          linewidth=params.pop('linewidth', .8), **plot_kw)
     else:
         plot = trigs.scatter(args.x_column, args.y_column, color=args.color,
                              edgecolor=params.pop('edgecolor', 'none'),
-                             s=params.pop('s', 12),
-                             **plot_kw)
+                             s=params.pop('s', 12), **plot_kw)
     ax = plot.gca()
     mappable = ax.collections[0]
 

--- a/gwsumm/plot/triggers/__main__.py
+++ b/gwsumm/plot/triggers/__main__.py
@@ -73,32 +73,32 @@ def create_parser():
         '-e',
         '--etg',
         default='omicron',
-        help='name of ETG (default: %(default)s)',
+        help="name of ETG (default: %(default)s)",
     )
     trigopts.add_argument(
         '-l',
         '--cache-file',
-        help='cache file containing event trigger file references',
+        help="cache file containing event trigger file references",
     )
     trigopts.add_argument(
         '-C',
         '--columns',
         type=lambda x: x.split(','),
-        help='(comma-separated) list of columns to read from '
-             'files: (default: {0})'.format(','.join(DEFAULT_COLUMNS)),
+        help="comma-separated list of columns to read from "
+             "files (default: {0})".format(','.join(DEFAULT_COLUMNS)),
     )
     trigopts.add_argument(
         '-s',
         '--snr',
         default=0,
         type=float,
-        help='minimum SNR (default: %(default)s)',
+        help="minimum SNR (default: %(default)s)",
     )
     trigopts.add_argument(
         '-a',
         '--state',
         metavar='FLAG',
-        help='restrict triggers to active times for flag',
+        help="restrict triggers to active times for flag",
     )
 
     # options for output plot
@@ -106,48 +106,48 @@ def create_parser():
         '-t',
         '--epoch',
         type=to_gps,
-        help='Zero-time for plot, (default: gpsstart)',
+        help="Zero-time for plot (default: gpsstart)",
     )
     popts.add_argument(
         '-x',
         '--x-column',
-        help='column for X-axis, (default: first --column)',
+        help="column for X-axis (default: first --column)",
     )
     popts.add_argument(
         '-f',
         '--y-column',
-        help='column for Y-axis, (default: second --column)',
+        help="column for Y-axis (default: second --column)",
     )
     popts.add_argument(
         '-c',
         '--color',
-        help='column for colour, (default: third --column)',
+        help="column for colour (default: third --column)",
     )
     popts.add_argument(
         '-p',
         '--plot-params',
         action='append',
         metavar='"{arg}={param}"',
-        help='extra plotting keyword arguments, '
-             'can be given multiple times',
+        help="extra plotting keyword arguments, "
+             "can be given multiple times",
     )
     popts.add_argument(
         '--tiles',
         action='store_true',
         default=False,
-        help='plot tiles instead of dots (default: %(default)s), '
-             'if selected \'duration\' and \'bandwidth\' will be '
-             'automatically added to --columns',
+        help="plot tiles instead of dots (default: %(default)s), "
+             "if selected 'duration' and 'bandwidth' will be "
+             "automatically added to --columns",
     )
     popts.add_argument(
         '--state-label',
-        help='label for state segments (default: --state)',
+        help="label for state segments (default: --state)",
     )
     popts.add_argument(
         '-o',
         '--output-file',
-        default='trigs.png',
-        help='output file name (default: %(default)s)',
+        default='triggers.png',
+        help="output file name (default: %(default)s)",
     )
 
     # return the argument parser
@@ -162,17 +162,13 @@ def main(args=None):
     parser = create_parser()
     args = parser.parse_args(args=args)
 
-    if args.epoch is None:
-        args.epoch = args.gpsstart
-    if not args.columns:
-        args.columns = DEFAULT_COLUMNS
+    args.epoch = args.epoch or args.gpsstart
+    args.columns = args.columns or DEFAULT_COLUMNS
     if len(args.columns) < 2:
-        parser.error('--columns must receive at least two columns, '
-                     'got {0}'.format(len(args.columns)))
-    if not args.x_column:
-        args.x_column = args.columns[0]
-    if not args.y_column:
-        args.y_column = args.columns[1]
+        parser.error("--columns must receive at least two columns, "
+                     "got {0}".format(len(args.columns)))
+    args.x_column = args.x_column or args.columns[0]
+    args.y_column = args.y_column or args.columns[1]
     if not args.color and len(args.columns) >= 3:
         args.color = args.columns[2]
 
@@ -282,7 +278,7 @@ def main(args=None):
 
     # save and exit
     plot.save(args.output_file)
-    LOGGER.info('Plot saved to {0.output_file}'.format(args))
+    LOGGER.info("Plot saved to {0.output_file}".format(args))
 
 
 # -- run from command-line ----------------------------------------------------

--- a/gwsumm/plot/triggers/tests/__init__.py
+++ b/gwsumm/plot/triggers/tests/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Alex Urban (2020)
+#
+# This file is part of GWSumm.
+#
+# GWSumm is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWSumm is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWSumm.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for gwsumm.plot.triggers
+"""
+
+__author__ = 'Alex Urban <alexander.urban@ligo.org>'

--- a/gwsumm/plot/triggers/tests/test_main.py
+++ b/gwsumm/plot/triggers/tests/test_main.py
@@ -100,7 +100,7 @@ def test_main_with_cache_and_tiles(tmpdir, caplog):
         '--tiles',
         '--output-file', plot,
     ]
-    # reset global variables and write an empty cache file
+    # write an empty cache file
     with open(cache, 'w') as f:
         f.write("")
     # test output

--- a/gwsumm/plot/triggers/tests/test_main.py
+++ b/gwsumm/plot/triggers/tests/test_main.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Alex Urban (2020)
+#
+# This file is part of GWSumm.
+#
+# GWSumm is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWSumm is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWSumm.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the `gwsumm.plot.triggers` command-line interface
+"""
+
+import os
+import pytest
+import shutil
+
+from unittest import mock
+
+from gwpy.segments import (
+    Segment,
+    SegmentList,
+    DataQualityFlag,
+)
+
+from .... import globalv
+from .. import __main__ as triggers_cli
+
+__author__ = 'Alex Urban <alexander.urban@ligo.org>'
+
+# -- test configuration
+
+CHANNEL = "H1:GDS-CALIB_STRAIN"
+
+# -- test data
+
+LOCK = DataQualityFlag(
+    name="H1:DMT-GRD_ISC_LOCK_NOMINAL:1",
+    active=SegmentList([Segment(2, 2048)]),
+    known=SegmentList([Segment(0, 3600)]),
+)
+
+
+# -- cli tests ----------------------------------------------------------------
+
+@mock.patch(
+    'gwpy.segments.DataQualityFlag.query_dqsegdb',
+    return_value=LOCK,
+)
+def test_main(dqflag, tmpdir, caplog):
+    outdir = str(tmpdir)
+    plot = os.path.join(outdir, "triggers.png")
+    args = [
+        CHANNEL,
+        '0', '3600',
+        '--snr', '1',
+        '--state', LOCK.name,
+        '--output-file', plot,
+    ]
+    # test output
+    with pytest.warns(UserWarning) as record:
+        triggers_cli.main(args)
+    assert os.path.exists(plot)
+    assert len(os.listdir(outdir)) == 1
+    assert 'Read 0 events' in caplog.text
+    assert "0 events in state '{}'".format(LOCK.name) in caplog.text
+    assert '0 events remaining with snr >= 1.0' in caplog.text
+    assert 'Plot saved to {}'.format(plot) in caplog.text
+    # test the `UserWarning`
+    # FIXME: once MatplotlibDeprecationWarning about colormaps is fixed,
+    #        assert that this UserWarning is the **only** warning
+    assert (record[0].message.args[0] ==
+            "Caught ValueError: No channel-level directory found at "
+            "/home/detchar/triggers/*/H1/GDS-CALIB_STRAIN_Omicron. Either "
+            "the channel name or ETG names are wrong, or this channel is not "
+            "configured for this ETG.")
+    # clean up
+    globalv.TRIGGERS = {}
+    shutil.rmtree(outdir, ignore_errors=True)
+
+
+def test_main_with_cache_and_tiles(tmpdir, caplog):
+    outdir = str(tmpdir)
+    cache = os.path.join(outdir, "empty.cache")
+    plot = os.path.join(outdir, "triggers.png")
+    args = [
+        CHANNEL,
+        '0', '3600',
+        '--cache-file', cache,
+        '--snr', '1',
+        '--tiles',
+        '--output-file', plot,
+    ]
+    # reset global variables and write an empty cache file
+    with open(cache, 'w') as f:
+        f.write("")
+    # test output
+    triggers_cli.main(args)
+    assert os.path.exists(plot)
+    assert len(os.listdir(outdir)) == 2  # 1 input, 1 output
+    assert 'Read cache of 0 files' in caplog.text
+    assert 'Read 0 events' in caplog.text
+    assert '0 events remaining with snr >= 1.0' in caplog.text
+    assert 'Plot saved to {}'.format(plot) in caplog.text
+    # clean up
+    globalv.TRIGGERS = {}
+    shutil.rmtree(outdir, ignore_errors=True)
+
+
+def test_main_invalid_columns(capsys):
+    args = [
+        CHANNEL,
+        '0', '3600',
+        '--columns', 'invalid',
+    ]
+    # test output
+    with pytest.raises(SystemExit):
+        triggers_cli.main(args)
+    (_, err) = capsys.readouterr()
+    assert err.endswith("--columns must receive at least two columns, got 1\n")

--- a/gwsumm/plot/triggers/tests/test_main.py
+++ b/gwsumm/plot/triggers/tests/test_main.py
@@ -96,6 +96,7 @@ def test_main_with_cache_and_tiles(tmpdir, caplog):
         '0', '3600',
         '--cache-file', cache,
         '--snr', '1',
+        '--plot-params', 'legend-loc="upper right"',
         '--tiles',
         '--output-file', plot,
     ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,7 +93,7 @@ omit =
 	gwsumm/html/tests/*
 	gwsumm/*version*
 	; omit scripts for now, will be done in a future PR
-	**/__main__.py
+	gwsumm/__main__.py
 	gwsumm/batch.py
 
 [flake8]


### PR DESCRIPTION
This PR seeks to improve GWSumm's coverage by implementing unit tests for `gwsumm.plot.guardian.__main__` and `gwsumm.plot.triggers.__main__`, which touch other modules in the codebase.

A similar treatment of `gwsumm.__main__` and `gwsumm.batch` is forthcoming.

cc @duncanmmacleod 