### PR TITLE
Bugfix for when hours are requested in a state

### DIFF
--- a/gwsumm/state/core.py
+++ b/gwsumm/state/core.py
@@ -323,7 +323,7 @@ class SummaryState(DataQualityFlag):
             segs_ = SegmentList()
             # get start day
             d = Time(float(self.start), format='gps', scale='utc').datetime
-            d.replace(hour=0, minute=0, second=0, microsecond=0)
+            d = d.replace(hour=0, minute=0, second=0, microsecond=0)
             end_ = Time(float(self.end), format='gps', scale='utc').datetime
             while d < end_:
                 # get GPS of day


### PR DESCRIPTION
Currently the "hours" option in a state is broken because the value for the day start is not being saved in the code. Basically the replace() method for a datetime object does not change the value in-place, it just returns the value. So essentially, all the broken code was doing was stating the day start but not actually using it. This fixes the problem