### PR TITLE
Fix plotting and processing issues when using modern numpy/matplotlib

### DIFF
--- a/gwsumm/plot/noisebudget.py
+++ b/gwsumm/plot/noisebudget.py
@@ -133,10 +133,9 @@ class NoiseBudgetPlot(get_plot('spectrum')):
             d.override_unit(darmdata.unit)  # enforce consistent units
             sum_ += d ** 2
         ax.plot(sum_ ** (1/2.), zorder=1, **sumargs)
-        ax.lines.insert(1, ax.lines.pop(-1))
 
         # plot residual of noises
-        if not self.pargs.pop('no-residual', False):
+        if not self.pargs.get('no-residual', False):
             resargs = self.parse_residual_params()
             try:
                 residual = (darmdata ** 2 - sum_) ** (1/2.)
@@ -146,11 +145,18 @@ class NoiseBudgetPlot(get_plot('spectrum')):
                 else:  # other error
                     raise
             ax.plot(residual, zorder=-1000, **resargs)
-            ax.lines.insert(1, ax.lines.pop(-1))
+
+        # Reorder legend
+        lines = ax.get_lines()
+        if not self.pargs.pop('no-residual', False):
+            lines.insert(1, lines.pop(-1))
+            lines.insert(2, lines.pop(-1))
+        else:
+            lines.insert(1, lines.pop(-1))
 
         # finalize
         self.apply_parameters(ax, **self.pargs)
-        ax.legend(**legendargs)
+        ax.legend(handles=lines, **legendargs)
 
         return self.finalize()
 

--- a/gwsumm/plot/sei.py
+++ b/gwsumm/plot/sei.py
@@ -149,10 +149,8 @@ class SeiWatchDogPlot(get_plot('data')):
             ax.set_ylabel('')
             ax.set_title(texify(channel.name), fontsize=10)
             ax.xaxis.set_minor_locator(NullLocator())
-            for tick in ax.yaxis.get_major_ticks():
-                tick.label.set_fontsize(10)
-            for tick in ax.xaxis.get_major_ticks():
-                tick.label.set_fontsize(16)
+            ax.tick_params(axis='x', which='major', labelsize=16)
+            ax.tick_params(axis='y', which='major', labelsize=10)
         plot.text(0.5, 0.02, 'Time [seconds] from trip (%s)' % self.gpstime,
                   ha='center', va='bottom', fontsize=24)
         plot.text(0.01, 0.5, 'Amplitude %s' % self.unit, ha='left',

--- a/gwsumm/tabs/sei.py
+++ b/gwsumm/tabs/sei.py
@@ -188,7 +188,7 @@ class SEIWatchDogTab(base):
                     causes = ['%s Unknown' % stage]
                 else:
                     allbits = numpy.nonzero(
-                        map(int, bin(int(bits))[2:][::-1]),
+                        numpy.atleast_1d(map(int, bin(int(bits))[2:][::-1])),
                     )[0]
                     causes = [latch.bits[b] for b in allbits]
                 t2 = Time(t, format='gps', scale='utc')


### PR DESCRIPTION
This PR fixes problems when plotting or processing in certain tabs when using modern `numpy` and `matplotlib` packages.

Specifically, there were API changes in more recent versions requiring changes to the behaviour how legends are reordered (in `plot/noisebudget.py`), axis labels are sized (in `plot/sei.py`), and how `numpy.nonzero` requires at least 1d sized arrays (in `tabs/sei.py`)