### PR TITLE
Add state bar

### DIFF
--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -103,7 +103,7 @@ class TimeSeriesDataPlot(DataLabelSvgMixin, DataPlot):
         # as a segment in the time series plot.
         if isinstance(self.statebar, SummaryState) and (
             state is None or (state.name.lower() == ALLSTATE)):
-            state = self.statebar
+                state = self.statebar
 
         if self.pargs.pop('no-state-segments', False):
             visible = False

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -102,8 +102,8 @@ class TimeSeriesDataPlot(DataLabelSvgMixin, DataPlot):
         # This allows the statebar's state to be included
         # as a segment in the time series plot.
         if isinstance(self.statebar, SummaryState) and (
-            state is None or (state.name.lower() == ALLSTATE)):
-                state = self.statebar
+                state is None or (state.name.lower() == ALLSTATE)):
+            state = self.statebar
 
         if self.pargs.pop('no-state-segments', False):
             visible = False

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -41,7 +41,7 @@ from ..utils import re_cchar
 from ..data import (get_timeseries, get_spectrogram,
                     get_coherence_spectrogram, get_range_spectrogram,
                     get_spectrum, get_coherence_spectrum, get_range_spectrum)
-from ..state import ALLSTATE
+from ..state import (ALLSTATE, SummaryState)
 from .registry import (get_plot, register_plot)
 from .mixins import DataLabelSvgMixin
 
@@ -95,13 +95,23 @@ class TimeSeriesDataPlot(DataLabelSvgMixin, DataPlot):
             method.
         """
         # allow user to disable the state segments axes
+
+        state = self.state
+        # If the state is not set or is set to "All",
+        # update the state to match the statebar's state.
+        # This allows the statebar's state to be included
+        # as a segment in the time series plot.
+        if isinstance(self.statebar, SummaryState) and (
+            state is None or (state.name.lower() == ALLSTATE)):
+            state = self.statebar
+
         if self.pargs.pop('no-state-segments', False):
             visible = False
-        if visible is None and self.state is not None and (
-                self.state.name.lower() != ALLSTATE):
+        if visible is None and state is not None and (
+                state.name.lower() != ALLSTATE):
             visible = True
         if visible:
-            sax = self.plot.add_segments_bar(self.state, ax, height=.14,
+            sax = self.plot.add_segments_bar(state, ax, height=.14,
                                              pad=.1,  **kwargs)
             sax.tick_params(axis='y', which='major', labelsize=12)
             sax.yaxis.set_ticks_position('none')

--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -252,13 +252,15 @@ class DataPlot(SummaryPlot):
 
     def __init__(self, channels, start, end, state=None, outdir='.',
                  tag=None, pid=None, href=None, new=True, all_data=False,
-                 read=True, fileformat='png', caption=None, **pargs):
+                 read=True, fileformat='png', caption=None, statebar=None,
+                 **pargs):
         super(DataPlot, self).__init__(href=href, new=new, caption=caption)
         if isinstance(channels, str):
             channels = split_channels(channels)
         self.channels = channels
         self.span = (start, end)
         self.state = state
+        self.statebar = statebar
         self._outdir = outdir
         if tag is not None:
             self.tag = tag

--- a/gwsumm/tabs/builtin.py
+++ b/gwsumm/tabs/builtin.py
@@ -597,7 +597,7 @@ class StateTab(PlotTab):
     """
     type = 'state'
 
-    def __init__(self, name, states=list(), **kwargs):
+    def __init__(self, name, states=list(),statebar=None, **kwargs):
         """Initialise a new `Tab`.
         """
         if kwargs.get('mode', None) is None:
@@ -608,6 +608,9 @@ class StateTab(PlotTab):
         if not isinstance(states, (tuple, list)):
             states = [states]
         self.states = states
+
+        # process statebar
+        self.statebar = statebar
 
     # -------------------------------------------
     # StateTab properties
@@ -666,6 +669,16 @@ class StateTab(PlotTab):
         self._defaultstate = state
 
     @property
+    def statebar(self):
+        return self._statebar
+
+    @statebar.setter
+    def statebar(self, state):
+        if not isinstance(state, SummaryState):
+            state = get_state(state)
+        self._statebar = state
+
+    @property
     def frames(self):
         # write page for each state
         statelinks = []
@@ -689,6 +702,18 @@ class StateTab(PlotTab):
         else:
             # otherwise use 'all' state - full span with no gaps
             kwargs.setdefault('states', ['All'])
