### PR TITLE
Fix coherence spectrogram archive problem

### DIFF
--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -137,8 +137,8 @@ def _get_coherence_spectrogram(channel_pair, segments, config=None,
         globalv.COHERENCE_COMPONENTS.setdefault(ck, SpectrogramList())
         coherence_bkp[ck] = globalv.COHERENCE_COMPONENTS[ck]
 
-    # When coherence components contain different segments, 
-    # computing coherence for new segments can result in a 
+    # When coherence components contain different segments,
+    # computing coherence for new segments can result in a
     # ValueError traceback due to incompatible shapes.
     # To prevent this issue, we collect segments from all components,
     # clear them from the global variable, and then restore from the
@@ -152,7 +152,8 @@ def _get_coherence_spectrogram(channel_pair, segments, config=None,
     # keep only the intersection of the segments
     spans = reduce(operator.and_, spans).coalesce()
     # clean the components in the global variable
-    globalv.COHERENCE_COMPONENTS.update({ck: SpectrogramList() for ck in ckeys})
+    globalv.COHERENCE_COMPONENTS.update(
+        {ck: SpectrogramList() for ck in ckeys})
 
     # restore the data for segments available in all components
     for seg in spans:

--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -189,9 +189,6 @@ def _get_coherence_spectrogram(channel_pair, segments, config=None,
             req = new - globalv.COHERENCE_COMPONENTS.get(
                             ckey, SpectrogramList()).segments
 
-            # key used to store this component in globalv (incl sample rate)
-            ckey = ckeys[components.index(comp)]
-
             # get data if there are new segments
             if abs(req) != 0:
 

--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -29,7 +29,8 @@ import numpy
 
 from astropy import units
 
-from gwpy.segments import (DataQualityFlag, SegmentList, Segment, SegmentListDict)
+from gwpy.segments import (DataQualityFlag, SegmentList, 
+                           Segment, SegmentListDict)
 from gwpy.frequencyseries import FrequencySeries
 from gwpy.spectrogram import SpectrogramList
 
@@ -135,7 +136,8 @@ def _get_coherence_spectrogram(channel_pair, segments, config=None,
     coherence_bkp = {}
     for ck in ckeys:
         globalv.COHERENCE_COMPONENTS.setdefault(ck, SpectrogramList())
-        coherence_bkp[ck] = globalv.COHERENCE_COMPONENTS.get(ck, SpectrogramList())
+        coherence_bkp[ck] = globalv.COHERENCE_COMPONENTS.get(
+            ck, SpectrogramList())
 
     # When coherence components contain different segments,
     # computing coherence for new segments can result in a
@@ -148,7 +150,8 @@ def _get_coherence_spectrogram(channel_pair, segments, config=None,
     # get the segment spans from all components
     spans = SegmentListDict()
     for ck in ckeys:
-        spans[ck] = SegmentList([spec.span for spec in globalv.COHERENCE_COMPONENTS[ck]])
+        spans[ck] = SegmentList(
+            [spec.span for spec in globalv.COHERENCE_COMPONENTS[ck]])
     # keep only the intersection of the segments
     spans = spans.intersection(list(ckeys))
 

--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -29,7 +29,7 @@ import numpy
 
 from astropy import units
 
-from gwpy.segments import (DataQualityFlag, SegmentList, 
+from gwpy.segments import (DataQualityFlag, SegmentList,
                            Segment, SegmentListDict)
 from gwpy.frequencyseries import FrequencySeries
 from gwpy.spectrogram import SpectrogramList


### PR DESCRIPTION
This PR addresses the issue encountered when computing coherence, which leads to a ValueError due to incompatible shapes, as illustrated in the following example:

```
ValueError: operands could not be broadcast together with shapes (734,8193) (9,8193) 
```

This problem often arises from utilizing the same channel across different coherence plots. It may occur when additional data is available during the computation of another plot, causing discrepancies in the segments of `globalv.COHERENCE_COMPONENTS` for that channel and the previously computed channel when saved to the HDF5 archive.

To tackle this issue, this PR ensures that all coherence components used have consistent segments within the globalv.COHERENCE_COMPONENTS variable.

### Testing this PR

To test this PR copy the corrupted archive located in `/home/iara.ota/public_html/summary/day/20240410/archive/L1-LSC_COHERENCE-1396742418-86400.h5_bkp` to the local `/home/${USER}/public_html/summary/day/20240410/archive` folder and rename it to remove the `_bkp` suffix. Run the GWSumm process for the LSC Coherence tab with the detchar conda environment to make sure the archive is corrupted and then with this PR changes:

```bash
python -m gwsumm day --verbose --ifo L1 --on-segdb-error warn --on-datafind-error warn --output-dir /home/iara.ota/public_html/summary --config-file /home/detchar/public_html/summary/etc/defaults.ini,/home/detchar/public_html/summary/etc/global.ini,/home/iara.ota/src/ligo-summary-pages/configurations/common/lsc-coherence.ini --multi-process 32 --archive LSC_COHERENCE 20240410
```

Run example: https://ldas-jobs.ligo-la.caltech.edu/~iara.ota/summary/day/20240410/isc/coherence/
