### PR TITLE
Bump gwbootstrap 1.3.1 up to 1.3.2

### DIFF
--- a/gwsumm/html/static.py
+++ b/gwsumm/html/static.py
@@ -33,7 +33,7 @@ CSS = OrderedDict((
                      'font-awesome/5.15.1/css/fontawesome.min.css'),
     ('font-awesome-solid', 'https://cdnjs.cloudflare.com/ajax/libs/'
                            'font-awesome/5.15.1/css/solid.min.css'),
-    ('gwbootstrap', 'https://cdn.jsdelivr.net/npm/gwbootstrap@1.3.1/'
+    ('gwbootstrap', 'https://cdn.jsdelivr.net/npm/gwbootstrap@1.3.2/'
                     'lib/gwbootstrap.min.css'),
 ))
 
@@ -50,7 +50,7 @@ JS = OrderedDict((
     ('datepicker', 'https://cdnjs.cloudflare.com/ajax/libs/'
                    'bootstrap-datepicker/1.9.0/js/'
                    'bootstrap-datepicker.min.js'),
-    ('gwbootstrap', 'https://cdn.jsdelivr.net/npm/gwbootstrap@1.3.1/'
+    ('gwbootstrap', 'https://cdn.jsdelivr.net/npm/gwbootstrap@1.3.2/'
                     'lib/gwbootstrap-extra.min.js'),
 ))
 


### PR DESCRIPTION
What it says on the tin: point to the newest version of gwbootstrap