### PR TITLE
Catch TypeErrors that arise writing StateVector objects

### DIFF
--- a/gwsumm/archive.py
+++ b/gwsumm/archive.py
@@ -293,7 +293,7 @@ def _write_object(data, *args, **kwargs):
     """
     try:
         return data.write(*args, **kwargs)
-    except ValueError as e:
+    except (TypeError, ValueError) as e:
         warnings.warn(str(e))
     except RuntimeError as e:
         if 'name already exists' in str(e).lower():


### PR DESCRIPTION
This PR applies a band-aid to an error I'm seeing in production, in which `gwsumm.archive._write_data` fails on writing `StateVector` objects because of byte representation.

cc @duncanmmacleod 