### PR TITLE
Properly handle empty dictionary in get_range_spectrogram

### DIFF
--- a/gwsumm/data/range.py
+++ b/gwsumm/data/range.py
@@ -122,17 +122,22 @@ def get_range_spectrogram(channel, segments, config=None, cache=None,
 
     # return correct data, according to state segment
     out = SpectrogramList()
-    for specgram in globalv.SPECTROGRAMS[key]:
-        for seg in segments:
-            if abs(seg) < specgram.dt.value:
-                continue
-            if specgram.span.intersects(seg):
-                common = specgram.span & type(seg)(seg[0],
-                                                   seg[1] + specgram.dt.value)
-                s = specgram.crop(*common)
-                if s.shape[0]:
-                    out.append(s)
+    try:
+        for specgram in globalv.SPECTROGRAMS[key]:
+            for seg in segments:
+                if abs(seg) < specgram.dt.value:
+                    continue
+                if specgram.span.intersects(seg):
+                    common = specgram.span & type(seg)(seg[0],
+                                                    seg[1] + specgram.dt.value)
+                    s = specgram.crop(*common)
+                    if s.shape[0]:
+                        out.append(s)
+    except KeyError:
+        # in case the key does not exist return empty SpectrogramList
+        return out
     return out.coalesce()
+
 
 
 @use_segmentlist

--- a/gwsumm/data/range.py
+++ b/gwsumm/data/range.py
@@ -139,7 +139,6 @@ def get_range_spectrogram(channel, segments, config=None, cache=None,
     return out.coalesce()
 
 
-
 @use_segmentlist
 def get_range_spectrum(channel, segments, config=None, cache=None, query=True,
                        nds=None, return_=True, nproc=1, datafind_error='raise',

--- a/gwsumm/data/range.py
+++ b/gwsumm/data/range.py
@@ -128,8 +128,8 @@ def get_range_spectrogram(channel, segments, config=None, cache=None,
                 if abs(seg) < specgram.dt.value:
                     continue
                 if specgram.span.intersects(seg):
-                    common = specgram.span & type(seg)(seg[0],
-                                                    seg[1] + specgram.dt.value)
+                    common = specgram.span & type(seg)(
+                        seg[0], seg[1] + specgram.dt.value)
                     s = specgram.crop(*common)
                     if s.shape[0]:
                         out.append(s)


### PR DESCRIPTION
This PR addresses the bug introduced in #403 by acknowledging that `globalv.SPECTROGRAMS` might not contain the specified `key`. In such cases, it now correctly returns an empty `SpectrogramList()`, according to the previously removed code snippet: 

```python
return globalv.SPECTROGRAMS.get(key, SpectrogramList())
```