### PR TITLE
Fix for gaps in segments causing unfilled pie chart plots

### DIFF
--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -1029,11 +1029,31 @@ class SegmentPiePlot(PiePlot, SegmentDataPlot):
             data.append(float(abs(segs.active)))
 
         # handle missing or future data
+        # TODO: There is something messed up about "labels" and
+        #       "label" that should be cleaned up
         total = float(sum(data))
-        if future or (total < alltime):
-            data.append(alltime - total)
+        current_alltime = globalv.NOW - int(self.span[0])
+        future_time = int(self.span[1]) - globalv.NOW
+        if ((future_time > 0 and total < current_alltime) or
+                (future_time <= 0 and total < alltime)):
+            if future_time > 0 and total < current_alltime:
+                data.append(current_alltime - total)
+            else:
+                data.append(alltime - total)
+            if 'labels' in plotargs:
+                plotargs['labels'] = (
+                    list(plotargs['labels']) + ['Missing segments'])
+            elif 'label' in plotargs:
+                plotargs['label'] = (
+                    list(plotargs['label']) + ['Missing segments'])
+            if 'colors' in plotargs:
+                plotargs['colors'] = list(plotargs['colors']) + ['red']
+        if future:
+            data.append(future_time)
             if 'labels' in plotargs:
                 plotargs['labels'] = list(plotargs['labels']) + [' ']
+            elif 'label' in plotargs:
+                plotargs['label'] = list(plotargs['label']) + [' ']
             if 'colors' in plotargs:
                 plotargs['colors'] = list(plotargs['colors']) + ['white']
 


### PR DESCRIPTION
This PR addresses a problem that there could be gaps in the segments, thus resulting in pie chart plots that can remain unfilled.

Here is an example for O4a.3: https://ldas-jobs.ligo.caltech.edu/~evan.goetz/summary/gps/1384873218-1389456018/segments/
Here is an example for "O4a.4" Dec 1 2023 - Jan 31 2024 ran on Jan 25 2024: https://ldas-jobs.ligo.caltech.edu/~evan.goetz/summary/gps/1385424018-1390694418/segments/

For reference, this is what the "O4a.4" interval run using the current gwsumm code: https://ldas-jobs.ligo.caltech.edu/~evan.goetz/summary/gps/1385424018-1390694419/segments/

We might consider changing the colors for the single IFO pie wedges in the `.ini` configuration file since the red pie wedges tend to blend together. Or we can chose a different color for the "Missing segments" wedge