### PR TITLE
Use standard exist_ok option when making directories

### DIFF
--- a/gwsumm/__main__.py
+++ b/gwsumm/__main__.py
@@ -71,7 +71,6 @@ from .tabs import (
 )
 from .utils import (
     get_default_ifo,
-    mkdir,
     re_flagdiv,
 )
 from .data import get_timeseries_dict
@@ -611,10 +610,10 @@ def main(args=None):
         globalv.HTMLONLY = True
 
     # build directories
-    mkdir(args.output_dir)
+    os.makedirs(args.output_dir, exist_ok=True)
     os.chdir(args.output_dir)
     plotdir = os.path.join(path, 'plots')
-    mkdir(plotdir)
+    os.makedirs(plotdir, exist_ok=True)
 
     # -- setup --------------------------------------
 
@@ -681,7 +680,7 @@ def main(args=None):
 
     if args.archive:
         archivedir = os.path.join(path, 'archive')
-        mkdir(archivedir)
+        os.makedirs(archivedir, exist_ok=True)
         args.archive = os.path.join(archivedir, '%s-%s-%d-%d.h5'
                                     % (ifo, args.archive, args.gpsstart,
                                        args.gpsend - args.gpsstart))
@@ -771,7 +770,7 @@ def main(args=None):
     # write config page
     about = get_tab('about')(span=span, parent=None, path=path)
     if not args.no_html:
-        mkdir(about.path)
+        os.makedirs(about.path, exist_ok=True)
         about.write_html(
             css=css, js=javascript, tabs=tabs, config=config.files,
             prog=PROG, ifo=ifo, ifomap=ifobases, about=about.index,
@@ -847,7 +846,7 @@ def main(args=None):
                         segdb_error=args.on_segdb_error,
                         datafind_error=args.on_datafind_error, **cache)
         if not tab.hidden and not isinstance(tab, get_tab('link')):
-            mkdir(tab.href)
+            os.makedirs(tab.href, exist_ok=True)
             tab.write_html(
                 css=css, js=javascript, tabs=tabs, ifo=ifo,
                 ifomap=ifobases, about=about.index, base=base,

--- a/gwsumm/batch.py
+++ b/gwsumm/batch.py
@@ -37,7 +37,6 @@ from gwpy.io import kerberos as gwkerberos
 from gwdetchar import cli
 
 from . import __version__
-from .utils import mkdir
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Alex Urban <alexander.urban@ligo.org>'
@@ -446,18 +445,19 @@ def main(args=None):
 
     # move to output directory
     indir = os.getcwd()
-    mkdir(args.output_dir)
+    os.makedirs(args.output_dir, exist_ok=True)
     os.chdir(args.output_dir)
     outdir = os.curdir
 
     # set node log path, and condor log path
     logdir = os.path.join(outdir, 'logs')
     htclogdir = args.log_dir or logdir
-    mkdir(logdir, htclogdir)
+    os.makedirs(logdir, exist_ok=True)
+    os.makedirs(htclogdir, exist_ok=True)
 
     # set config directory and copy config files
     etcdir = os.path.join(outdir, 'etc')
-    mkdir(etcdir)
+    os.makedirs(etcdir, exist_ok=True)
 
     for (i, fp) in enumerate(args.global_config):
         inicopy = os.path.join(etcdir, os.path.basename(fp))

--- a/gwsumm/tabs/core.py
+++ b/gwsumm/tabs/core.py
@@ -715,8 +715,8 @@ class BaseTab(object):
         """
         # setup directories
         outdir = os.path.split(self.index)[0]
-        if outdir and not os.path.isdir(outdir):
-            os.makedirs(outdir)
+        if outdir:
+            os.makedirs(outdir, exist_ok=True)
 
         # get default style and scripts
         if css is None:

--- a/gwsumm/tests/test_utils.py
+++ b/gwsumm/tests/test_utils.py
@@ -20,11 +20,9 @@
 
 """
 
-import os.path
 import time
 import re
 import sys
-import shutil
 from math import pi
 
 import pytest
@@ -57,16 +55,6 @@ def test_vprint(capsys):
     utils.vprint('anything\n', stream=sys.stdout)
     out, err = capsys.readouterr()
     assert re.match(r'\Aanything \(\d+\.\d\d\)\n\Z', out) is not None
-
-
-def test_mkdir():
-    d = 'test-dir/test-dir2'
-    try:
-        utils.mkdir(d)
-        assert os.path.isdir(d)
-    finally:
-        if os.path.isdir(d):
-            shutil.rmtree(d)
 
 
 def test_nat_sorted():

--- a/gwsumm/utils.py
+++ b/gwsumm/utils.py
@@ -19,7 +19,6 @@
 """Utilities for GWSumm
 """
 
-import os
 import re
 import sys
 from socket import getfqdn
@@ -75,15 +74,6 @@ def vprint(message, verbose=True, stream=sys.stdout, profile=True):
     if verbose:
         stream.write(message)
         stream.flush()
-
-
-def mkdir(*paths):
-    """Conditional mkdir operation, for convenience
-    """
-    for path in paths:
-        path = os.path.normpath(path)
-        if not os.path.isdir(path):
-            os.makedirs(path)
 
 
 def nat_sorted(iterable, key=None):


### PR DESCRIPTION
This PR removes the custom checking if directories already exist by using the `exist_ok` option in `os.makedirs()`. This modest change is a small simplification step that improves code maintainability and standard python best practices