### PR TITLE
Update gwsumm for upstream dependency changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,6 @@ jobs:
           - macOS
           - Ubuntu
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
     runs-on: ${{ matrix.os }}-latest
@@ -49,7 +48,7 @@ jobs:
 
     steps:
     - name: Get source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -110,14 +109,15 @@ jobs:
       run: python -m coverage report --show-missing
 
     - name: Publish coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5.5.1
       with:
         files: coverage.xml
-        flags: ${{ runner.os }},python${{ matrix.python-version }}
+        flags: ${{ runner.os }}-python${{ matrix.python-version }}
+        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: pytest-conda-${{ matrix.os }}-${{ matrix.python-version }}
         path: pytest.xml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,9 +27,9 @@ jobs:
     name: Flake8
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/gwsumm/__main__.py
+++ b/gwsumm/__main__.py
@@ -53,7 +53,7 @@ from gwpy.segments import (Segment, SegmentList)
 from gwpy.signal.spectral import _lal as fft_lal
 from gwpy.time import (Time, _tconvert, tconvert, to_gps)
 
-from gwdetchar.cli import logger
+from gwdetchar.utils.cli import logger
 
 from . import (
     __version__,

--- a/gwsumm/batch.py
+++ b/gwsumm/batch.py
@@ -30,7 +30,7 @@ import sys
 
 from glue import pipeline
 
-from gwdetchar import cli
+from gwdetchar.utils import cli
 
 from . import __version__
 

--- a/gwsumm/html/tests/test_bootstrap.py
+++ b/gwsumm/html/tests/test_bootstrap.py
@@ -24,7 +24,7 @@ __author__ = 'Alex Urban <alexander.urban@ligo.org>'
 import pytest
 from datetime import datetime
 
-from gwdetchar.utils import parse_html
+from gwdetchar.utils.utils import parse_html
 
 from .. import bootstrap
 

--- a/gwsumm/html/tests/test_html5.py
+++ b/gwsumm/html/tests/test_html5.py
@@ -26,7 +26,7 @@ import shutil
 
 from markdown import markdown
 
-from gwdetchar.utils import parse_html
+from gwdetchar.utils.utils import parse_html
 
 from .. import html5
 

--- a/gwsumm/plot/builtin.py
+++ b/gwsumm/plot/builtin.py
@@ -33,7 +33,7 @@ from gwpy.plot.colors import tint
 from gwpy.plot.gps import GPSTransform
 from gwpy.segments import SegmentList
 
-from gwdetchar.plot import texify
+from gwdetchar.utils.plot import texify
 
 from .. import (globalv, io)
 from ..mode import (Mode, get_mode)

--- a/gwsumm/plot/core.py
+++ b/gwsumm/plot/core.py
@@ -35,7 +35,7 @@ from gwpy.segments import Segment
 from gwpy.detector import ChannelList
 from gwpy.plot import Plot
 
-from gwdetchar.plot import texify
+from gwdetchar.utils.plot import texify
 
 from ..channels import (get_channel, split as split_channels,
                         split_combination as split_channel_combination)

--- a/gwsumm/plot/guardian/__main__.py
+++ b/gwsumm/plot/guardian/__main__.py
@@ -30,7 +30,7 @@ from configparser import DEFAULTSECT
 
 from gwpy.time import to_gps
 
-from gwdetchar.cli import logger
+from gwdetchar.utils.cli import logger
 
 from ... import globalv
 from ...archive import (write_data_archive, read_data_archive)

--- a/gwsumm/plot/guardian/core.py
+++ b/gwsumm/plot/guardian/core.py
@@ -25,7 +25,7 @@ from gwpy.plot.colors import tint
 from gwpy.plot.segments import SegmentRectangle
 from gwpy.segments import (Segment, SegmentList)
 
-from gwdetchar.plot import texify
+from gwdetchar.utils.plot import texify
 
 from ...data import get_timeseries
 from ...segments import get_segments

--- a/gwsumm/plot/mixins.py
+++ b/gwsumm/plot/mixins.py
@@ -26,7 +26,7 @@ from io import StringIO
 
 from lxml import etree
 
-from gwdetchar.plot import texify
+from gwdetchar.utils.plot import texify
 
 re_bit_label = re.compile(r'\[(?P<idx>.*)\] (?P<label>.*)')
 re_source_label = re.compile(r'(?P<label>.*) \[(?P<flag>.*)\]')

--- a/gwsumm/plot/noisebudget.py
+++ b/gwsumm/plot/noisebudget.py
@@ -25,7 +25,7 @@ import numpy
 
 from gwpy.segments import SegmentList
 
-from gwdetchar.plot import texify
+from gwdetchar.utils.plot import texify
 
 from ..data import get_spectrum
 from .registry import (get_plot, register_plot)

--- a/gwsumm/plot/range.py
+++ b/gwsumm/plot/range.py
@@ -31,7 +31,7 @@ import gwpy.astro
 from gwpy.segments import (Segment, SegmentList)
 from gwpy.timeseries import TimeSeries
 
-from gwdetchar.plot import texify
+from gwdetchar.utils.plot import texify
 
 from .registry import (get_plot, register_plot)
 from .utils import hash

--- a/gwsumm/plot/segments.py
+++ b/gwsumm/plot/segments.py
@@ -42,7 +42,7 @@ from gwpy.plot.segments import SegmentRectangle
 from gwpy.segments import (Segment, SegmentList, DataQualityFlag)
 from gwpy.time import (from_gps, to_gps)
 
-from gwdetchar.plot import texify
+from gwdetchar.utils.plot import texify
 
 from .. import globalv
 from ..mode import (Mode, get_mode)

--- a/gwsumm/plot/sei.py
+++ b/gwsumm/plot/sei.py
@@ -28,7 +28,7 @@ from matplotlib.ticker import NullLocator
 from gwpy.plot import Plot
 from gwpy.timeseries import TimeSeriesDict
 
-from gwdetchar.plot import texify
+from gwdetchar.utils.plot import texify
 
 from ..channels import get_channel
 from ..utils import re_quote

--- a/gwsumm/plot/triggers/__main__.py
+++ b/gwsumm/plot/triggers/__main__.py
@@ -31,7 +31,7 @@ from glue.lal import Cache
 from gwpy.segments import Segment
 from gwpy.time import to_gps
 
-from gwdetchar.cli import logger
+from gwdetchar.utils.cli import logger
 
 from ...segments import get_segments
 from ...triggers import (get_triggers, keep_in_segments)

--- a/gwsumm/plot/triggers/core.py
+++ b/gwsumm/plot/triggers/core.py
@@ -32,7 +32,7 @@ from gwpy.plot.gps import GPSTransform
 from gwpy.plot.utils import (color_cycle, marker_cycle)
 from gwpy.segments import SegmentList
 
-from gwdetchar.plot import texify
+from gwdetchar.utils.plot import texify
 
 from ... import globalv
 from ...channels import get_channel

--- a/gwsumm/plot/utils.py
+++ b/gwsumm/plot/utils.py
@@ -30,7 +30,7 @@ from gwpy.plot.utils import (  # noqa: F401
     AXES_PARAMS,
 )
 
-from gwdetchar.plot import texify
+from gwdetchar.utils.plot import texify
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 

--- a/gwsumm/tabs/guardian.py
+++ b/gwsumm/tabs/guardian.py
@@ -37,7 +37,7 @@ from glue.lal import Cache
 from gwpy.segments import DataQualityDict
 
 from gwdetchar.io import html
-from gwdetchar.plot import texify
+from gwdetchar.utils.plot import texify
 
 from .. import globalv
 from ..config import GWSummConfigParser

--- a/gwsumm/tabs/management.py
+++ b/gwsumm/tabs/management.py
@@ -28,7 +28,7 @@ from glue.lal import Cache
 from gwpy.segments import (DataQualityDict, SegmentList)
 
 from gwdetchar.io import html
-from gwdetchar.plot import texify
+from gwdetchar.utils.plot import texify
 
 from ..config import GWSummConfigParser
 from .registry import (get_tab, register_tab)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 name = "gwsumm"
 description = "A python toolbox used by the LIGO Scientific Collaboration for detector characterisation"
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
   { name = "Alex Urban", email = "alex.urban@ligo.org" },
   { name = "Duncan Macleod", email = "duncan.macleod@ligo.org" },
@@ -28,7 +28,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Topic :: Scientific/Engineering",
@@ -39,7 +38,7 @@ classifiers = [
 dependencies = [
   "astropy >=3.0.0",
   "gwdatafind >=1.1.1",
-  "gwdetchar >=2.2.7",
+  "gwdetchar >=2.3.2",
   "gwpy >=3.0.9",
   "gwtrigfind",
   "lalsuite",


### PR DESCRIPTION
This PR updates the `gwsumm` package for upstream changes:
- imports for the `gwdetchar=2.3.2` release that reorganized some of the utility functions
- minimum python in the gwdetchar feedstock is now `python=3.10`, so we can't support the tests in a python 3.9 environment
- update github action versions