+
+        # Load statebar, used for adding a state segment to a timeseries plot.
+        # This is only applied to the "All" or unassigned (None) state.
+        if cp.has_option(section, 'statebar'):
+            # statebar should be a single element
+            # if a list is given, consider just the first element
+            kwargs.setdefault(
+                'statebar', [re_quote.sub('', s).strip() for s in
+                           cp.get(section, 'statebar').split(',')][0])
+        else:
+            kwargs.setdefault('statebar', None)
+
         # parse core Tab information
         return super(StateTab, cls).from_ini(cp, section, *args, **kwargs)
 

--- a/gwsumm/tabs/builtin.py
+++ b/gwsumm/tabs/builtin.py
@@ -674,7 +674,7 @@ class StateTab(PlotTab):
 
     @statebar.setter
     def statebar(self, state):
-        if not isinstance(state, SummaryState):
+        if not isinstance(state, SummaryState) and state is not None:
             state = get_state(state)
         self._statebar = state
 

--- a/gwsumm/tabs/builtin.py
+++ b/gwsumm/tabs/builtin.py
@@ -597,7 +597,7 @@ class StateTab(PlotTab):
     """
     type = 'state'
 
-    def __init__(self, name, states=list(),statebar=None, **kwargs):
+    def __init__(self, name, states=list(), statebar=None, **kwargs):
         """Initialise a new `Tab`.
         """
         if kwargs.get('mode', None) is None:
@@ -710,7 +710,7 @@ class StateTab(PlotTab):
             # if a list is given, consider just the first element
             kwargs.setdefault(
                 'statebar', [re_quote.sub('', s).strip() for s in
-                           cp.get(section, 'statebar').split(',')][0])
+                             cp.get(section, 'statebar').split(',')][0])
         else:
             kwargs.setdefault('statebar', None)
 

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -335,8 +335,12 @@ class DataTab(ProcessedTab, ParentTab):
         except ValueError:
             allstate = generate_all_state(self.start, self.end)
         allstate.fetch(config=config, segdb_error=segdb_error, **kwargs)
-        for state in self.states + [self.statebar]:
+        for state in self.states:
             state.fetch(config=config, segdb_error=segdb_error, **kwargs)
+        # finilize statebar
+        if self.statebar:
+            self.statebar.fetch(config=config, segdb_error=segdb_error, **kwargs)
+
 
     def process(self, config=ConfigParser(), nproc=1, **stateargs):
         """Process data for this tab

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -287,11 +287,12 @@ class DataTab(ProcessedTab, ParentTab):
                 mods.setdefault('all-data', True)
                 if type_:
                     plot = PlotClass.from_ini(cp, pdef, start, end, sources,
-                                              state=None, outdir=plotdir,
-                                              **mods)
+                                              state=None, statebar=job.statebar,
+                                              outdir=plotdir, **mods)
                 else:
                     plot = PlotClass(sources, start, end, state=None,
-                                     outdir=plotdir, **mods)
+                                     statebar=job.statebar, outdir=plotdir,
+                                     **mods)
                 job.plots.append(plot)
                 if subidx == index:
                     for span in subplots:
@@ -309,7 +310,8 @@ class DataTab(ProcessedTab, ParentTab):
                                                   outdir=plotdir, **mods)
                     else:
                         plot = PlotClass(sources, start, end, state=state,
-                                         outdir=plotdir, **mods)
+                                         statebar=job.statebar, outdir=plotdir,
+                                         **mods)
                     job.plots.append(plot)
                     if subidx == index:
                         for span in subplots:

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -342,7 +342,6 @@ class DataTab(ProcessedTab, ParentTab):
             self.statebar.fetch(config=config, segdb_error=segdb_error,
                                 **kwargs)
 
