### PR TITLE
Add default `rcParams`

### DIFF
--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -212,7 +212,41 @@ class DataPlot(SummaryPlot):
     #: plot() call style
     _single_call = False
     #: dict of default plotting kwargs
-    defaults = {}
+    defaults = {
+        'animation.convert_args': ['-layers', 'OptimizePlus'],
+        'axes.axisbelow': False,
+        'axes.edgecolor': 'gray',
+        'axes.formatter.limits': [-3, 4],
+        'axes.formatter.use_mathtext': True,
+        'axes.grid': True,
+        'axes.labelpad': 5.0,
+        'axes.labelsize': 18.0,
+        'axes.titlesize': 22.0,
+        'contour.algorithm': 'mpl2014',
+        'figure.figsize': [12.0, 6.0],
+        'figure.labelsize': 'large',
+        'figure.labelweight': 'normal',
+        'font.sans-serif': ['Roboto'],
+        'grid.alpha': 0.5,
+        'grid.linewidth': 0.5,
+        'legend.edgecolor': 'inherit',
+        'legend.fancybox': False,
+        'legend.fontsize': 10.0,
+        'legend.handlelength': 1.0,
+        'legend.numpoints': 2,
+        'mathtext.bf': 'Roboto',
+        'mathtext.cal': 'Calligraffiti',
+        'mathtext.fontset': 'custom',
+        'mathtext.it': 'Roboto:italic',
+        'mathtext.rm': 'Roboto',
+        'mathtext.sf': 'Roboto',
+        'mathtext.tt': 'Roboto Slab',
+        'savefig.transparent': True,
+        'svg.fonttype': 'none',
+        'text.parse_math': True,
+        'xtick.labelsize': 14.0,
+        'ytick.labelsize': 14.0,
+    }
     #: list of parameters parsed for `plot()` calls
     DRAW_PARAMS = list(putils.ARTIST_PARAMS)
 

--- a/gwsumm/tests/test_plot.py
+++ b/gwsumm/tests/test_plot.py
@@ -250,7 +250,7 @@ class TestDataPlot(TestSummaryPlot):
         assert plot.channels == [get_channel('X1:TEST'),
                                  get_channel('Y1:TEST')]
         assert plot.pargs == {'marker': 'o'}
-        assert plot.rcParams == {'figure.figsize': (2, 1)}
+        assert plot.rcParams == {'figure.figsize': (12., 6.)}
 
         cp.set('plot', 'type', 'blah')
         with pytest.warns(UserWarning):

--- a/gwsumm/tests/test_plot.py
+++ b/gwsumm/tests/test_plot.py
@@ -250,7 +250,7 @@ class TestDataPlot(TestSummaryPlot):
         assert plot.channels == [get_channel('X1:TEST'),
                                  get_channel('Y1:TEST')]
         assert plot.pargs == {'marker': 'o'}
-        assert plot.rcParams == {'figure.figsize': (12., 6.)}
+        assert plot.rcParams['figure.figsize'] == (2, 1)
 
         cp.set('plot', 'type', 'blah')
         with pytest.warns(UserWarning):


### PR DESCRIPTION
This pull request introduces default `rcParams`, ensuring that plots have the desired appearance without the necessity of activating the `ligo-summary-3.10` Conda environment.

These parameters were obtained by comparing the `matplotlib.rcParams` differences between `igwn` and `ligo-summary-3.10` Conda environments.