### PR TITLE
Avoid sphinx-automodapi 0.17.0 when building docs on RTD

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -28,6 +28,6 @@ dependencies:
   # docs
   - numpydoc
   - sphinx
-  - sphinx-automodapi
+  - sphinx-automodapi !=0.17.0
   - sphinx_bootstrap_theme
   - sphinxcontrib-programoutput


### PR DESCRIPTION
This PR attempts to hack around the current readthedocs build failure by avoiding a package that is corrupt in the cache.