### PR TITLE
Update default omicron trigger reading behaviour

### DIFF
--- a/gwsumm/triggers.py
+++ b/gwsumm/triggers.py
@@ -86,9 +86,9 @@ ETG_READ_KW = {
         'format': 'ascii',
     },
     'omicron': {
-        'format': 'ligolw',
-        'tablename': 'sngl_burst',
-        'use_numpy_dtypes': True,
+        'format': 'hdf5',
+        'path': '/triggers',
+        'trigfind-ext': 'h5',
     },
     'pycbc_live': {
         'format': 'hdf5.pycbc_live',


### PR DESCRIPTION
This PR updates the default omicron trigger reading behaviour from xml files to hdf5 files. This is needed especially for `gwsumm.plot.triggers` since there is no current input mechanism for deciding from which files to read triggers.