### PR TITLE
Bugfix for empty trigger tables

### DIFF
--- a/gwsumm/triggers.py
+++ b/gwsumm/triggers.py
@@ -281,11 +281,11 @@ def get_triggers(channel, etg, segments, config=GWSummConfigParser(),
             if 'fstart' in columns and 'fend' in columns:
                 for colval in ['bandwidth', 'central_freq']:
                     if colval not in columns:
-                        columns.extend(colval)
+                        columns.extend([colval])
             if ('tstart' in columns and
                     'tend' in columns and
                     'duration' not in columns):
-                columns.extend('duration')
+                columns.extend(['duration'])
             tab = EventTable(names=columns)
         else:  # map to LIGO_LW table with full column listing
             tab = EventTable(lsctables.New(TableClass))


### PR DESCRIPTION
This PR fixes the empty table where we want to extend the columns. There was a bug when using `extend('foo')`. It should be `extend(['foo'])`.