### PR TITLE
Add RangeCumulativeHistogramPlot class

### DIFF
--- a/gwsumm/plot/__init__.py
+++ b/gwsumm/plot/__init__.py
@@ -98,6 +98,7 @@ from .range import (
     RangeSpectrogramDataPlot,
     RangeSpectrumDataPlot,
     RangeCumulativeSpectrumDataPlot,
+    RangeCumulativeHistogramPlot,
     SimpleTimeVolumeDataPlot,
     GWpyTimeVolumeDataPlot,
 )

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -711,7 +711,9 @@ class TimeSeriesHistogramPlot(DataPlot):
         # plot
         for ax, arr, pargs in zip(cycle(axes), data, histargs):
             # set range if not given
-            if pargs.get('range') is None:
+            # but leave is as None in the cumulative histogram, this avoids
+            # the histogram to extend to x > y(x) = 1
+            if pargs.get('range') is None and self.type != 'range-cumulative-histogram':
                 pargs['range'] = self._get_range(
                     data,
                     # use range from first dataset if already calculated

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -730,11 +730,6 @@ class TimeSeriesHistogramPlot(DataPlot):
             if pargs.get('range')[1] == 'max':
                 pargs['range'] = (pargs['range'][0], arr.max().value)
 
-            # Remove data with range smaller than 1 Mpc for cumulative plot
-            if self.type == 'range-cumulative-histogram':
-                arr = numpy.array(arr)
-                arr = arr[arr>=1]
-
             # plot histogram
             _, _, patches = ax.hist(arr, **pargs)
 

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -718,7 +718,7 @@ class TimeSeriesHistogramPlot(DataPlot):
                 # use xlim if manually set (user or INI)
                 xlim=None if ax.get_autoscalex_on() else ax.get_xlim(),
             )
-            
+
             # plot histogram
             _, _, patches = ax.hist(arr, **pargs)
 
@@ -759,20 +759,20 @@ class TimeSeriesHistogramPlot(DataPlot):
 
     def _get_range(self, data, range=None, xlim=None):
         if range is not None:
-                if range == 'autoscaling':
-                    return None
-                else:
-                    range = list(range)
-                    try:
-                        if range[0] == 'min':
-                            range[0] = numpy.min(data)
-                        if range[1] == 'max':
-                            range[1] = numpy.max(data)
-                        if range[0] < range[1]:
-                            return range
-                    except (ValueError, IndexError) as exc:
-                        if not str(exc).startswith('zero-size array'):
-                            raise
+            if range == 'autoscaling':
+                return None
+            else:
+                range = list(range)
+                try:
+                    if range[0] == 'min':
+                        range[0] = numpy.min(data)
+                    if range[1] == 'max':
+                        range[1] = numpy.max(data)
+                    if range[0] < range[1]:
+                        return range
+                except (ValueError, IndexError) as exc:
+                    if not str(exc).startswith('zero-size array'):
+                        raise
         if xlim is not None:
             return xlim
         try:

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -723,12 +723,16 @@ class TimeSeriesHistogramPlot(DataPlot):
             # Add the option to enable autoscaling
             if pargs.get('range') == 'autoscaling':
                 pargs['range'] = None
-            # Add option to set the minimum range based on the data
-            if pargs.get('range')[0] == 'min':
-                pargs['range'] = (arr.min().value, pargs['range'][1])
-            # Add option to set the maximum range based on the data
-            if pargs.get('range')[1] == 'max':
-                pargs['range'] = (pargs['range'][0], arr.max().value)
+            if arr.size:
+                # Add option to set the minimum range based on the data
+                if pargs.get('range')[0] == 'min':
+                    pargs['range'] = (arr.min().value, pargs['range'][1])
+                # Add option to set the maximum range based on the data
+                if pargs.get('range')[1] == 'max':
+                    pargs['range'] = (pargs['range'][0], arr.max().value)
+            else:
+                # If arr is empty reset the range parameter
+                pargs['range'] = None
 
             # plot histogram
             _, _, patches = ax.hist(arr, **pargs)

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -711,9 +711,7 @@ class TimeSeriesHistogramPlot(DataPlot):
         # plot
         for ax, arr, pargs in zip(cycle(axes), data, histargs):
             # set range if not given
-            # but leave is as None in the cumulative histogram, this avoids
-            # the histogram to extend to x > y(x) = 1
-            if pargs.get('range') is None and self.type != 'range-cumulative-histogram':
+            if pargs.get('range') is None:
                 pargs['range'] = self._get_range(
                     data,
                     # use range from first dataset if already calculated
@@ -721,6 +719,16 @@ class TimeSeriesHistogramPlot(DataPlot):
                     # use xlim if manually set (user or INI)
                     xlim=None if ax.get_autoscalex_on() else ax.get_xlim(),
                 )
+
+            # Add the option to enable autoscaling
+            if pargs.get('range') == 'autoscaling':
+                pargs['range'] = None
+            # Add option to set the minimum range based on the data
+            if pargs.get('range')[0] == 'min':
+                pargs['range'] = (arr.min().value, pargs['range'][1])
+            # Add option to set the maximum range based on the data
+            if pargs.get('range')[1] == 'max':
+                pargs['range'] = (pargs['range'][0], arr.max().value)
 
             # Remove data with range smaller than 1 Mpc for cumulative plot
             if self.type == 'range-cumulative-histogram':

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -722,6 +722,11 @@ class TimeSeriesHistogramPlot(DataPlot):
                     xlim=None if ax.get_autoscalex_on() else ax.get_xlim(),
                 )
 
