### PR TITLE
Upgrade matplotlib API for colormaps

### DIFF
--- a/gwsumm/tabs/guardian.py
+++ b/gwsumm/tabs/guardian.py
@@ -27,7 +27,7 @@ from dateutil import tz
 
 import numpy
 
-from matplotlib.cm import get_cmap
+from matplotlib import colormaps
 from matplotlib.colors import Normalize
 
 from astropy.time import Time
@@ -113,7 +113,7 @@ class GuardianTab(DataTab):
         labels = ['[%d] %s' % (grdidxs[state], state) for state in pstates]
 
         # define colours
-        cmap = get_cmap('brg')(Normalize(-1, 1)(
+        cmap = colormaps['brg'](Normalize(-1, 1)(
             numpy.linspace(-1, 1, len(pstates))))[::-1]
         th = len(flags) > 8 and (new.span[1] - new.span[0])/200. or 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
   "lxml",
   "markdown",
   "MarkupPy",
-  "matplotlib >=3.5",
+  "matplotlib >=3.9",
   "numpy >=1.16",
   "pygments >=2.7.0",
   "python-dateutil",


### PR DESCRIPTION
Fixes an error when using matplotlib>=3.9. This change necessitates updating the dependency requirements to matplotlib>=3.9

See https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.9.0.html#top-level-cmap-registration-and-access-functions-in-mpl-cm