### PR TITLE
Fix when no html section given in configuration

### DIFF
--- a/gwsumm/__main__.py
+++ b/gwsumm/__main__.py
@@ -749,7 +749,7 @@ def main(args=None):
     # get link to issues report page
     try:
         issues = config.get('html', 'issues')
-    except KeyError:
+    except (NoSectionError, KeyError):
         issues = True
 
     # write 404 error page


### PR DESCRIPTION
According to everything I can gather, the summary page configuration should not require an [html] section and an issues key-value pair to generate a simple page. However, the case where no [html] section is provided is not caught and so an error is produced. This PR fixes the issue

Closes #348 (at least the issue pointed out here, though not fully addressing all the question about the documentation far out of date. I'll be addressing that separately)