### PR TITLE
Fix SEI watchdog plotting (data access issue)

### DIFF
--- a/gwsumm/plot/sei.py
+++ b/gwsumm/plot/sei.py
@@ -21,6 +21,7 @@
 
 import re
 from configparser import NoSectionError, NoOptionError
+from math import ceil, floor
 
 from matplotlib.pyplot import subplots
 from matplotlib.ticker import NullLocator
@@ -46,7 +47,7 @@ class SeiWatchDogPlot(get_plot('data')):
         """Configure a new `SeiWatchDogPlot`.
         """
         super().__init__(
-            [], int(gpstime) - duration/2., int(gpstime) + duration/2.,
+            [], floor(gpstime - duration/2.), ceil(gpstime + duration/2.),
         )
 
         # get params


### PR DESCRIPTION
The SeiWatchDogPlot.draw() class method accesses data (oof) and may end up trying to access data beyond the end of the frame cache because the current class initialization uses an int() truncation to the GPS time used for the centre of the plot range. This sometimes results in an incorrect frame cache that the reading of data is a different range.

To fix this, we use floor and ceil to make sure the full range of data is selected