### PR TITLE
Added a new "metastate" section type where one can combine states from different detectors

### DIFF
--- a/gwsumm/config.py
+++ b/gwsumm/config.py
@@ -305,7 +305,7 @@ class GWSummConfigParser(configparser.ConfigParser):
         """Read and format a list of `SummaryState` definitions from the
         given :class:`~configparser.ConfigParser`
         """
-        from .state import (register_state, SummaryState,
+        from .state import (register_state, SummaryState, SummaryMetaState,
                             ALLSTATE, generate_all_state, get_state)
         # parse the [states] section into individual state definitions
         try:
@@ -327,6 +327,9 @@ class GWSummConfigParser(configparser.ConfigParser):
             if re.match(r'state[-\s]', section):
                 states.append(register_state(
                     SummaryState.from_ini(self, section)))
+            elif re.match(r'metastate[-\s]', section):
+                states.append(register_state(
+                    SummaryMetaState.from_ini(self, section)))
 
         # register All state
         start = self.getint(section, 'gps-start-time')

--- a/gwsumm/config.py
+++ b/gwsumm/config.py
@@ -307,21 +307,30 @@ class GWSummConfigParser(configparser.ConfigParser):
         """
         from .state import (register_state, SummaryState, SummaryMetaState,
                             ALLSTATE, generate_all_state, get_state)
-        # parse the [states] section into individual state definitions
+        # Parse the [states] section into individual state definitions.
+        # Each state definition is amended to the GWSummConfigParser as a new
+        # section with name and definition key-value pairs.
         try:
             states = dict(self.nditems(section))
         except configparser.NoSectionError:
             self.add_section(section)
             states = {}
         for state in states:
-            if not (self.has_section('state-%s' % state) or
-                    self.has_section('state %s' % state)):
-                section = 'state-%s' % state
+            if not (self.has_section(f'state-{state}') or
+                    self.has_section(f'state {state}')):
+                section = f'state-{state}'
                 self.add_section(section)
                 self.set(section, 'name', state)
                 self.set(section, 'definition', states[state])
 
-        # parse each state section into a new state
+        # Parse each state section into a new state.
+        # Here we reset the states variable to an empty list because the
+        # previous code block added all of the states section into their own
+        # sections [state-<state>]. We register those states and metastates,
+        # appending them also to the states list. Metastates are states that
+        # use another state definition, where they look for the key name. If
+        # key is not defined, then name is used instead. The key or name is
+        # expected to have an 'H1-' or 'L1-' prefix.
         states = []
         for section in self.sections():
             if re.match(r'state[-\s]', section):

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -41,7 +41,7 @@ from ..utils import re_cchar
 from ..data import (get_timeseries, get_spectrogram,
                     get_coherence_spectrogram, get_range_spectrogram,
                     get_spectrum, get_coherence_spectrum, get_range_spectrum)
-from ..state import ALLSTATE
+from ..state import ALLSTATE, SummaryMetaState
 from .registry import (get_plot, register_plot)
 from .mixins import DataLabelSvgMixin
 
@@ -507,6 +507,10 @@ class SpectrumDataPlot(DataPlot):
                 valid = self.state
             else:
                 valid = SegmentList([self.span])
+
+            if isinstance(valid, SummaryMetaState):
+                valid = globalv.STATES[
+                    f'{channel.ifo}-{valid.uses[0][3:]}'.lower()]
 
             if self.type == 'coherence-spectrum':
                 data = get_coherence_spectrum(

--- a/gwsumm/state/__init__.py
+++ b/gwsumm/state/__init__.py
@@ -55,9 +55,9 @@ API reference
 
 """
 
-from .core import SummaryState
+from .core import (SummaryState, SummaryMetaState)
 from .registry import (get_state, get_states, register_state)
 from .all import (ALLSTATE, generate_all_state)
 
 __all__ = ['ALLSTATE', 'SummaryState', 'get_state', 'get_states',
-           'register_state', 'generate_all_state']
+           'register_state', 'generate_all_state', 'SummaryMetaState']

--- a/gwsumm/state/core.py
+++ b/gwsumm/state/core.py
@@ -352,11 +352,43 @@ class SummaryState(DataQualityFlag):
 
 
 class SummaryMetaState(SummaryState):
