### PR TITLE
Update build.yml github actions and readthedocs OS/python

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,23 +53,26 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Cache conda packages
-      uses: actions/cache@v4
-      env:
-        # increment to reset cache
-        CACHE_NUMBER: 0
-      with:
-        path: ~/conda_pkgs_dir
-        key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ env.CACHE_NUMBER }}
-        restore-keys: ${{ runner.os }}-conda-${{ matrix.python-version }}-
+    # EG 13 Dec 2024: commenting out broken cache
+    # - name: Cache conda packages
+    #   uses: actions/cache@v4
+    #   env:
+    #     # increment to reset cache
+    #     CACHE_NUMBER: 0
+    #   with:
+    #     path: ~/conda_pkgs_dir
+    #     key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ env.CACHE_NUMBER }}
+    #     restore-keys: ${{ runner.os }}-conda-${{ matrix.python-version }}-
 
     - name: Configure conda
       uses: conda-incubator/setup-miniconda@v3
       with:
-        activate-environment: test
-        miniforge-variant: Mambaforge
+        auto-update-conda: true
+        channels: conda-forge
         python-version: ${{ matrix.python-version }}
-        use-mamba: true
+        # this is needed for caching to work properly:
+        # EG 13 Dec 2024: commenting out broken cache
+        # use-only-tar-bz2: true
 
     - name: Conda info
       run: conda info --all
@@ -77,15 +80,15 @@ jobs:
     - name: Install dependencies
       run: |
         # parse requirements to install as much as possible with conda
-        mamba create --name pip2conda pip2conda
-        mamba run -n pip2conda pip2conda \
+        conda create --name pip2conda pip2conda
+        conda run -n pip2conda pip2conda \
             --all \
             --output environment.txt \
             --python-version ${{ matrix.python-version }}
         echo "-----------------"
         cat environment.txt
         echo "-----------------"
-        mamba install --quiet --yes --name test --file environment.txt
+        conda install --quiet --yes --name test --file environment.txt
 
     - name: Install GWSumm
       run: python -m pip install . --no-build-isolation -vv

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-24.04"
   tools:
-    python: "mambaforge-22.9"
+    python: "miniconda-latest"
 
 conda:
   environment: docs/environment.yml


### PR DESCRIPTION
This PR removes mamba with conda-incubator/setup-miniconda@v3 and from readthedocs configuration. It also comments out the github cache action as it seems to not be functioning properly. We can revisit whether we want to keep this going forward but for now it is commented out.

These changes enable the CI to work properly now.