### PR TITLE
Replace rstrip() with removesuffix() in triggers text

### DIFF
--- a/gwsumm/plot/triggers/core.py
+++ b/gwsumm/plot/triggers/core.py
@@ -296,7 +296,7 @@ class TriggerDataPlot(TriggerPlotMixin, TimeSeriesDataPlot):
             colstr = get_column_string(col)
             # format row value
             try:
-                valstr = f"{row[col]:.2f}".rstrip('.0')
+                valstr = f"{row[col]:.2f}".removesuffix('.00')
             except ValueError:  # not float()able
                 valstr = str(row[col])
             txt.append(f'{colstr} = {valstr}')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "astropy >=3.0.0",
   "gwdatafind >=1.1.1",
   "gwdetchar >=2.2.6",
-  "gwpy >=2.0.0",
+  "gwpy >=2.0.0, <=3.0.8",
   "gwtrigfind",
   "lalsuite",
   "ligo-segments",
@@ -53,7 +53,7 @@ dependencies = [
   "pygments >=2.7.0",
   "python-dateutil",
   "python-ligo-lw",
-  "scipy >=1.2.0",
+  "scipy >=1.2.0, <1.14",
 ]
 
 dynamic = ["version"]


### PR DESCRIPTION
This PR replaces `rstrip('.0')` with `removesuffix('.00')` to avoid removing any `0` before `.` in the string. See the examples below:

```
>>> a = "10.00" 
>>> b = "11.00" 
>>> c = "110.00"
>>> a.rstrip('.0')
'1'
>>> a.removesuffix('.00')
'10'
>>> b.rstrip('.0')
'11'
>>> b.removesuffix('.00')
'11'
>>> c.rstrip('.0')
'11'
>>> c.removesuffix('.00')
'110'
```