### PR TITLE
Fix case when data is missing at beginning of vt span

### DIFF
--- a/gwsumm/plot/range.py
+++ b/gwsumm/plot/range.py
@@ -271,7 +271,7 @@ class SimpleTimeVolumeDataPlot(get_plot('segments')):
         min_x0 = min([r.x0.value for r in allranges])
         for i, r in enumerate(allranges):
             if r.x0.value > min_x0:
-                missing = int( (r.x0.value - min_x0) / r.dx.value)
+                missing = int((r.x0.value - min_x0) / r.dx.value)
                 allranges[i] = r.pad((missing, 0))
         try:
             combined_range = TimeSeries(numpy.zeros(allranges[0].size),

--- a/gwsumm/plot/range.py
+++ b/gwsumm/plot/range.py
@@ -272,7 +272,7 @@ class SimpleTimeVolumeDataPlot(get_plot('segments')):
         # find the earliest time we have any data
         min_x0 = min([r.x0.value for r in allranges])
         for i, r in enumerate(allranges):
-            # pad all range time series that don't start at min_x0 
+            # pad all range time series that don't start at min_x0
             # so that all time series have the same start time
             if r.x0.value > min_x0:
                 missing = int((r.x0.value - min_x0) / r.dx.value)

--- a/gwsumm/plot/range.py
+++ b/gwsumm/plot/range.py
@@ -264,6 +264,15 @@ class SimpleTimeVolumeDataPlot(get_plot('segments')):
         return (4/3. * pi * ts * range ** 3).to('Mpc^3 kyr')
 
     def combined_time_volume(self, allsegments, allranges):
+        empty = [i for i, r in enumerate(allranges) if not len(r.value)]
+        for i in empty[-1:]:
+            allsegments.pop(i)
+            allranges.pop(i)
+        min_x0 = min([r.x0.value for r in allranges])
+        for i, r in enumerate(allranges):
+            if r.x0.value > min_x0:
+                missing = int( (r.x0.value - min_x0) / r.dx.value)
+                allranges[i] = r.pad((missing, 0))
         try:
             combined_range = TimeSeries(numpy.zeros(allranges[0].size),
                                         xindex=allranges[0].times, unit='Mpc')

--- a/gwsumm/plot/range.py
+++ b/gwsumm/plot/range.py
@@ -264,12 +264,16 @@ class SimpleTimeVolumeDataPlot(get_plot('segments')):
         return (4/3. * pi * ts * range ** 3).to('Mpc^3 kyr')
 
     def combined_time_volume(self, allsegments, allranges):
+        # first remove any IFOs that have no range data at all
         empty = [i for i, r in enumerate(allranges) if not len(r.value)]
         for i in empty[::-1]:
             allsegments.pop(i)
             allranges.pop(i)
+        # find the earliest time we have any data
         min_x0 = min([r.x0.value for r in allranges])
         for i, r in enumerate(allranges):
+            # pad all range time series that don't start at min_x0 
+            # so that all time series have the same start time
             if r.x0.value > min_x0:
                 missing = int((r.x0.value - min_x0) / r.dx.value)
                 allranges[i] = r.pad((missing, 0))

--- a/gwsumm/plot/range.py
+++ b/gwsumm/plot/range.py
@@ -265,7 +265,7 @@ class SimpleTimeVolumeDataPlot(get_plot('segments')):
 
     def combined_time_volume(self, allsegments, allranges):
         empty = [i for i, r in enumerate(allranges) if not len(r.value)]
-        for i in empty[-1:]:
+        for i in empty[::-1]:
             allsegments.pop(i)
             allranges.pop(i)
         min_x0 = min([r.x0.value for r in allranges])


### PR DESCRIPTION
This PR addresses #381 so that the combined VT calculation is correct in all cases where data from at least one detector is missing. 

In cases where data is entirely missing from one detector, this detector also is no longer considered during the combined VT calculation. 

This PR can be tested by running the O4a summary command with the production archive file. 