### PR TITLE
Remove direct usage of igwn-segments

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -13,7 +13,6 @@ dependencies:
   - gwdetchar >=2.0.0
   - gwpy >=3.0.0
   - gwtrigfind
-  - igwn-segments
   - lalsuite
   - lscsoft-glue >=1.60.0
   - lxml

--- a/gwsumm/data/timeseries.py
+++ b/gwsumm/data/timeseries.py
@@ -657,7 +657,7 @@ def _get_timeseries_dict(channels, segments, config=None,
             else:  # read
                 # NOTE: this sieve explicitly casts our segment to
                 #       igwn_segments.segment to prevent `TypeError` from
-                #       a mismatch with igwn_segments.segment
+                #       a mismatch with gwpy.segments.Segment
                 segcache = sieve_cache(fcache, segment=segment)
                 segstart, segend = map(float, segment)
                 tsd = DictClass.read(segcache, qchannels, start=segstart,

--- a/gwsumm/data/utils.py
+++ b/gwsumm/data/utils.py
@@ -22,8 +22,6 @@
 from collections import OrderedDict
 from functools import wraps
 
-from igwn_segments import segmentlist as LigoSegmentList
-
 from gwpy.segments import (DataQualityFlag, SegmentList, Segment)
 
 from ..channels import get_channel
@@ -44,7 +42,7 @@ def use_segmentlist(f):
     def decorated_func(arg1, segments, *args, **kwargs):
         if isinstance(segments, DataQualityFlag):
             segments = segments.active
-        elif not isinstance(segments, LigoSegmentList):
+        elif not isinstance(segments, SegmentList):
             segments = SegmentList([Segment(*x) for x in segments])
         return f(arg1, segments, *args, **kwargs)
     return decorated_func

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
   "gwdetchar >=2.2.7",
   "gwpy >=2.0.0, <=3.0.8",
   "gwtrigfind",
-  "igwn-segments",
   "lalsuite",
   "lscsoft-glue >=1.60.0",
   "lxml",


### PR DESCRIPTION
We're using `gwpy.segments` everywhere else, so there's no need to have a direct usage of `igwn-segments`