-    """A meta state where different states may be used"""
+    """A meta state where different states may be used when processing a
+    `~gwsumm.tabs.DataTab`.
 
-    def __init__(self, name, known=SegmentList(), active=SegmentList(),
+    An example use ase is when one wants to plot two different state times on
+    the same plot. This currently has limitations as it expects the states to
+    be from different detectors. So when using this metastate, each value in
+    "uses" needs to be prefixed by "<IFO>"
+
+    Parameters
+    ----------
+    name : `str`
+        name for this state
+    uses : `list`
+        list of strings for which states to use. Ex.: ['H1-quiet', 'L1-quiet']
+    known : `~gwpy.segments.SegmentList`, optional
+        list of known segments
+    active : `~gwpy.segments.SegmentList`, optional
+        list of active segments
+    description : `str`, optional
+        text describing what this state means
+    definition : `str`, optional
+        logical combination of flags that define known and active segments
+        for this state (see :attr:`documentation <SummaryState.definition>`
+        for details)
+    hours : `str`, optional
+        a string of the form "<start>-<end>,<IFO|utc|local>"
+    key : `str`, optional
+        registry key for this state, defaults to :attr:`~SummaryState.name`
+    filename : `str`, optional
+        path to filename with segments
+    url : `str`, optional
+        URL to read the segments
+    """
+
+    def __init__(self, name, uses, known=SegmentList(), active=SegmentList(),
                  description=None, definition=None, hours=None, key=None,
-                 filename=None, url=None, uses=[]):
+                 filename=None, url=None):
 
         super(SummaryMetaState, self).__init__(
             name=name, known=known, active=active,
@@ -367,6 +399,21 @@ class SummaryMetaState(SummaryState):
 
     @classmethod
     def from_ini(cls, config, section):
+        """Create a new `SummaryMetaState` from a section in a `ConfigParser`.
+
+        Parameters
+        ----------
+        config : :class:`~gwsumm.config.GWConfigParser`
+            customised configuration parser containing given section
+        section : `str`
+            name of section to parse
+
+        Returns
+        -------
+        `SummaryMetaState`
+            a new state, with attributes set from the options in the
+            configuration
+        """
         config = GWSummConfigParser.from_configparser(config)
         # get parameters
         params = dict(config.nditems(section))
@@ -384,6 +431,9 @@ class SummaryMetaState(SummaryState):
               segmentcache=None, segdb_error='raise',
               datacache=None, datafind_error='raise', nproc=1, nds=None,
               **kwargs):
+        """Finalise this state by fetching the states this metastate uses,
+        either from global memory, or from the segment database
+        """
 
         for idx, state in enumerate(self.uses):
             globalv.STATES[state.lower()].fetch(

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -357,6 +357,8 @@ class DataTab(ProcessedTab, ParentTab):
             datafind_error=stateargs.get('datafind_error', 'raise'),
             nproc=nproc, nds=stateargs.get('nds', None))
         vprint("States finalised [%d total]\n" % len(self.states))
+
+        # loop over states for this tab and print out information
         for state in self.states:
             if isinstance(state, SummaryMetaState):
                 vprint(

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -60,7 +60,8 @@ from ..data.timeseries import FRAMETYPE_REGEX
 from ..data.utils import get_fftparams
 from ..plot import get_plot
 from ..segments import get_segments
-from ..state import (generate_all_state, ALLSTATE, get_state)
+from ..state import (generate_all_state, ALLSTATE, get_state,
+                     SummaryMetaState)
 from ..triggers import get_triggers
 from ..utils import (re_flagdiv, vprint, safe_eval)
 
@@ -357,11 +358,22 @@ class DataTab(ProcessedTab, ParentTab):
             nproc=nproc, nds=stateargs.get('nds', None))
         vprint("States finalised [%d total]\n" % len(self.states))
         for state in self.states:
-            vprint("    {0.name}: {1} segments | {2} seconds".format(
-                state, len(state.active), abs(state.active)))
+            if isinstance(state, SummaryMetaState):
+                vprint(
+                    f"Metastate {state.key} has {len(state.uses)} states")
+            else:
+                vprint("    {0.name}: {1} segments | {2} seconds".format(
+                    state, len(state.active), abs(state.active)))
             if state is self.defaultstate:
                 vprint(" [DEFAULT]")
             vprint('\n')
+            if isinstance(state, SummaryMetaState):
+                for idx, this_state in enumerate(state.uses):
+                    vprint(f"    {this_state}: ")
+                    vprint(f"{len(globalv.STATES[this_state.lower()].active)} "
+                           "segments | ")
+                    vprint(f"{abs(globalv.STATES[this_state.lower()].active)} "
+                           "seconds\n")
 
         # pre-process requests for 'all-data' plots
         all_data = any([(p.all_data & p.new) for p in self.plots])

--- a/gwsumm/tests/test_config.py
+++ b/gwsumm/tests/test_config.py
@@ -186,6 +186,18 @@ class TestGWSummConfigParser(object):
         assert states['locked'].definition == 'X1:TEST-STATE:1'
         assert state.ALLSTATE in states
 
+    def test_load_state_metastate(self):
+        cp = self.new()
+        cp.set_date_options(0, 100)
+        cp.add_section('metastate-test')
+        cp.set('metastate-test', 'uses', 'locked')
+        cp.set('metastate-test', 'name', 'meta')
+        cp.load_states()
+        states = state.get_states()
+        assert len(states) == 3
+        assert 'meta' in states
+        assert states['meta'].uses == ['locked']
+
     def test_load_plugins(self, cnfg):
         # check that empty section doesn't cause havoc
         cp = self.PARSER()


### PR DESCRIPTION
This fixes a problem where the "Quiet" and "Noisy" states were undefined in time, so the whole duration was used. This meant there was no distinction between the states as plotted for the summary pages.

A metastate would be defined as
```
[metastate-Quiet]
key = Quiet
name = SEI Quiet
uses = H1-quiet,L1-quiet

[state-H1-Quiet]
name = SEI Quiet
key = H1-quiet
hours = 1-5,H1

[state-L1-Quiet]
name = SEI Quiet
key = L1-quiet
hours = 2-6,L1
```

It is not super robust in that it's really only supposed to be used for combining some interval for H1 and some interval for L1. I'm not sure it's really ready to be heavily used in many situations

Addresses the comment in #358