### PR TITLE
Update formula for cumulative range

### DIFF
--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -520,7 +520,8 @@ class SpectrumDataPlot(DataPlot):
                 if str(data.unit) == 'Mpc':
                     data = (data**3).cumsum() ** (1/3.)
                 else:
-                    data = (data**2).cumsum() ** (1/2.)
+                    # implement Eq. 10 from https://arxiv.org/abs/2502.07253
+                    data = (data**2).cumsum() / (data**2).sum()
                 try:
                     data = (100 * data / data[-1],)
                 except IndexError:

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -521,7 +521,7 @@ class SpectrumDataPlot(DataPlot):
                     data = (data**3).cumsum() ** (1/3.)
                 else:
                     # implement Eq. 10 from https://arxiv.org/abs/2502.07253
-                    data = (data**2).cumsum() / (data**2).sum()
+                    data = (data**2).cumsum() / (data**2).sum() ** (1/2.)
                 try:
                     data = (100 * data / data[-1],)
                 except IndexError:


### PR DESCRIPTION
This PR updates the method of calculating the cumulative range to be in line with Eq. 10 from https://arxiv.org/abs/2502.07253. This address multiple issues with the current calculation. This update requires no changes to existing configuration files used with `gwsumm`. 

A comparison of the cumulative range plot before and after this update can be seen below:

### Current method of cumulative range
![cum_range_old](https://github.com/user-attachments/assets/4eee7e47-d254-4445-9668-06d304a85e57)

### Updated method of cumulative range
![cum_range_new](https://github.com/user-attachments/assets/312942fa-d01c-42d3-9db0-0de0516f8d6e)
