### PR TITLE
Fix pcolormesh call in newer matplotlib versions

### DIFF
--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -389,8 +389,8 @@ class SpectrogramDataPlot(TimeSeriesDataPlot):
 
         # add colorbar
         if len(specgrams) == 0:
-            ax.pcolormesh([1, 10], [1, 10], [[1, 10]], visible=False,
-                          **plotargs)
+            ax.pcolormesh([1, 10], [1, 10], [[1, 10], [1, 10]],
+                          visible=False, **plotargs)
         ax.colorbar(label=clabel)
 
         # customise and finalise


### PR DESCRIPTION
Apparently this fails in recent versions of `matplotlib`:
```
ax.pcolormesh([1, 10], [1, 10], [[1, 10]], visible=False, **plotargs)
```
with error:
```
TypeError: Dimensions of C (1, 2) are incompatible with X (2) and/or Y (2); see help(pcolormesh)
```

It should instead be
```
ax.pcolormesh([1, 10], [1, 10], [[1, 10], [1, 10]], visible=False, **plotargs)
```