### PR TITLE
Fix state switcher menu going off screen

### DIFF
--- a/gwsumm/html/bootstrap.py
+++ b/gwsumm/html/bootstrap.py
@@ -152,7 +152,7 @@ def state_switcher(states, default=0):
            id_='states', role='button', title='Show/hide state menu',
            **{'data-bs-toggle': 'dropdown'})
     page.div(
-        class_='dropdown-menu dropdown-menu-right state-switch shadow',
+        class_='dropdown-menu dropdown-menu-end state-switch shadow',
         id_='statemenu',
     )
     page.h6('Select below to view this page in another state (different '

--- a/gwsumm/html/tests/test_bootstrap.py
+++ b/gwsumm/html/tests/test_bootstrap.py
@@ -84,7 +84,7 @@ def test_state_switcher():
         '<ul class="nav navbar-nav">\n<li class="nav-item dropdown">\n'
         '<a class="nav-link dropdown-toggle" href="#" id="states" role='
         '"button" title="Show/hide state menu" data-bs-toggle="dropdown">Test'
-        '</a>\n<div class="dropdown-menu dropdown-menu-right state-switch '
+        '</a>\n<div class="dropdown-menu dropdown-menu-end state-switch '
         'shadow" id="statemenu">\n<h6 class="dropdown-header">Select below to '
         'view this page in another state (different time segments).</h6>\n'
         '<div class="dropdown-divider"></div>\n<a class="dropdown-item state" '


### PR DESCRIPTION
The state switcher menu was going off screen in the new bootstrap version. This fixes the issue. See fixed version:
https://ldas-jobs.ligo-wa.caltech.edu/~iara.ota/summary/day/20240319/lock/glitches/