-
     def process(self, config=ConfigParser(), nproc=1, **stateargs):
         """Process data for this tab
 

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -360,7 +360,7 @@ class DataTab(ProcessedTab, ParentTab):
             datafind_error=stateargs.get('datafind_error', 'raise'),
             nproc=nproc, nds=stateargs.get('nds', None))
         vprint(f"States finalised [{len(self.states) + len([self.statebar])}"
-               " total]\n" )
+               " total]\n")
         for state in self.states + [self.statebar]:
             vprint(f"    {state.name}: {len(state.active)} segments"
                    " | {abs(state.active)} seconds")

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -305,6 +305,7 @@ class DataTab(ProcessedTab, ParentTab):
                     if type_:
                         plot = PlotClass.from_ini(cp, pdef, start, end,
                                                   sources, state=state,
+                                                  statebar=job.statebar,
                                                   outdir=plotdir, **mods)
                     else:
                         plot = PlotClass(sources, start, end, state=state,
@@ -332,7 +333,7 @@ class DataTab(ProcessedTab, ParentTab):
         except ValueError:
             allstate = generate_all_state(self.start, self.end)
         allstate.fetch(config=config, segdb_error=segdb_error, **kwargs)
-        for state in self.states:
+        for state in self.states + [self.statebar]:
             state.fetch(config=config, segdb_error=segdb_error, **kwargs)
 
     def process(self, config=ConfigParser(), nproc=1, **stateargs):
@@ -356,10 +357,9 @@ class DataTab(ProcessedTab, ParentTab):
             segdb_error=stateargs.get('segdb_error', 'raise'),
             datafind_error=stateargs.get('datafind_error', 'raise'),
             nproc=nproc, nds=stateargs.get('nds', None))
-        vprint("States finalised [%d total]\n" % len(self.states))
-        for state in self.states:
-            vprint("    {0.name}: {1} segments | {2} seconds".format(
-                state, len(state.active), abs(state.active)))
+        vprint(f"States finalised [{len(self.states) + len([self.statebar])} total]\n" )
+        for state in self.states + [self.statebar]:
+            vprint(f"    {state.name}: {len(state.active)} segments | {abs(state.active)} seconds")
             if state is self.defaultstate:
                 vprint(" [DEFAULT]")
             vprint('\n')

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -338,8 +338,9 @@ class DataTab(ProcessedTab, ParentTab):
         for state in self.states:
             state.fetch(config=config, segdb_error=segdb_error, **kwargs)
         # finilize statebar
-        if self.statebar:
-            self.statebar.fetch(config=config, segdb_error=segdb_error, **kwargs)
+        if self.statebar is not None:
+            self.statebar.fetch(config=config, segdb_error=segdb_error,
+                                **kwargs)
 
 
     def process(self, config=ConfigParser(), nproc=1, **stateargs):
@@ -365,11 +366,15 @@ class DataTab(ProcessedTab, ParentTab):
             nproc=nproc, nds=stateargs.get('nds', None))
         vprint(f"States finalised [{len(self.states) + len([self.statebar])}"
                " total]\n")
-        for state in self.states + [self.statebar]:
+        for state in self.states:
             vprint(f"    {state.name}: {len(state.active)} segments"
-                   " | {abs(state.active)} seconds")
+                   f" | {abs(state.active)} seconds")
             if state is self.defaultstate:
                 vprint(" [DEFAULT]")
+            vprint('\n')
+        if self.statebar is not None:
+            vprint(f"    {self.statebar.name}: {len(self.statebar.active)}"
+                   f" segments | {abs(state.active)} seconds")
             vprint('\n')
 
         # pre-process requests for 'all-data' plots

--- a/gwsumm/tabs/data.py
+++ b/gwsumm/tabs/data.py
@@ -287,8 +287,8 @@ class DataTab(ProcessedTab, ParentTab):
                 mods.setdefault('all-data', True)
                 if type_:
                     plot = PlotClass.from_ini(cp, pdef, start, end, sources,
-                                              state=None, statebar=job.statebar,
-                                              outdir=plotdir, **mods)
+                                              state=None, outdir=plotdir,
+                                              statebar=job.statebar, **mods)
                 else:
                     plot = PlotClass(sources, start, end, state=None,
                                      statebar=job.statebar, outdir=plotdir,
@@ -359,9 +359,11 @@ class DataTab(ProcessedTab, ParentTab):
             segdb_error=stateargs.get('segdb_error', 'raise'),
             datafind_error=stateargs.get('datafind_error', 'raise'),
             nproc=nproc, nds=stateargs.get('nds', None))
-        vprint(f"States finalised [{len(self.states) + len([self.statebar])} total]\n" )
+        vprint(f"States finalised [{len(self.states) + len([self.statebar])}"
+               " total]\n" )
         for state in self.states + [self.statebar]:
-            vprint(f"    {state.name}: {len(state.active)} segments | {abs(state.active)} seconds")
+            vprint(f"    {state.name}: {len(state.active)} segments"
+                   " | {abs(state.active)} seconds")
             if state is self.defaultstate:
                 vprint(" [DEFAULT]")
             vprint('\n')


### PR DESCRIPTION
This PR introduces a `statebar` configuration option, allowing users to choose to display the green/red bar for a selected state of time series plots in the "All" state tab.

# Example

[See this page](https://ldas-jobs.ligo-la.caltech.edu/~iara.ota/summary/day/20240820/sei/ground_blrms_overview/) for an example plot with the "Locked" state indicated by the bar. The configuration file should include:


```ini
[tab-blrms]
name = Ground motion BLRMS overview
statebar = Locked
shortname = Ground BLRMS overview
parent = SEI
...

```