+            # Remove data with range smaller than 1 Mpc for cumulative plot
+            if self.type == 'range-cumulative-histogram':
+                arr = numpy.array(arr)
+                arr = arr[arr>=1]
+
             # plot histogram
             _, _, patches = ax.hist(arr, **pargs)
 

--- a/gwsumm/plot/range.py
+++ b/gwsumm/plot/range.py
@@ -152,6 +152,21 @@ class RangeDataHistogramPlot(RangePlotMixin, get_plot('histogram')):
 
 register_plot(RangeDataHistogramPlot)
 
+class RangeCumulativeHistogramPlot(RangePlotMixin, get_plot('histogram')):
+    type = 'range-cumulative-histogram'
+    defaults = get_plot('histogram').defaults.copy()
+    defaults.update(RangePlotMixin.defaults.copy())
+    defaults.update({
+        'xlabel': 'Angle-averaged range [Mpc]',
+        'ylabel': 'Cumulative time duration',
+        'log': False,
+        'cumulative': True,
+        'density': True,
+    })
+
+
+register_plot(RangeCumulativeHistogramPlot)
+
 
 class RangeSpectrogramDataPlot(RangePlotMixin, get_plot('spectrogram')):
     type = 'range-spectrogram'

--- a/gwsumm/plot/range.py
+++ b/gwsumm/plot/range.py
@@ -162,11 +162,11 @@ class RangeCumulativeHistogramPlot(RangePlotMixin, get_plot('histogram')):
         'log': False,
         'cumulative': True,
         'density': True,
+        'range': (1, 'max'),
     })
 
 
 register_plot(RangeCumulativeHistogramPlot)
-
 
 class RangeSpectrogramDataPlot(RangePlotMixin, get_plot('spectrogram')):
     type = 'range-spectrogram'

--- a/gwsumm/plot/range.py
+++ b/gwsumm/plot/range.py
@@ -152,6 +152,7 @@ class RangeDataHistogramPlot(RangePlotMixin, get_plot('histogram')):
 
 register_plot(RangeDataHistogramPlot)
 
+
 class RangeCumulativeHistogramPlot(RangePlotMixin, get_plot('histogram')):
     type = 'range-cumulative-histogram'
     defaults = get_plot('histogram').defaults.copy()
@@ -167,6 +168,7 @@ class RangeCumulativeHistogramPlot(RangePlotMixin, get_plot('histogram')):
 
 
 register_plot(RangeCumulativeHistogramPlot)
+
 
 class RangeSpectrogramDataPlot(RangePlotMixin, get_plot('spectrogram')):
     type = 'range-spectrogram'

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -266,7 +266,7 @@ class DataTab(ProcessedTab, ParentTab):
             if cp.has_section(pdef):
                 type_ = cp.get(pdef, 'type')
                 PlotClass = get_plot(type_)
-            elif (pdef not in ['range-histogram', 'segment-histogram', 
+            elif (pdef not in ['range-histogram', 'segment-histogram',
                                'range-cumulative-histogram'] and
                     pdef.endswith('-histogram')):
                 type_ = None

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -266,7 +266,7 @@ class DataTab(ProcessedTab, ParentTab):
             if cp.has_section(pdef):
                 type_ = cp.get(pdef, 'type')
                 PlotClass = get_plot(type_)
-            elif (pdef not in ['range-histogram', 'segment-histogram'] and
+            elif (pdef not in ['range-histogram', 'segment-histogram', 'range-cumulative-histogram'] and
                     pdef.endswith('-histogram')):
                 type_ = None
                 etg, column = pdef.rsplit('-', 2)[:2]

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -266,7 +266,8 @@ class DataTab(ProcessedTab, ParentTab):
             if cp.has_section(pdef):
                 type_ = cp.get(pdef, 'type')
                 PlotClass = get_plot(type_)
-            elif (pdef not in ['range-histogram', 'segment-histogram', 'range-cumulative-histogram'] and
+            elif (pdef not in ['range-histogram', 'segment-histogram', 
+                               'range-cumulative-histogram'] and
                     pdef.endswith('-histogram')):
                 type_ = None
                 etg, column = pdef.rsplit('-', 2)[:2]


### PR DESCRIPTION
This pull request introduces the `RangeCumulativeHistogramPlot` class, derived from `RangePlotMixin`. This new class facilitates the creation of cumulative density histograms within a specified range.

Additionally, this PR includes the option to enable automatic scaling of the histogram in Matplotlib. This can be achieved by setting `range = None` when defining it as `'autoscaling'`.  Similarly, the `'max'` and `'min'` options are also added to scale the histogram based on the data.

# Important observation
The `RangeCumulativeHistogramPlot` class will be computed from the $h(t)$ channel, therefore it is not the most efficient way to plot the cumulative histogram for the BNS range.  It is faster to use the `DMT-SNSL_EFFECTIVE_RANGE_MPC` channel and the standard `histogram` plot type to do so.
