### PR TITLE
Enumerate variables needed by the HTCondor workflow

### DIFF
--- a/gwsumm/data/timeseries.py
+++ b/gwsumm/data/timeseries.py
@@ -553,7 +553,7 @@ def _get_timeseries_dict(channels, segments, config=None,
     if nds is None and cache is not None:
         nds = False
     elif nds is None:
-        nds = 'LIGO_DATAFIND_SERVER' not in os.environ
+        nds = 'GWDATAFIND_SERVER' not in os.environ
 
     # read new data
     query &= (abs(new) > 0)


### PR DESCRIPTION
This PR closes #375 by replacing the use of `getenv=true` with a hardcoded set of environment variables to pass through from the submit environment.