### PR TITLE
Add environment variables to submit jobs

### DIFF
--- a/gwsumm/data/timeseries.py
+++ b/gwsumm/data/timeseries.py
@@ -554,7 +554,7 @@ def _get_timeseries_dict(channels, segments, config=None,
     if nds is None and cache is not None:
         nds = False
     elif nds is None:
-        nds = 'LIGO_DATAFIND_SERVER' not in os.environ
+        nds = 'GWDATAFIND_SERVER' not in os.environ
 
     # read new data
     query &= (abs(new) > 0)

--- a/gwsumm/tests/test_batch.py
+++ b/gwsumm/tests/test_batch.py
@@ -57,6 +57,8 @@ def test_main(tmpdir, caplog):
         '--maxjobs', '5',
         '--condor-timeout', '3',
         '--condor-command', 'notification=false',
+        '--condor-command', 'environment=VAR1=VAL1',
+        '--condor-command', 'environment=VAR2=VAL2',
         '--config-file', k1test,
         '--global-config', global_,
         '--nds',
@@ -69,6 +71,7 @@ def test_main(tmpdir, caplog):
     # test log output
     batch.main(args)
     assert "Copied all INI configuration files to ./etc" in caplog.text
+    assert "Appending VAR2=VAL2 to condor 'environment' value" in caplog.text
     assert " -- Configured HTML htmlnode job" in caplog.text
     assert " -- Configured job for config {}".format(
         os.path.join(outdir, "etc", os.path.basename(k1test))) in caplog.text


### PR DESCRIPTION
See https://computing.docs.ligo.org/guide/htcondor/environment/?h=getenv#getenv. This PR is inspired by https://github.com/gwpy/gwsumm/pull/376, but I wanted to keep the existing code as simple as possible to avoid confusion.

An example summary page: https://ldas-jobs.ligo-wa.caltech.edu/~evan.goetz/summary/day/20251102/

Note that we need to add some variables in the summary page configuration: `MPLCONFIGDIR`, `GWPY_RCPARAMS`, `GWPY_USETEX`, `MATPLOTLIBRC`, and `XDG_DATA_HOME`. This will be done in a separate MR in that repository

Closes #375