### PR TITLE
Fix spectrum plots for different states

### DIFF
--- a/gwsumm/data/range.py
+++ b/gwsumm/data/range.py
@@ -139,11 +139,13 @@ def get_range_spectrogram(channel, segments, config=None, cache=None,
 def get_range_spectrum(channel, segments, config=None, cache=None, query=True,
                        nds=None, return_=True, nproc=1, datafind_error='raise',
                        frametype=None, stride=60, fftlength=None, overlap=None,
-                       method=None, which='all', state='', **rangekwargs):
+                       method=None, which='all', state=None, **rangekwargs):
     """Compute percentile spectra of the range integrand from a set of
     spectrograms
     """
-    name = str(channel) + f',{state}'
+    name = str(channel)
+    if state:
+        name += f',{state}'
     cmin = f'{name}.min'
     cmax = f'{name}.max'
 

--- a/gwsumm/data/range.py
+++ b/gwsumm/data/range.py
@@ -117,7 +117,6 @@ def get_range_spectrogram(channel, segments, config=None, cache=None,
             add_spectrogram(outspec if 'energy' in rangekwargs else
                             outspec**(1/2.), key=key)
 
-
     if not return_:
         return
 

--- a/gwsumm/data/range.py
+++ b/gwsumm/data/range.py
@@ -117,15 +117,30 @@ def get_range_spectrogram(channel, segments, config=None, cache=None,
             add_spectrogram(outspec if 'energy' in rangekwargs else
                             outspec**(1/2.), key=key)
 
-    if return_:
-        return globalv.SPECTROGRAMS.get(key, SpectrogramList())
+
+    if not return_:
+        return
+
+    # return correct data, according to state segment
+    out = SpectrogramList()
+    for specgram in globalv.SPECTROGRAMS[key]:
+        for seg in segments:
+            if abs(seg) < specgram.dt.value:
+                continue
+            if specgram.span.intersects(seg):
+                common = specgram.span & type(seg)(seg[0],
+                                                   seg[1] + specgram.dt.value)
+                s = specgram.crop(*common)
+                if s.shape[0]:
+                    out.append(s)
+    return out.coalesce()
 
 
 @use_segmentlist
 def get_range_spectrum(channel, segments, config=None, cache=None, query=True,
                        nds=None, return_=True, nproc=1, datafind_error='raise',
                        frametype=None, stride=60, fftlength=None, overlap=None,
-                       method=None, which='all', state=None, **rangekwargs):
+                       method=None, which='all', state='', **rangekwargs):
     """Compute percentile spectra of the range integrand from a set of
     spectrograms
     """

--- a/gwsumm/data/range.py
+++ b/gwsumm/data/range.py
@@ -125,13 +125,13 @@ def get_range_spectrogram(channel, segments, config=None, cache=None,
 def get_range_spectrum(channel, segments, config=None, cache=None, query=True,
                        nds=None, return_=True, nproc=1, datafind_error='raise',
                        frametype=None, stride=60, fftlength=None, overlap=None,
-                       method=None, which='all', **rangekwargs):
+                       method=None, which='all', state=None, **rangekwargs):
     """Compute percentile spectra of the range integrand from a set of
     spectrograms
     """
-    name = str(channel)
-    cmin = '%s.min' % name
-    cmax = '%s.max' % name
+    name = str(channel) + f',{state}'
+    cmin = f'{name}.min'
+    cmax = f'{name}.max'
 
     if name not in globalv.SPECTRUM:
         speclist = get_range_spectrogram(
@@ -164,4 +164,4 @@ def get_range_spectrum(channel, segments, config=None, cache=None, query=True,
         return globalv.SPECTRUM[cmin]
     if which == 'max':
         return globalv.SPECTRUM[cmax]
-    raise ValueError("Unrecognised value for `which`: %r" % which)
+    raise ValueError(f"Unrecognised value for `which`: {which}")

--- a/gwsumm/data/spectral.py
+++ b/gwsumm/data/spectral.py
@@ -34,7 +34,6 @@ from scipy import interpolate
 
 from astropy import units
 
-from gwpy.segments import DataQualityFlag
 from gwpy.frequencyseries import FrequencySeries
 from gwpy.spectrogram import SpectrogramList
 

--- a/gwsumm/data/spectral.py
+++ b/gwsumm/data/spectral.py
@@ -327,7 +327,7 @@ def apply_transfer_function_series(specgram, tfunc):
 def get_spectrum(channel, segments, config=None, cache=None,
                  query=True, nds=None, format='power', return_=True,
                  frametype=None, nproc=1, datafind_error='raise',
-                 state='', **fftparams):
+                 state=None, **fftparams):
     """Retrieve the time-series and generate a spectrum of the given
     channel
     """
@@ -357,13 +357,15 @@ def get_spectrum(channel, segments, config=None, cache=None,
 
 def _get_spectrum(channel, segments, config=None, cache=None, query=True,
                   nds=None, format='power', return_=True, which='all',
-                  state='', **fftparams):
+                  state=None, **fftparams):
     """Retrieve the time-series and generate a spectrum of the given
     channel
     """
     channel = get_channel(channel)
 
-    name = f'{channel.ndsname},{state},{format}'
+    name = f'{channel.ndsname},{format}'
+    if state:
+        name = f'{channel.ndsname},{state},{format}'
     cmin = f'{name}.min'
     cmax = f'{name}.max'
 

--- a/gwsumm/data/spectral.py
+++ b/gwsumm/data/spectral.py
@@ -328,7 +328,7 @@ def apply_transfer_function_series(specgram, tfunc):
 def get_spectrum(channel, segments, config=None, cache=None,
                  query=True, nds=None, format='power', return_=True,
                  frametype=None, nproc=1, datafind_error='raise',
-                 state=None, **fftparams):
+                 state='', **fftparams):
     """Retrieve the time-series and generate a spectrum of the given
     channel
     """
@@ -358,7 +358,7 @@ def get_spectrum(channel, segments, config=None, cache=None,
 
 def _get_spectrum(channel, segments, config=None, cache=None, query=True,
                   nds=None, format='power', return_=True, which='all',
-                  state=None, **fftparams):
+                  state='', **fftparams):
     """Retrieve the time-series and generate a spectrum of the given
     channel
     """

--- a/gwsumm/data/spectral.py
+++ b/gwsumm/data/spectral.py
@@ -328,8 +328,8 @@ def apply_transfer_function_series(specgram, tfunc):
 def get_spectrum(channel, segments, config=None, cache=None,
                  query=True, nds=None, format='power', return_=True,
                  frametype=None, nproc=1, datafind_error='raise',
-                 **fftparams):
-    """Retrieve the time-series and generate a spectrogram of the given
+                 state=None, **fftparams):
+    """Retrieve the time-series and generate a spectrum of the given
     channel
     """
     channel = get_channel(channel)
@@ -338,7 +338,7 @@ def get_spectrum(channel, segments, config=None, cache=None,
         segments = segments.active
     else:
         name = channel.ndsname
-    name += ',%s' % format
+    name += f',{format}'
 
     # read data for all sub-channels
     specs = []
@@ -351,6 +351,7 @@ def get_spectrum(channel, segments, config=None, cache=None,
                                    return_=return_, frametype=frametype,
                                    nproc=nproc,
                                    datafind_error=datafind_error,
+                                   state=state,
                                    **fftparams))
     if return_ and len(channels) == 1:
         return specs[0]
@@ -363,8 +364,8 @@ def get_spectrum(channel, segments, config=None, cache=None,
 
 def _get_spectrum(channel, segments, config=None, cache=None, query=True,
                   nds=None, format='power', return_=True, which='all',
-                  **fftparams):
-    """Retrieve the time-series and generate a spectrogram of the given
+                  state=None, **fftparams):
+    """Retrieve the time-series and generate a spectrum of the given
     channel
     """
     channel = get_channel(channel)
