### PR TITLE
Add support for specifying range method

### DIFF
--- a/gwsumm/plot/range.py
+++ b/gwsumm/plot/range.py
@@ -55,6 +55,7 @@ RAN_DICT = {
         'burst_range_psd': gwpy.astro.burst_range_spectrum,
 }
 
+
 def _get_params(keys, pargs, nchans=1):
     """Return a `dict` of `list` of plot arguments for every channel
     """
@@ -113,6 +114,7 @@ class RangePlotMixin(object):
             # replace range_func arg with correct method
             if 'range_func' in rangekwargs.keys():
                 rangekwargs['range_func'] = RAN_DICT[rangekwargs['range_func']]
+                print(rangekwargs['range_func'])
             rlist = self.range_func(channel, valid, query=self.read,
                                     **fftkwargs, **rangekwargs)
             try:

--- a/gwsumm/plot/range.py
+++ b/gwsumm/plot/range.py
@@ -27,6 +27,7 @@ import numpy
 
 from matplotlib.ticker import (LogLocator, MaxNLocator)
 
+import gwpy.astro
 from gwpy.segments import (Segment, SegmentList)
 from gwpy.timeseries import TimeSeries
 
@@ -44,6 +45,15 @@ __credits__ = 'Alex Urban <alexander.urban@ligo.org>'
 
 
 # -- utils --------------------------------------------------------------------
+
+RAN_DICT = {
+        'sensemon_range': gwpy.astro.sensemon_range,
+        'sensemon_range_psd': gwpy.astro.sensemon_range_psd,
+        'inspiral_range': gwpy.astro.inspiral_range,
+        'inspiral_range_psd': gwpy.astro.inspiral_range_psd,
+        'burst_range': gwpy.astro.burst_range,
+        'burst_range_psd': gwpy.astro.burst_range_spectrum,
+}
 
 def _get_params(keys, pargs, nchans=1):
     """Return a `dict` of `list` of plot arguments for every channel
@@ -79,7 +89,7 @@ class RangePlotMixin(object):
             ['stride', 'fftlength', 'overlap'],
             self.pargs, nchans=len(self.channels))
         self.rangeparams = _get_params(
-            ['mass1', 'mass2', 'snr', 'energy', 'fmin', 'fmax'],
+            ['mass1', 'mass2', 'snr', 'energy', 'fmin', 'fmax', 'range_func'],
             self.pargs, nchans=len(self.channels))
         self.range_func = (get_range_spectrogram if
                            'spec' in self.type else get_range)
@@ -100,6 +110,9 @@ class RangePlotMixin(object):
                 valid = self.state.active
             else:
                 valid = SegmentList([self.span])
+            # replace range_func arg with correct method
+            if 'range_func' in rangekwargs.keys():
+                rangekwargs['range_func'] = RAN_DICT[rangekwargs['range_func']]
             rlist = self.range_func(channel, valid, query=self.read,
                                     **fftkwargs, **rangekwargs)
             try:

--- a/gwsumm/plot/range.py
+++ b/gwsumm/plot/range.py
@@ -114,7 +114,6 @@ class RangePlotMixin(object):
             # replace range_func arg with correct method
             if 'range_func' in rangekwargs.keys():
                 rangekwargs['range_func'] = RAN_DICT[rangekwargs['range_func']]
-                print(rangekwargs['range_func'])
             rlist = self.range_func(channel, valid, query=self.read,
                                     **fftkwargs, **rangekwargs)
             try:


### PR DESCRIPTION
This PR adds support for specifying the `range_func` when generating range-related plots. This is done using a dictionary of methods, meaning that if new methods are added to gwpy, this dict needs to be updated accordingly. 

An example of this functionality can be seen here in the bottom left plot (requires LIGO.org credentials):

https://ldas-jobs.ligo-wa.caltech.edu/~derek.davis/detchar/preO4/summary_test/noise_sub_page/day/20230328/cal/nonsens/