### PR TITLE
Ignore `nan` spectrogram values

### DIFF
--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -291,8 +291,8 @@ def _get_coherence_spectrogram(channel_pair, segments, config=None,
                 globalv.SPECTROGRAMS[key].coalesce()
             else:
                 warnings.warn('NaN values found in the spectrogram.'
-                                         ' Spectrogram will not be appended to'
-                                         ' global memory value')
+                              ' Spectrogram will not be appended to'
+                              ' global memory value')
 
     if not return_:
         return

--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -290,7 +290,9 @@ def _get_coherence_spectrogram(channel_pair, segments, config=None,
                 globalv.SPECTROGRAMS[key].append(csg)
                 globalv.SPECTROGRAMS[key].coalesce()
             else:
-                warnings.warn('NaN values found in the spectrogram.')
+                warnings.warn('NaN values found in the spectrogram.'
+                                         ' Spectrogram will not be appended to'
+                                         ' global memory value')
 
     if not return_:
         return

--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -286,8 +286,9 @@ def _get_coherence_spectrogram(channel_pair, segments, config=None,
             cxy, cxx, cyy = [_get_from_list(
                 globalv.COHERENCE_COMPONENTS[ck], seg) for ck in ckeys]
             csg = abs(cxy)**2 / cxx / cyy
-            globalv.SPECTROGRAMS[key].append(csg)
-            globalv.SPECTROGRAMS[key].coalesce()
+            if not numpy.any(numpy.isnan(csg)):
+                globalv.SPECTROGRAMS[key].append(csg)
+                globalv.SPECTROGRAMS[key].coalesce()
 
     if not return_:
         return

--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -289,6 +289,8 @@ def _get_coherence_spectrogram(channel_pair, segments, config=None,
             if not numpy.any(numpy.isnan(csg)):
                 globalv.SPECTROGRAMS[key].append(csg)
                 globalv.SPECTROGRAMS[key].coalesce()
+            else:
+                warnings.warn('NaN values found in the spectrogram, skipping...')
 
     if not return_:
         return

--- a/gwsumm/data/coherence.py
+++ b/gwsumm/data/coherence.py
@@ -290,7 +290,7 @@ def _get_coherence_spectrogram(channel_pair, segments, config=None,
                 globalv.SPECTROGRAMS[key].append(csg)
                 globalv.SPECTROGRAMS[key].coalesce()
             else:
-                warnings.warn('NaN values found in the spectrogram, skipping...')
+                warnings.warn('NaN values found in the spectrogram.')
 
     if not return_:
         return

--- a/gwsumm/data/spectral.py
+++ b/gwsumm/data/spectral.py
@@ -239,12 +239,13 @@ def _get_spectrogram(channel, segments, config=None, cache=None,
 def add_spectrogram(specgram, key=None, coalesce=True):
     """Add a `Spectrogram` to the global memory cache
     """
-    if key is None:
-        key = specgram.name or str(specgram.channel)
-    globalv.SPECTROGRAMS.setdefault(key, SpectrogramList())
-    globalv.SPECTROGRAMS[key].append(specgram)
-    if coalesce:
-        globalv.SPECTROGRAMS[key].coalesce()
+    if not numpy.any(numpy.isnan(specgram)):
+        if key is None:
+            key = specgram.name or str(specgram.channel)
+        globalv.SPECTROGRAMS.setdefault(key, SpectrogramList())
+        globalv.SPECTROGRAMS[key].append(specgram)
+        if coalesce:
+            globalv.SPECTROGRAMS[key].coalesce()
 
 
 @use_segmentlist

--- a/gwsumm/data/spectral.py
+++ b/gwsumm/data/spectral.py
@@ -246,6 +246,8 @@ def add_spectrogram(specgram, key=None, coalesce=True):
         globalv.SPECTROGRAMS[key].append(specgram)
         if coalesce:
             globalv.SPECTROGRAMS[key].coalesce()
+    else:
+        warnings.warn('NaN values found in the spectrogram, skipping...')
 
 
 @use_segmentlist

--- a/gwsumm/data/spectral.py
+++ b/gwsumm/data/spectral.py
@@ -247,7 +247,9 @@ def add_spectrogram(specgram, key=None, coalesce=True):
         if coalesce:
             globalv.SPECTROGRAMS[key].coalesce()
     else:
-        warnings.warn('NaN values found in the spectrogram.')
+        warnings.warn('NaN values found in the spectrogram.'
+                                 ' Spectrogram will not be appended to'
+                                 ' global memory value')
 
 
 @use_segmentlist

--- a/gwsumm/data/spectral.py
+++ b/gwsumm/data/spectral.py
@@ -248,8 +248,8 @@ def add_spectrogram(specgram, key=None, coalesce=True):
             globalv.SPECTROGRAMS[key].coalesce()
     else:
         warnings.warn('NaN values found in the spectrogram.'
-                                 ' Spectrogram will not be appended to'
-                                 ' global memory value')
+                      ' Spectrogram will not be appended to'
+                      ' global memory value')
 
 
 @use_segmentlist

--- a/gwsumm/data/spectral.py
+++ b/gwsumm/data/spectral.py
@@ -247,7 +247,7 @@ def add_spectrogram(specgram, key=None, coalesce=True):
         if coalesce:
             globalv.SPECTROGRAMS[key].coalesce()
     else:
-        warnings.warn('NaN values found in the spectrogram, skipping...')
+        warnings.warn('NaN values found in the spectrogram.')
 
 
 @use_segmentlist


### PR DESCRIPTION
If the data is corrupted, the computed spectrograms may contain `nan` values. While these `nan` values are ignored in spectrogram plots, but they can cause issues in derived products such as the power spectral density and ratio spectrogram, where the presence of `nan` values leads to all values becoming `nan`, resulting in empty plots. This pull request addresses this issue by removing any potential `nan` values from the data used and saved in `globalv.SPECTROGRAMS`.
