### PR TITLE
Update the Fscan pages with new figure of merit

### DIFF
--- a/gwsumm/tabs/fscan.py
+++ b/gwsumm/tabs/fscan.py
@@ -100,8 +100,9 @@ class FscanTab(base):
                 else:
                     self.line_count_plots.append(SummaryPlot(
                         href='/~%s/%s' % (user, postbase)))
-                if ('line_count' not in p and '0.00_100.00' in p and
-                    '_2.png' in p):
+                if ('line_count' not in p and
+                        '0.00_100.00' in p and
+                        '_2.png' in p):
                     self.line_count_plots.append(SummaryPlot(
                         href='/~%s/%s' % (user, postbase)))
 


### PR DESCRIPTION
Bring the Line Count statistic to the top of the Fscan pages and separate them from the 'spectra' section. Drop alphabetical organization of the Fscan detail pages (it was previously sorted as 'Coherence Daily', 'Coherence Monthly', and 'Coherence Weekly'; now it doesn't have a sorting so it relies on the configuration file for organization).

With the configuration file, the Fscan pages are properly sorted as 'Daily', 'Weekly', and 'Monthly'.

Example new output:
https://ldas-jobs.ligo-wa.caltech.edu/~evan.goetz/summary/day/20210427/detchar/fscan/

I suppose this would require a point release to bring in the new page format to production summary pages.