@@ -373,9 +374,9 @@ def _get_spectrum(channel, segments, config=None, cache=None, query=True,
         segments = segments.active
     else:
         name = channel.ndsname
-    name += ',%s' % format
-    cmin = '%s.min' % name
-    cmax = '%s.max' % name
+    name += f',{format},{state}'
+    cmin = f'{name}.min'
+    cmax = f'{name}.max'
 
     if name not in globalv.SPECTRUM:
         if os.path.isfile(channel.ndsname):
@@ -424,4 +425,4 @@ def _get_spectrum(channel, segments, config=None, cache=None, query=True,
         return globalv.SPECTRUM[cmin]
     if which == 'max':
         return globalv.SPECTRUM[cmax]
-    raise ValueError("Unrecognised value for `which`: %r" % which)
+    raise ValueError(f"Unrecognised value for `which`: {which}")

--- a/gwsumm/data/spectral.py
+++ b/gwsumm/data/spectral.py
@@ -333,12 +333,6 @@ def get_spectrum(channel, segments, config=None, cache=None,
     channel
     """
     channel = get_channel(channel)
-    if isinstance(segments, DataQualityFlag):
-        name = ','.join([channel.ndsname, segments.name])
-        segments = segments.active
-    else:
-        name = channel.ndsname
-    name += f',{format}'
 
     # read data for all sub-channels
     specs = []
@@ -369,12 +363,8 @@ def _get_spectrum(channel, segments, config=None, cache=None, query=True,
     channel
     """
     channel = get_channel(channel)
-    if isinstance(segments, DataQualityFlag):
-        name = ','.join([channel.ndsname, segments.name])
-        segments = segments.active
-    else:
-        name = channel.ndsname
-    name += f',{format},{state}'
+
+    name = f'{channel.ndsname},{state},{format}'
     cmin = f'{name}.min'
     cmax = f'{name}.max'
 

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -527,7 +527,8 @@ class SpectrumDataPlot(DataPlot):
             else:
                 try:
                     data = get_spectrum(str(channel), valid, query=False,
-                                        format=sdform, method=method)
+                                        format=sdform, method=method,
+                                        state=valid)
                 except ValueError as exc:
                     # math op failed beacuse one of the datasets is empty
                     if (

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -512,10 +512,11 @@ class SpectrumDataPlot(DataPlot):
                 data = get_coherence_spectrum(
                     [str(channel), str(channel2)], valid, query=False)
             elif self.type == 'range-spectrum':
-                data = get_range_spectrum(str(channel), valid, query=False)
+                data = get_range_spectrum(str(channel), valid, query=False,
+                                          state=valid)
             elif self.type == 'cumulative-range-spectrum':
-                data = get_range_spectrum(
-                    str(channel), valid, query=False, which='mean')
+                data = get_range_spectrum(str(channel), valid, query=False,
+                                          which='mean', state=valid)
                 if str(data.unit) == 'Mpc':
                     data = (data**3).cumsum() ** (1/3.)
                 else:


### PR DESCRIPTION
This PR addresses a bug related to computing the _spectrum_ for different states. Previously, the same spectrogram was being plotted for different states despite having different segments, due to a global variable storing spectrum data with identical keys for all states. This issue has been resolved by introducing the `state` argument to the `get_spectrum` and `get_spectrum_range` functions, using the state name as a key to differentiate spectrum data.

The original intention behind the removed snippet below

```python
if isinstance(segments, DataQualityFlag):	
    name = ','.join([channel.ndsname, segments.name])
    segments = segments.active
else:
    name = channel.ndsname
```
was to incorporate the state into the `name` variable. However, this condition always failed because of the decorator `use_segmentlist`, which was already reseting `segments = segments.active`, therefore making it impossible to insert the state in the `name` variable. With the introduction of the `state` variable, this redundant condition has been removed.

Additionally, the range _spectrogram_ also required fixing as it failed to change with the state. The code introduced mirrors that used in `_get_spectrogram` to ensure the correct data is returned.

## Example:
- h(t) spectrum: https://ldas-jobs.ligo-la.caltech.edu/~iara.ota/summary/day/20240322/lock/strain
- range spectrum and spectrogram: https://ldas-jobs.ligo-la.caltech.edu/~iara.ota/summary/day/20240322/lock/range/
- Network seimic noisy and quiet states: https://ldas-jobs.ligo.caltech.edu/~iara.ota/summary/day/20240325/sei/