### PR TITLE
Update Axes.grid keyword to use 'visible'

### DIFF
--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -143,7 +143,7 @@ class TimeSeriesDataPlot(DataLabelSvgMixin, DataPlot):
                 ax.set_epoch(float(epoch if epoch is not None else self.start))
                 if ax.get_autoscalex_on():
                     ax.set_xlim(float(self.start), float(self.end))
-            ax.grid(True, which='both')
+            ax.grid(visible=True, which='both')
         return plot
 
     # -- main draw method -----------------------
@@ -319,7 +319,7 @@ class SpectrogramDataPlot(TimeSeriesDataPlot):
         # initialise
         plot = self.init_plot()
         ax = plot.gca()
-        ax.grid(b=True, axis='y', which='major')
+        ax.grid(visible=True, axis='y', which='major')
         channel = self.channels[0]
 
         # parse data arguments
@@ -463,7 +463,7 @@ class SpectrumDataPlot(DataPlot):
         """
         plot = self.init_plot()
         ax = plot.gca()
-        ax.grid(b=True, axis='both', which='both')
+        ax.grid(visible=True, axis='both', which='both')
 
         if self.state:
             self.pargs.setdefault(
@@ -661,7 +661,7 @@ class TimeSeriesHistogramPlot(DataPlot):
         plot = super(TimeSeriesHistogramPlot, self).init_plot(
             geometry=geometry, **kwargs)
         for ax in plot.axes:
-            ax.grid(True, which='both')
+            ax.grid(visible=True, which='both')
         return plot
 
     def parse_plot_kwargs(self, **defaults):
@@ -982,7 +982,7 @@ class SpectralVarianceDataPlot(SpectrumDataPlot):
         # customise
         self.add_hvlines()
         self.apply_parameters(ax, **self.pargs)
-        ax.grid(b=True, axis='both', which='both')
+        ax.grid(visible=True, axis='both', which='both')
 
         return self.finalize()
 

--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -791,7 +791,7 @@ class DataPlot(SummaryPlot):
 
     def _apply_grid_params(self, ax, val):
         if val in ('major', 'minor'):
-            ax.grid(True, which=val)
+            ax.grid(visible=True, which=val)
         else:
             ax.grid(val)
 

--- a/gwsumm/plot/noisebudget.py
+++ b/gwsumm/plot/noisebudget.py
@@ -73,7 +73,7 @@ class NoiseBudgetPlot(get_plot('spectrum')):
         """
         plot = self.init_plot()
         ax = plot.gca()
-        ax.grid(b=True, axis='both', which='both')
+        ax.grid(visible=True, axis='both', which='both')
 
         if self.state:
             self.pargs.setdefault(
@@ -175,7 +175,7 @@ class RelativeNoiseBudgetPlot(get_plot('spectrum')):
         """
         plot = self.init_plot()
         ax = plot.gca()
-        ax.grid(b=True, axis='both', which='both')
+        ax.grid(visible=True, axis='both', which='both')
 
         if self.state:
             self.pargs.setdefault(

--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -847,7 +847,7 @@ class ODCDataPlot(SegmentLabelSvgMixin, StateVectorDataPlot):
         # make figure
         plot = self.init_plot()
         ax = plot.gca()
-        ax.grid(False, which='both', axis='y')
+        ax.grid(visible=False, which='both', axis='y')
 
         # extract plotting arguments
         nosummary = self.pargs.pop('no_summary_bit', False)
@@ -1272,7 +1272,7 @@ class SegmentBarPlot(BarPlot, SegmentDataPlot):
                            rotation_mode='anchor', ha='right', fontsize=13)
         ax.tick_params(axis='x', pad=2)
         ax.xaxis.labelpad = 2
-        ax.xaxis.grid(False)
+        ax.xaxis.grid(visible=False)
         self.pargs.setdefault('xlim', (-.5, len(data)-.5))
 
         # customise plot

--- a/gwsumm/plot/triggers/core.py
+++ b/gwsumm/plot/triggers/core.py
@@ -144,7 +144,7 @@ class TriggerDataPlot(TriggerPlotMixin, TimeSeriesDataPlot):
         # initialise figure
         plot = self.init_plot()
         ax = plot.gca()
-        ax.grid(True, which='both')
+        ax.grid(visible=True, which='both')
 
         # work out labels
         labels = self.pargs.pop('labels', self.channels)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "lxml",
   "markdown",
   "MarkupPy",
-  "matplotlib >=3.1",
+  "matplotlib >=3.5",
   "numpy >=1.16",
   "pygments >=2.7.0",
   "python-dateutil",


### PR DESCRIPTION
This PR updates the Axes.grid keyword arguments to use `visible` that is needed because of upstream `matplotlib` updates.

This PR replaces #368