### PR TITLE
Add mapping for HOFT_TEST frames

### DIFF
--- a/gwsumm/data/timeseries.py
+++ b/gwsumm/data/timeseries.py
@@ -107,6 +107,8 @@ SHORT_HOFT_TYPES = {  # map aggregated h(t) type to short h(t) type
     'H1_HOFT_C00': 'H1_DMT_C00',
     'L1_HOFT_C00': 'L1_DMT_C00',
     'V1Online': 'V1_llhoft',
+    'H1_HOFT_TEST': 'H1_DMT_TEST',
+    'L1_HOFT_TEST': 'L1_DMT_TEST',
 }
 
 VIRGO_HOFT_CHANNELS = {


### PR DESCRIPTION
This PR adds mapping for the aggregated HOFT_TEST to the 1-s long DMT_TEST frames