### PR TITLE
Add reading permission to the archive file

### DIFF
--- a/gwsumm/archive.py
+++ b/gwsumm/archive.py
@@ -176,6 +176,8 @@ def write_data_archive(outfile, channels=True, timeseries=True,
 
         # moves the new file to the backup directory
         shutil.move(temp_outfile, outfile)
+        # Changes permission to allow reading from any user
+        os.chmod(outfile, 0o664)
 
     except Exception:
         # if it fails for any reason, raise and continue


### PR DESCRIPTION
#378 changed the creation of the archive file from a temporary file, to avoid loosing backups. By construction, [`NamedTemporaryFile` gives sets the permission to 600](https://stackoverflow.com/a/10541972). In this PR the permission of the newly created archive file is reset to 664, which grants reading permission to any user. 