### PR TITLE
Change fancybox gallery name

### DIFF
--- a/gwsumm/tabs/builtin.py
+++ b/gwsumm/tabs/builtin.py
@@ -455,7 +455,7 @@ class PlotTab(Tab):
         k = i = 0
         fbkw.setdefault('rel', 'fancybox')
         fbkw.setdefault('target', '_blank')
-        fbkw.setdefault('data-fancybox', 'gallery')
+        fbkw.setdefault('data-fancybox', 'summary')
         fbkw.setdefault('data-fancybox-group', 'images')
 
         for j, plot in enumerate(plots):


### PR DESCRIPTION
This PR updates the Fancybox initialization by changing the `data-fancybox` attribute from "gallery" to "summary." This modification tailors Fancybox specifically for Summary Pages, introducing new date navigation buttons within the gallery. These buttons allow users to easily switch between different dates. This PR is linked to the associated changes in [gwbootstrap PR#63](https://github.com/gwdetchar/gwbootstrap/pull/63)