### PR TITLE
Change the V1 h(t) mapping from original frame type to backup frame type

### DIFF
--- a/gwsumm/data/timeseries.py
+++ b/gwsumm/data/timeseries.py
@@ -107,6 +107,7 @@ SHORT_HOFT_TYPES = {  # map aggregated h(t) type to short h(t) type
     'H1_HOFT_C00': 'H1_DMT_C00',
     'L1_HOFT_C00': 'L1_DMT_C00',
     'HoftOnline': 'V1_llhoft',
+    'V1Online': 'V1_llhoft',
     'H1_HOFT_TEST': 'H1_DMT_TEST',
     'L1_HOFT_TEST': 'L1_DMT_TEST',
 }

--- a/gwsumm/data/timeseries.py
+++ b/gwsumm/data/timeseries.py
@@ -106,7 +106,7 @@ ADC_TYPES = {
 SHORT_HOFT_TYPES = {  # map aggregated h(t) type to short h(t) type
     'H1_HOFT_C00': 'H1_DMT_C00',
     'L1_HOFT_C00': 'L1_DMT_C00',
-    'V1Online': 'V1_llhoft',
+    'HoftOnline': 'V1_llhoft',
     'H1_HOFT_TEST': 'H1_DMT_TEST',
     'L1_HOFT_TEST': 'L1_DMT_TEST',
 }


### PR DESCRIPTION
This PR changes the V1 frametype mapping for HoftOnline channels to use a backup V1_llhoft frametype

This should be merged and deployed carefully since until the configuration file are appropriately changed, the deployment could break the network summary pages