### PR TITLE
External state pages

### DIFF
--- a/gwsumm/tabs/__init__.py
+++ b/gwsumm/tabs/__init__.py
@@ -37,6 +37,7 @@ from .core import (
 )
 from .builtin import (
     ExternalTab,
+    ExternalStateTab,
     PlotTab,
     StateTab,
     UrlTab,


### PR DESCRIPTION
This PR adds an `ExternalStatePage` in order to have a tab with states that comes from an external generated process.