### PR TITLE
Switch from python-ligo-lw to igwn-ligolw

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,19 +10,19 @@ dependencies:
   # install
   - astropy >=3.0.0
   - gwdatafind >=1.1.1
-  - gwdetchar >=2.0.0
-  - gwpy >=3.0.0
+  - gwdetchar >=2.3.2
+  - gwpy >=3.0.9
   - gwtrigfind
   - lalsuite
   - lscsoft-glue >=1.60.0
   - lxml
   - markdown
   - MarkupPy
-  - matplotlib >=3.1
+  - matplotlib >=3.5
   - numpy >=1.16
   - pygments >=2.7.0
   - python-dateutil
-  - python-ligo-lw
+  - igwn-ligolw
   - scipy >=1.2.0
   # docs
   - numpydoc

--- a/gwsumm/tabs/etg.py
+++ b/gwsumm/tabs/etg.py
@@ -66,9 +66,9 @@ class EventTriggerTab(get_tab('default')):
         later (but before running :meth:`~DataTab.process`) via
         :meth:`~DataTab.add_state`.
     table : `type`, `str`, optional
-        LIGO_LW `~glue.ligolw.table.Table` class to use for this ETG,
-        e.g. use `~glue.ligolw.lsctables.SnglBurstTable` for Omicron, or
-        `~glue.ligolw.lsctables.SnglInspiralTable` for CBC
+        LIGO_LW `~igwn_ligolw.ligolw.Table` class to use for this ETG,
+        e.g. use `~igwn_ligolw.lsctables.SnglBurstTable` for Omicron, or
+        `~igwn_ligolw.lsctables.SnglInspiralTable` for CBC
     cache : `~glue.lal.Cache`, `str`, optional
         `Cache` object, or path to a LAL-format cache file on disk,
         from which to read the event triggers. If no cache is given,

--- a/gwsumm/triggers.py
+++ b/gwsumm/triggers.py
@@ -26,7 +26,7 @@ from astropy.table import vstack as vstack_tables
 
 from lal.utils import CacheEntry
 
-from ligo.lw import lsctables
+from igwn_ligolw import lsctables
 
 from glue.lal import Cache
 
@@ -116,7 +116,7 @@ def get_etg_table(etg):
 
     Returns
     -------
-    table : `type`, subclass of `~ligo.lw.table.Table`
+    table : `type`, subclass of `~igwn_ligolw.ligolw.Table`
         LIGO_LW table registered to the given ETG
 
     Raises

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
   "numpy >=1.16",
   "pygments >=2.7.0",
   "python-dateutil",
-  "python-ligo-lw",
+  "igwn-ligolw",
   "scipy >=1.2.0",
 ]
 


### PR DESCRIPTION
Like `gwdetchar`, this PR changes the dependency from python-ligo-lw to igwn-ligolw.

An example showing this works using `igwn-ligolw`: https://ldas-jobs.ligo-wa.caltech.edu/~evan.goetz/triggers.png