### PR TITLE
Unpin numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "markdown",
   "MarkupPy",
   "matplotlib >=3.5",
-  "numpy >=1.16,<2.0",
+  "numpy >=1.16",
   "pygments >=2.7.0",
   "python-dateutil",
   "python-ligo-lw",


### PR DESCRIPTION
This MR removes the upper version constraint on `numpy`. NumPy v2 is mature and should be preferred over older versions.