### PR TITLE
Set XDG_CONFIG_HOME and XDG_CACHE_HOME in batch jobs

### DIFF
--- a/gwsumm/__main__.py
+++ b/gwsumm/__main__.py
@@ -38,6 +38,9 @@ import re
 import sys
 import warnings
 
+from astropy.config import get_config_dir
+from astropy.config.paths import get_cache_dir
+
 from collections import OrderedDict
 from configparser import (DEFAULTSECT, NoOptionError, NoSectionError)
 from dateutil.relativedelta import relativedelta
@@ -609,11 +612,22 @@ def main(args=None):
     if args.html_only:
         globalv.HTMLONLY = True
 
-    # build directories
+    # build output directories
     os.makedirs(args.output_dir, exist_ok=True)
     os.chdir(args.output_dir)
     plotdir = os.path.join(path, 'plots')
     os.makedirs(plotdir, exist_ok=True)
+
+    # build astropy XDG directories
+    # The functions get_config_dir() and get_cache_dir() either return the
+    # default ~/.astropy/config, ~/.astropy/cache directories or the
+    # directories specified by the XDG_CONFIG_HOME and XDG_CACHE_HOME
+    # environment variables. We only need to create directories if the
+    # variables are set
+    if os.environ.get('XDG_CONFIG_HOME', None):
+        os.makedirs(os.path.join(get_config_dir(), 'astropy'), exist_ok=True)
+    if os.environ.get('XDG_CACHE_HOME', None):
+        os.makedirs(os.path.join(get_cache_dir(), 'astropy'), exist_ok=True)
 
     # -- setup --------------------------------------
 

--- a/gwsumm/batch.py
+++ b/gwsumm/batch.py
@@ -498,13 +498,32 @@ def main(args=None):
     if ('environment' in condorcmds and
             'BEARER_TOKEN_FILE' not in condorcmds['environment']):
         condorcmds['environment'] += (
-            ';BEARER_TOKEN_FILE='
+            ' BEARER_TOKEN_FILE='
             '$$(CondorScratchDir)/.condor_creds/scitokens.use'
             )
     elif 'environment' not in condorcmds:
         condorcmds['environment'] = (
             'BEARER_TOKEN_FILE='
             '$$(CondorScratchDir)/.condor_creds/scitokens.use'
+            )
+
+    # set XDG_CONFIG_HOME and XDG_CACHE_HOME vars for astropy
+    # see https://docs.astropy.org/en/stable/environment_variables.html
+    # the logic here is that if 'environment' exists in condorcmds then
+    # if XDG_CONFIG_HOME or XDG_CACHE_HOME doesn't exist then add it (space
+    # separated list), or if 'environment' doesn't exist then we've already
+    # started with BEARER_TOKEN_FILE above and now we add the XDG variables
+    if (('environment' in condorcmds and
+         'XDG_CONFIG_HOME' not in condorcmds['environment']) or
+            'environment' not in condorcmds):
+        condorcmds['environment'] += (
+            ' XDG_CONFIG_HOME=$$(CondorScratchDir)/tmp/config'
+            )
+    if (('environment' in condorcmds and
+         'XDG_CACHE_HOME' not in condorcmds['environment']) or
+            'environment' not in condorcmds):
+        condorcmds['environment'] += (
+            ' XDG_CACHE_HOME=$$(CondorScratchDir)/tmp/cache'
             )
 
     # -- build individual gw_summary jobs -----------

--- a/gwsumm/batch.py
+++ b/gwsumm/batch.py
@@ -526,6 +526,12 @@ def main(args=None):
             ' XDG_CACHE_HOME=$$(CondorScratchDir)/tmp/cache'
             )
 
+    # Make sure the environment is a quotation marked string
+    if not condorcmds['environment'].startswith('"'):
+        condorcmds['environment'] = f"\"{condorcmds['environment']}"
+    if not condorcmds['environment'].endswith('"'):
+        condorcmds['environment'] = f"{condorcmds['environment']}\""
+
     # -- build individual gw_summary jobs -----------
 
     globalconfig = ','.join(args.global_config)

--- a/gwsumm/tests/test_archive.py
+++ b/gwsumm/tests/test_archive.py
@@ -62,10 +62,7 @@ def create(data, **metadata):
     return d
 
 
-# -- tests --------------------------------------------------------------------
-
-def test_write_archive(delete=True):
-    empty_globalv()
+def add_data():
     data.add_timeseries(TEST_DATA)
     data.add_timeseries(create([1, 2, 3, 4, 5],
                                dt=60., channel='X1:TEST-TREND.mean'))
@@ -78,6 +75,13 @@ def test_write_archive(delete=True):
     t = EventTable(random.random((100, 5)), names=['time', 'a', 'b', 'c', 'd'])
     t.meta['segments'] = SegmentList([Segment(0, 100)])
     triggers.add_triggers(t, 'X1:TEST-TABLE,testing')
+
+
+# -- tests --------------------------------------------------------------------
+
+def test_write_archive(delete=True):
+    empty_globalv()
+    add_data()
     fname = tempfile.mktemp(suffix='.h5', prefix='gwsumm-tests-')
     try:
         archive.write_data_archive(fname)
@@ -85,11 +89,16 @@ def test_write_archive(delete=True):
     finally:
         if delete and os.path.isfile(fname):
             os.remove(fname)
-    return fname
 
 
 def test_read_archive():
-    fname = test_write_archive(delete=False)
+    empty_globalv()
+    add_data()
+    fname = tempfile.mktemp(suffix='.h5', prefix='gwsumm-tests-')
+    try:
+        archive.write_data_archive(fname)
+    except Exception:
+        raise
     empty_globalv()
     try:
         archive.read_data_archive(fname)


### PR DESCRIPTION
This PR adds to the batch jobs, the environment variables `XDG_CONFIG_HOME` and `XDG_CACHE_HOME` which crucially need to be accessible at all times, especially now that we're using scitokens. Since these are being inherited through `getenv=True`, setting these environment variables will override that, and beneficially should set us up for when we eventually remove `getenv=True`