### PR TITLE
Import iterutils module from lal instead of glue

### DIFF
--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -35,7 +35,7 @@ from matplotlib.artist import setp
 from matplotlib.colors import (rgb2hex, is_color_like, TABLEAU_COLORS)
 from matplotlib.patches import Rectangle
 
-from glue import iterutils
+from lal import iterutils
 
 from gwpy.plot.colors import (GW_OBSERVATORY_COLORS, tint)
 from gwpy.plot.segments import SegmentRectangle


### PR DESCRIPTION
This PR moves an import of the `iterutils` module (not to be confused with the standard library module `itertools`) from `glue` to `lal`, the former has been deprecated for many years and is being removed.