### PR TITLE
Add dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "actions"
+    labels:
+      - "build-and-test"


### PR DESCRIPTION
This PR adds the github dependabot taking inspiration from the gwdetchar dependabot https://github.com/gwdetchar/gwdetchar/blob/master/.github/dependabot.yml

Thanks @duncanmmacleod for the tip.