### PR TITLE
When no list of tabs is given, write_html() fails

### DIFF
--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -735,6 +735,8 @@ class BaseTab(object):
         if tabs:
             navbar = str(self.html_navbar(ifo=ifo, ifomap=ifomap,
                                           tabs=tabs, help_=help_))
+        else:
+            navbar = None
 
         # initialize page
         self.page = gwhtml.new_bootstrap_page(


### PR DESCRIPTION
Closes #334

Simple fix when no list of tabs is given, then no navbar should be created.