### PR TITLE
Migrate LIGO_LW handling to use python-ligo-lw

### DIFF
--- a/gwsumm/triggers.py
+++ b/gwsumm/triggers.py
@@ -102,7 +102,7 @@ for name in lsctables.TableByName:
     ETG_READ_KW[name] = {
         'format': 'ligolw',
         'tablename': name,
-        'use_numpy_dtype': True,
+        'use_numpy_dtypes': True,
     }
 
 

--- a/gwsumm/triggers.py
+++ b/gwsumm/triggers.py
@@ -26,8 +26,9 @@ from astropy.table import vstack as vstack_tables
 
 from lal.utils import CacheEntry
 
+from ligo.lw import lsctables
+
 from glue.lal import Cache
-from glue.ligolw import lsctables
 
 from gwpy.io.cache import cache_segments
 from gwpy.table import (EventTable, filters as table_filters)
@@ -115,7 +116,7 @@ def get_etg_table(etg):
 
     Returns
     -------
-    table : `~gwpy.table.Table`
+    table : `type`, subclass of `~ligo.lw.table.Table`
         LIGO_LW table registered to the given ETG
 
     Raises

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ install_requires =
 	numpy >=1.16
 	pygments >=2.7.0
 	python-dateutil
+	python-ligo-lw
 	scipy >=1.2.0
 tests_require =
 	flake8


### PR DESCRIPTION
This PR migrates the `gwsum.triggers` module to use `python-ligo-lw` for handling LIGO_LW files, instead of `glue.ligolw`.

All of the actual reading is done by GWpy, so this change doesn't actually change how the files are read, but instead modifies some edge cases (e.g. empty table creation, etc).