### PR TITLE
Use llhoft as short type for LIGO aggregated h(t)

### DIFF
--- a/gwsumm/data/timeseries.py
+++ b/gwsumm/data/timeseries.py
@@ -104,8 +104,8 @@ ADC_TYPES = {
 }
 
 SHORT_HOFT_TYPES = {  # map aggregated h(t) type to short h(t) type
-    'H1_HOFT_C00': 'H1_DMT_C00',
-    'L1_HOFT_C00': 'L1_DMT_C00',
+    'H1_HOFT_C00': 'H1_llhoft',
+    'L1_HOFT_C00': 'L1_llhoft',
     'V1Online': 'V1_llhoft',
 }
 


### PR DESCRIPTION
This PR patches `gwsumm.data.timeseries` to define `{H1,L1}_llhoft` as the 1-second equivalent of `{H1,L1}_HOFT_C00`, rather than the equivalent `*_DMT_C00` frames. The `llhoft` files are the official low-latency product that are cached for a period (~1 month) on LDAS and discoverable with `gwdatafind`.